### PR TITLE
[improvement] Include headers in response object

### DIFF
--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.ByteArrayInputStream;

--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.util.concurrent.FutureCallback;
@@ -76,7 +77,6 @@ public abstract class AbstractChannelTest {
     };
 
     @Mock private Request request;
-    @Mock private FutureCallback<Response> callback;
     private FakeEndpoint endpoint;
 
     private Channel channel;
@@ -263,6 +263,7 @@ public abstract class AbstractChannelTest {
         ListenableFuture<Response> call = channel.execute(endpoint, request);
         assertThat(call.get().body()).hasContent("");
         assertThat(call.get().code()).isEqualTo(200);
+        assertThat(call.get().headers()).containsEntry("Content-Length", ImmutableList.of("0"));
     }
 
     @Test

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue.core;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -28,6 +29,8 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.Executor;
@@ -159,7 +162,7 @@ final class QueuedChannel implements Channel {
         }
     }
 
-    private enum  RateLimitedResponse implements Response {
+    private enum RateLimitedResponse implements Response {
         INSTANCE;
 
         @Override
@@ -170,6 +173,11 @@ final class QueuedChannel implements Channel {
         @Override
         public int code() {
             return 429;
+        }
+
+        @Override
+        public Map<String, List<String>> headers() {
+            return ImmutableMap.of();
         }
 
         @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -179,11 +179,6 @@ final class QueuedChannel implements Channel {
         public Map<String, List<String>> headers() {
             return ImmutableMap.of();
         }
-
-        @Override
-        public Optional<String> contentType() {
-            return Optional.empty();
-        }
     }
 
     @Value.Immutable

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -35,7 +35,6 @@ import com.palantir.dialogue.UrlBuilder;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Test;
@@ -105,11 +104,6 @@ public class RetryingChannelTest {
         @Override
         public Map<String, List<String>> headers() {
             return ImmutableMap.of();
-        }
-
-        @Override
-        public Optional<String> contentType() {
-            return Optional.empty();
         }
     }
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.Channel;
@@ -32,6 +33,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.UrlBuilder;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -98,6 +100,11 @@ public class RetryingChannelTest {
         @Override
         public int code() {
             return 200;
+        }
+
+        @Override
+        public Map<String, List<String>> headers() {
+            return ImmutableMap.of();
         }
 
         @Override

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -116,6 +117,11 @@ public final class HttpChannel implements Channel {
             @Override
             public int code() {
                 return response.statusCode();
+            }
+
+            @Override
+            public Map<String, List<String>> headers() {
+                return response.headers().map();
             }
 
             @Override

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -30,7 +30,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public final class HttpChannel implements Channel {
@@ -122,11 +121,6 @@ public final class HttpChannel implements Channel {
             @Override
             public Map<String, List<String>> headers() {
                 return response.headers().map();
-            }
-
-            @Override
-            public Optional<String> contentType() {
-                return response.headers().firstValue(Headers.CONTENT_TYPE);
             }
         };
     }

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
@@ -16,14 +16,9 @@
 
 package com.palantir.dialogue;
 
-import com.google.common.collect.Iterables;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public final class OkHttpResponse implements Response {
 
@@ -52,15 +47,5 @@ public final class OkHttpResponse implements Response {
     @Override
     public Map<String, List<String>> headers() {
         return delegate.headers().toMultimap();
-    }
-
-    @Override
-    public Optional<String> contentType() {
-        // TODO(rfink): Maybe cache this
-        // TODO(rfink): Header case sensitivity?
-        Collection<String> headers = delegate.headers(Headers.CONTENT_TYPE);
-        Preconditions.checkArgument(headers.size() <= 1, "Expected zero or one Content-Type headers",
-                SafeArg.of("contentType", headers));
-        return Optional.ofNullable(headers.size() == 1 ? Iterables.getOnlyElement(headers) : null);
     }
 }

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
@@ -21,6 +21,8 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public final class OkHttpResponse implements Response {
@@ -45,6 +47,11 @@ public final class OkHttpResponse implements Response {
     @Override
     public int code() {
         return delegate.code();
+    }
+
+    @Override
+    public Map<String, List<String>> headers() {
+        return delegate.headers().toMultimap();
     }
 
     @Override

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
+import javax.ws.rs.core.HttpHeaders;
 
 /** Package private internal API. */
 final class ConjureBodySerDe implements BodySerDe {
@@ -102,7 +103,7 @@ final class ConjureBodySerDe implements BodySerDe {
 
     @Override
     public InputStream deserializeInputStream(Response exchange) {
-        Optional<String> contentType = exchange.contentType();
+        Optional<String> contentType = exchange.getFirstHeader(HttpHeaders.CONTENT_TYPE);
         if (!contentType.isPresent()) {
             throw new SafeIllegalArgumentException("Response is missing Content-Type header");
         }
@@ -176,7 +177,8 @@ final class ConjureBodySerDe implements BodySerDe {
 
         @Override
         public T deserialize(Response response) {
-            EncodingDeserializerContainer<T> container = getResponseDeserializer(response.contentType());
+            Optional<String> contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);
+            EncodingDeserializerContainer<T> container = getResponseDeserializer(contentType);
             return container.deserializer.deserialize(response.body());
         }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoder.java
@@ -31,6 +31,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.ws.rs.core.HttpHeaders;
 
 public enum DefaultErrorDecoder implements ErrorDecoder {
     INSTANCE;
@@ -42,7 +44,8 @@ public enum DefaultErrorDecoder implements ErrorDecoder {
         // TODO(rfink): What about HTTP/101 switching protocols?
         // TODO(rfink): What about HEAD requests?
 
-        if (response.contentType().isPresent() && response.contentType().get().equals("application/json")) {
+        Optional<String> contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);
+        if (contentType.isPresent() && contentType.get().equals("application/json")) {
             final String body;
             try {
                 body = toString(response.body());

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
@@ -30,6 +31,8 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -145,6 +148,7 @@ public class ConjureBodySerDeTest {
 
         private InputStream body = new ByteArrayInputStream(new byte[] {});
         private int code = 0;
+        private Map<String, List<String>> headers = ImmutableMap.of();
         private Optional<String> contentType = Optional.empty();
 
         @Override
@@ -155,6 +159,11 @@ public class ConjureBodySerDeTest {
         @Override
         public int code() {
             return code;
+        }
+
+        @Override
+        public Map<String, List<String>> headers() {
+            return headers;
         }
 
         @Override

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import javax.ws.rs.core.HttpHeaders;
 import org.junit.Test;
 
 public class ConjureBodySerDeTest {
@@ -46,7 +46,7 @@ public class ConjureBodySerDeTest {
         Encoding plain = new StubEncoding("text/plain");
 
         TestResponse response = new TestResponse();
-        response.contentType = Optional.of("text/plain");
+        response.contentType("text/plain");
         BodySerDe serializers = new ConjureBodySerDe(ImmutableList.of(json, plain));
         String value = serializers.deserializer(TYPE).deserialize(response);
         assertThat(value).isEqualTo(plain.getContentType());
@@ -64,7 +64,7 @@ public class ConjureBodySerDeTest {
     @Test
     public void testUnsupportedRequestContentType() {
         TestResponse response = new TestResponse();
-        response.contentType = Optional.of("application/unknown");
+        response.contentType("application/unknown");
         BodySerDe serializers = new ConjureBodySerDe(ImmutableList.of(new StubEncoding("application/json")));
         assertThatThrownBy(() -> serializers.deserializer(TYPE).deserialize(response))
                 .isInstanceOf(SafeRuntimeException.class)
@@ -97,7 +97,7 @@ public class ConjureBodySerDeTest {
         Encoding plain = new StubEncoding("text/plain");
 
         TestResponse response = new TestResponse();
-        response.contentType = Optional.of("application/unknown");
+        response.contentType("application/unknown");
         BodySerDe serializers = new ConjureBodySerDe(ImmutableList.of(json, plain));
         RequestBody body = serializers.serializer(TYPE).serialize("test");
         assertThat(body.contentType()).isEqualTo(json.getContentType());
@@ -149,7 +149,6 @@ public class ConjureBodySerDeTest {
         private InputStream body = new ByteArrayInputStream(new byte[] {});
         private int code = 0;
         private Map<String, List<String>> headers = ImmutableMap.of();
-        private Optional<String> contentType = Optional.empty();
 
         @Override
         public InputStream body() {
@@ -166,9 +165,8 @@ public class ConjureBodySerDeTest {
             return headers;
         }
 
-        @Override
-        public Optional<String> contentType() {
-            return contentType;
+        public void contentType(String contentType) {
+            this.headers = ImmutableMap.of(HttpHeaders.CONTENT_TYPE, ImmutableList.of(contentType));
         }
     }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
@@ -36,6 +37,8 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.CheckForNull;
 import org.junit.Test;
@@ -145,6 +148,11 @@ public final class DefaultErrorDecoderTest {
             @Override
             public int code() {
                 return code;
+            }
+
+            @Override
+            public Map<String, List<String>> headers() {
+                return ImmutableMap.of();
             }
 
             @Override

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
@@ -39,8 +39,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.CheckForNull;
+import javax.ws.rs.core.HttpHeaders;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -152,12 +152,7 @@ public final class DefaultErrorDecoderTest {
 
             @Override
             public Map<String, List<String>> headers() {
-                return ImmutableMap.of();
-            }
-
-            @Override
-            public Optional<String> contentType() {
-                return Optional.of(mediaType);
+                return ImmutableMap.of(HttpHeaders.CONTENT_TYPE, ImmutableList.of(mediaType));
             }
         };
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -31,6 +31,9 @@ public interface Response {
     /** The HTTP headers for this response. */
     Map<String, List<String>> headers();
 
-    /** The content-type HTTP header of the response if it exists. */
-    Optional<String> contentType();
+    /** Retrieves the first value from the header map for the given key. */
+    default Optional<String> getFirstHeader(String header) {
+        return Optional.ofNullable(headers().get(header))
+                .flatMap(values -> values.stream().findFirst());
+    }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -33,5 +33,4 @@ public interface Response {
 
     /** The content-type HTTP header of the response if it exists. */
     Optional<String> contentType();
-
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -17,6 +17,8 @@
 package com.palantir.dialogue;
 
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface Response {
@@ -26,6 +28,10 @@ public interface Response {
     /** The HTTP response code for this response. */
     int code();
 
+    /** The HTTP headers for this response. */
+    Map<String, List<String>> headers();
+
     /** The content-type HTTP header of the response if it exists. */
     Optional<String> contentType();
+
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -28,7 +28,8 @@ public interface Response {
     /** The HTTP response code for this response. */
     int code();
 
-    /** The HTTP headers for this response. */
+    /** The HTTP headers for this response. Headers names are compared in a case-insensitive fashion as per
+     * https://tools.ietf.org/html/rfc7540#section-8.1.2. */
     Map<String, List<String>> headers();
 
     /** Retrieves the first value from the header map for the given key. */

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -16,6 +16,7 @@
 
 package com.palantir.dialogue;
 
+import com.google.common.collect.ImmutableList;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,10 @@ public interface Response {
 
     /** Retrieves the first value from the header map for the given key. */
     default Optional<String> getFirstHeader(String header) {
-        return Optional.ofNullable(headers().get(header))
-                .flatMap(values -> values.stream().findFirst());
+        List<String> headerList = headers().getOrDefault(header, ImmutableList.of());
+
+        return headerList.isEmpty()
+                ? Optional.empty()
+                : Optional.of(headerList.get(0));
     }
 }


### PR DESCRIPTION
## After this PR
Headers are now accessible in the `Response` object.