### PR TITLE
Provide client-side warnings on deprecated endpoint invocations

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -34,6 +34,7 @@ public final class Channels {
         List<LimitedChannel> limitedChannels = channels.stream()
                 // Instrument inner-most channel with metrics so that we measure only the over-the-wire-time
                 .map(channel -> new InstrumentedChannel(channel, metrics))
+                .map(channel -> new DeprecationWarningChannel(channel, metrics))
                 .map(channel -> new TracedChannel(channel, "Concurrency-Limited Dialogue Request"))
                 .map(TracedRequestChannel::new)
                 .map(ConcurrencyLimitedChannel::create)

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class DeprecationWarningChannel implements Channel {
+    private static final Logger log = LoggerFactory.getLogger(DeprecationWarningChannel.class);
+    private static final Object SENTINEL = new Object();
+
+    private final Channel delegate;
+    private final TaggedMetricRegistry registry;
+    private final Cache<String, Object> loggingRateLimiter = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(1))
+            .build();
+
+    DeprecationWarningChannel(Channel delegate, TaggedMetricRegistry registry) {
+        this.delegate = delegate;
+        this.registry = registry;
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+        return DialogueFutures.addDirectCallback(
+                delegate.execute(endpoint, request),
+                DialogueFutures.onSuccess(response -> {
+                    if (response != null) {
+                        response.getFirstHeader("deprecation").ifPresent(deprecated -> {
+                            registry.meter(MetricName.builder()
+                                    .safeName("client.deprecations")
+                                    .putSafeTags("service-name", endpoint.serviceName())
+                                    .build())
+                                    .mark();
+
+                            if (tryAcquire(endpoint.serviceName())) {
+                                log.warn(
+                                        "Using a deprecated endpoint when connecting to service",
+                                        SafeArg.of("serviceName", endpoint.serviceName()),
+                                        SafeArg.of("endpointHttpMethod", endpoint.httpMethod()),
+                                        SafeArg.of("endpointName", endpoint.endpointName()),
+                                        SafeArg.of("endpointClientVersion", endpoint.version()),
+                                        SafeArg.of(
+                                                "service",
+                                                response.getFirstHeader("server").orElse("no server header provided")));
+                            }
+                        });
+                    }
+                }));
+    }
+
+    /**
+     * Returns true when the loggingRateLimiter permits logging for the provided serviceName, and false otherwise.
+     *
+     * <p>Note: this method is not synchronized because the throttling is best effort rather than guaranteed -- the
+     * penalty for failing to rate limit correctly is a few extra log lines, and we choose that penalty over the cost
+     * of synchronization.
+     */
+    private boolean tryAcquire(String serviceName) {
+        if (loggingRateLimiter.getIfPresent(serviceName) == null) {
+            loggingRateLimiter.put(serviceName, SENTINEL);
+            return true;
+        }
+        return false;
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
@@ -30,6 +30,14 @@ import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A channel that logs warnings when the response from a server contains the "deprecation" header. Logs include the
+ * content of the "server" header when it is provided, and always include endpoint details.
+ *
+ * <p>Deprecation warnings are produced at most once per minute per service. The {@code client.deprecations} meter may
+ * be used to understand more granular rates of deprecated calls against a particular service using the
+ * {@code service-name} tag.
+ */
 final class DeprecationWarningChannel implements Channel {
     private static final Logger log = LoggerFactory.getLogger(DeprecationWarningChannel.class);
     private static final Object SENTINEL = new Object();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueFutures.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueFutures.java
@@ -20,6 +20,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class DialogueFutures {
     private DialogueFutures() {}
@@ -27,5 +29,17 @@ final class DialogueFutures {
     static <T> ListenableFuture<T> addDirectCallback(ListenableFuture<T> future, FutureCallback<T> callback) {
         Futures.addCallback(future, callback, MoreExecutors.directExecutor());
         return future;
+    }
+
+    static <T> FutureCallback<T> onSuccess(Consumer<T> onSuccess) {
+        return new FutureCallback<T>() {
+            @Override
+            public void onSuccess(@Nullable T result) {
+                onSuccess.accept(result);
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {}
+        };
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueFutures.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueFutures.java
@@ -39,7 +39,7 @@ final class DialogueFutures {
             }
 
             @Override
-            public void onFailure(Throwable throwable) {}
+            public void onFailure(Throwable _throwable) {}
         };
     }
 }


### PR DESCRIPTION
## Before this PR
Clients invoking deprecated endpoints have no local signaling about those deprecations

## After this PR
Clients invoking deprecated endpoints will log a warning indicating which service class and, when available, the details of the server indicating access to a deprecated endpoint.