### PR TITLE
[improvement] dialogue-core targets jdk8

### DIFF
--- a/dialogue-core/build.gradle
+++ b/dialogue-core/build.gradle
@@ -2,8 +2,6 @@ apply from: "$rootDir/gradle/publish-jar.gradle"
 apply plugin: 'com.palantir.revapi'
 apply plugin: 'com.palantir.metric-schema'
 
-sourceCompatibility = 11
-
 dependencies {
     compile project(':dialogue-target')
     compile 'com.github.ben-manes.caffeine:caffeine'

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/InstrumentedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/InstrumentedChannel.java
@@ -53,7 +53,7 @@ final class InstrumentedChannel implements Channel {
         ListenableFuture<Response> response = delegate.execute(endpoint, request);
         Futures.addCallback(
                 response,
-                new FutureCallback<>() {
+                new FutureCallback<Response>() {
                     @Override
                     public void onSuccess(@Nullable Response _result) {
                         record(endpoint);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -28,6 +28,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -182,7 +183,7 @@ final class QueuedChannel implements Channel {
 
         @Override
         public InputStream body() {
-            return InputStream.nullInputStream();
+            return new ByteArrayInputStream(new byte[0]);
         }
 
         @Override

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -32,6 +32,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.UrlBuilder;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +93,7 @@ public class RetryingChannelTest {
     private static final class TestResponse implements Response {
         @Override
         public InputStream body() {
-            return InputStream.nullInputStream();
+            return new ByteArrayInputStream(new byte[0]);
         }
 
         @Override


### PR DESCRIPTION
## Before this PR
dialogue-core required jdk11, which isn't always available.

## After this PR
Dialogue clients can be built for jdk8
