### PR TITLE
Move verb+body validation into an isolated Channel

### DIFF
--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.ByteArrayInputStream;
@@ -204,9 +205,9 @@ public abstract class AbstractChannelTest {
     public void get_failsWhenBodyIsGiven() {
         endpoint.method = HttpMethod.GET;
         when(request.body()).thenReturn(Optional.of(body));
-        assertThatThrownBy(() -> channel.execute(endpoint, request))
-                .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessage("GET endpoints must not have a request body");
+        assertThatThrownBy(() -> Futures.getDone(channel.execute(endpoint, request)))
+                .hasCauseInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("must not have a request body");
     }
 
     @Test
@@ -227,9 +228,9 @@ public abstract class AbstractChannelTest {
     public void delete_failsWhenBodyIsGiven() {
         endpoint.method = HttpMethod.DELETE;
         when(request.body()).thenReturn(Optional.of(body));
-        assertThatThrownBy(() -> channel.execute(endpoint, request))
-                .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessage("DELETE endpoints must not have a request body");
+        assertThatThrownBy(() -> Futures.getDone(channel.execute(endpoint, request)))
+                .hasCauseInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("must not have a request body");
     }
 
     @Test

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -33,6 +33,7 @@ public final class Channels {
                 // Instrument inner-most channel with metrics so that we measure only the over-the-wire-time
                 .map(channel -> new InstrumentedChannel(channel, metrics))
                 .map(channel -> new DeprecationWarningChannel(channel, metrics))
+                .map(MethodRequestBodyValidatingChannel::new)
                 .map(channel -> new TracedChannel(channel, "Concurrency-Limited Dialogue Request"))
                 .map(TracedRequestChannel::new)
                 .map(ConcurrencyLimitedChannel::create)

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/MethodRequestBodyValidatingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/MethodRequestBodyValidatingChannel.java
@@ -1,0 +1,31 @@
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+
+/** Validates that <code>GET</code> and <code>DELETE</code> requests do not contain bodies. */
+final class MethodRequestBodyValidatingChannel implements Channel {
+
+    private final Channel delegate;
+
+    MethodRequestBodyValidatingChannel(Channel delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+        HttpMethod method = endpoint.httpMethod();
+        if ((method == HttpMethod.DELETE || method == HttpMethod.GET)
+                && request.body().isPresent()) {
+            return Futures.immediateFailedFuture(
+                    new SafeIllegalArgumentException("GET and DELETE endpoints must not have a request body"));
+        }
+        return delegate.execute(endpoint, request);
+    }
+}

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -84,7 +84,6 @@ public final class HttpChannel implements Channel {
         // Fill request body and set HTTP method
         switch (endpoint.httpMethod()) {
             case GET:
-                Preconditions.checkArgument(!request.body().isPresent(), "GET endpoints must not have a request body");
                 httpRequest.GET();
                 break;
             case POST:
@@ -94,8 +93,6 @@ public final class HttpChannel implements Channel {
                 httpRequest.PUT(toBody(request));
                 break;
             case DELETE:
-                Preconditions.checkArgument(
-                        !request.body().isPresent(), "DELETE endpoints must not have a request body");
                 httpRequest.DELETE();
                 break;
         }


### PR DESCRIPTION
Fix: channel.execute must not throw, a future should be returned.
Follow-up: implement an outer channel to catch RuntimeExceptions
and Errors thrown and convert them into immediate failed futures.
