### PR TITLE
Add tracing around queue and execution time

### DIFF
--- a/dialogue-core/build.gradle
+++ b/dialogue-core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compile 'com.netflix.concurrency-limits:concurrency-limits-core'
     compile 'com.palantir.conjure.java.runtime:client-config'
     compile 'com.palantir.safe-logging:preconditions'
+    compile 'com.palantir.tracing:tracing'
     compile 'io.dropwizard.metrics:metrics-core'
 
     testCompile 'com.palantir.safe-logging:preconditions-assertj'

--- a/versions.props
+++ b/versions.props
@@ -10,6 +10,7 @@ com.palantir.conjure.java:* = 4.0.0
 com.palantir.ri:resource-identifier = 1.0.1
 com.palantir.safe-logging:* = 1.10.1
 com.palantir.tokens:auth-tokens = 3.6.1
+com.palantir.tracing:tracing = 3.2.0
 com.squareup.okhttp3:* = 3.14.1
 io.dropwizard.metrics:metrics-core = 3.2.6
 org.immutables:* = 2.7.5


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
There was no tracing of requests

## After this PR
We trace how long the request was enqueued
