### PR TITLE
[improvement] Add static constructor for JavaHttp client

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static java.util.stream.Collectors.toList;
+
+import com.palantir.dialogue.Channel;
+import java.util.Collection;
+import java.util.List;
+
+public final class Channels {
+
+    private Channels() {}
+
+    public static Channel create(Collection<? extends Channel> channels) {
+        List<LimitedChannel> limitedChannels = channels.stream()
+                .map(ConcurrencyLimitedChannel::create)
+                .collect(toList());
+
+        return new RetryingChannel(new QueuedChannel(new RoundRobinChannel(limitedChannels)));
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ChannelsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ChannelsTest.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class ChannelsTest {
+
+    @Mock private Channel delegate;
+    @Mock private Endpoint endpoint;
+    @Mock private Request request;
+    @Mock private Response response;
+    private Channel channel;
+
+    @Before
+    public void before() {
+        channel = Channels.create(ImmutableList.of(delegate));
+    }
+
+    @Test
+    public void testRequestMakesItThrough() throws ExecutionException, InterruptedException {
+        ListenableFuture<Response> expectedResponse = Futures.immediateFuture(response);
+        when(delegate.execute(endpoint, request)).thenReturn(expectedResponse);
+
+        assertThat(channel.execute(endpoint, request).get()).isEqualTo(response);
+    }
+}

--- a/dialogue-java-client/build.gradle
+++ b/dialogue-java-client/build.gradle
@@ -3,6 +3,7 @@ apply from: "$rootDir/gradle/publish-jar.gradle"
 sourceCompatibility = 11
 
 dependencies {
+    compile project(':dialogue-core')
     compile project(':dialogue-target')
     compile 'com.google.guava:guava'
     compile 'com.palantir.conjure.java.runtime:client-config'

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/JavaChannels.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/JavaChannels.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import static java.util.stream.Collectors.toList;
+
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.dialogue.core.Channels;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+public final class JavaChannels {
+
+    private JavaChannels() {}
+
+    public static Channel create(ClientConfiguration conf) {
+        // TODO(jellis): read/write timeouts
+        // TODO(jellis): record metrics
+        // TODO(jellis): gcm cipher toggle
+        // TODO(jellis): proxy creds + mesh proxy
+        // TODO(jellis): configure node selection strategy
+        // TODO(jellis): failed url cooldown
+        // TODO(jellis): backoff slot size (possibly unnecessary)
+        // TODO(jellis): client QoS, server QoS, retries?
+
+        HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(conf.connectTimeout())
+                .proxy(conf.proxy())
+                .sslContext(createSslContext(conf.trustManager()))
+                .build();
+
+        List<Channel> channels = conf.uris().stream()
+                .map(uri -> HttpChannel.of(client, url(uri)))
+                .collect(toList());
+
+        return Channels.create(channels);
+    }
+
+    private static URL url(String uri) {
+        try {
+            return new URL(uri);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static SSLContext createSslContext(TrustManager trustManager) {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(new KeyManager[] {}, new TrustManager[] {trustManager}, null);
+            return sslContext;
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/dialogue-java-client/src/test/java/com/palantir/dialogue/JavaChannelsTest.java
+++ b/dialogue-java-client/src/test/java/com/palantir/dialogue/JavaChannelsTest.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.client.config.ClientConfigurations;
+import java.net.URL;
+import java.nio.file.Paths;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class JavaChannelsTest extends AbstractChannelTest {
+    private static final SslConfiguration SSL_CONFIG = SslConfiguration.of(
+            Paths.get("src/test/resources/trustStore.jks"),
+            Paths.get("src/test/resources/keyStore.jks"),
+            "keystore");
+
+    @Override
+    Channel createChannel(URL baseUrl) {
+        ServiceConfiguration serviceConf = ServiceConfiguration.builder()
+                .addUris(baseUrl.toString())
+                .security(SSL_CONFIG)
+                .build();
+        return JavaChannels.create(ClientConfigurations.of(serviceConf));
+    }
+}


### PR DESCRIPTION
## Before this PR
No standard way to construct a client.

## After this PR
Can now construct a properly configured `Channel` backed by the java `HttpClient` given a `ClientConfiguration`. This should act as the entry point when migrating existing clients to Dialogue.

## Other considerations
We should consider how many of the existing conjure features we want to continue to support (there are TODOs for the ones not currently supported). eg: cipher suites may not need to be configured anymore and backoff slot size may not make sense, given we're relying mostly on Concurrency limiting to cause client size backpressure.