### PR TITLE
Backstop against exceptions thrown in Channel impls

### DIFF
--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -206,9 +205,7 @@ public abstract class AbstractChannelTest {
         endpoint.method = HttpMethod.GET;
         when(request.body()).thenReturn(Optional.of(body));
         assertThatThrownBy(() -> Futures.getDone(channel.execute(endpoint, request)))
-                .hasCauseInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessage("com.palantir.logsafe.exceptions.SafeIllegalArgumentException: "
-                        + "GET endpoints must not have a request body");
+                .hasMessageContaining("GET endpoints must not have a request body");
     }
 
     @Test
@@ -230,9 +227,7 @@ public abstract class AbstractChannelTest {
         endpoint.method = HttpMethod.DELETE;
         when(request.body()).thenReturn(Optional.of(body));
         assertThatThrownBy(() -> Futures.getDone(channel.execute(endpoint, request)))
-                .hasCauseInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessage("com.palantir.logsafe.exceptions.SafeIllegalArgumentException: "
-                        + "DELETE endpoints must not have a request body");
+                .hasMessageContaining("DELETE endpoints must not have a request body");
     }
 
     @Test

--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.ByteArrayInputStream;
@@ -204,9 +205,10 @@ public abstract class AbstractChannelTest {
     public void get_failsWhenBodyIsGiven() {
         endpoint.method = HttpMethod.GET;
         when(request.body()).thenReturn(Optional.of(body));
-        assertThatThrownBy(() -> channel.execute(endpoint, request))
-                .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessage("GET endpoints must not have a request body");
+        assertThatThrownBy(() -> Futures.getDone(channel.execute(endpoint, request)))
+                .hasCauseInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessage("com.palantir.logsafe.exceptions.SafeIllegalArgumentException: "
+                        + "GET endpoints must not have a request body");
     }
 
     @Test
@@ -227,9 +229,10 @@ public abstract class AbstractChannelTest {
     public void delete_failsWhenBodyIsGiven() {
         endpoint.method = HttpMethod.DELETE;
         when(request.body()).thenReturn(Optional.of(body));
-        assertThatThrownBy(() -> channel.execute(endpoint, request))
-                .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessage("DELETE endpoints must not have a request body");
+        assertThatThrownBy(() -> Futures.getDone(channel.execute(endpoint, request)))
+                .hasCauseInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessage("com.palantir.logsafe.exceptions.SafeIllegalArgumentException: "
+                        + "DELETE endpoints must not have a request body");
     }
 
     @Test

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -42,6 +42,7 @@ public final class Channels {
         Channel channel = new QueuedChannel(limited, DispatcherMetrics.of(metrics));
         channel = new RetryingChannel(channel);
         channel = new UserAgentChannel(channel, userAgent);
+        channel = new NeverThrowChannel(channel);
 
         return channel;
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -38,9 +38,11 @@ public final class Channels {
                 .map(ConcurrencyLimitedChannel::create)
                 .collect(ImmutableList.toImmutableList());
 
-        return new UserAgentChannel(
-                new RetryingChannel(
-                        new QueuedChannel(new RoundRobinChannel(limitedChannels), DispatcherMetrics.of(metrics))),
-                userAgent);
+        LimitedChannel limited = new RoundRobinChannel(limitedChannels);
+        Channel channel = new QueuedChannel(limited, DispatcherMetrics.of(metrics));
+        channel = new RetryingChannel(channel);
+        channel = new UserAgentChannel(channel, userAgent);
+
+        return channel;
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowChannel.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The contract of {@link Channel} requires that the {@link Channel#execute} method never throws. This is a defensive
+ * backstop so that callers can rely on this invariant.
+ */
+final class NeverThrowChannel implements Channel {
+
+    private static final Logger log = LoggerFactory.getLogger(QueuedChannel.class);
+    private final Channel delegate;
+
+    NeverThrowChannel(Channel delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+        try {
+            return delegate.execute(endpoint, request);
+        } catch (RuntimeException e) {
+            log.error(
+                    "Exception thrown from dialogue channel, which should never happen. This may be a bug in the"
+                            + " channel implementation",
+                    e);
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowChannel.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 final class NeverThrowChannel implements Channel {
 
-    private static final Logger log = LoggerFactory.getLogger(QueuedChannel.class);
+    private static final Logger log = LoggerFactory.getLogger(NeverThrowChannel.class);
     private final Channel delegate;
 
     NeverThrowChannel(Channel delegate) {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowChannel.java
@@ -42,11 +42,8 @@ final class NeverThrowChannel implements Channel {
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
         try {
             return delegate.execute(endpoint, request);
-        } catch (RuntimeException e) {
-            log.error(
-                    "Exception thrown from dialogue channel, which should never happen. This may be a bug in the"
-                            + " channel implementation",
-                    e);
+        } catch (RuntimeException | Error e) {
+            log.error("Dialogue channels should never throw. This may be a bug in the channel implementation", e);
             return Futures.immediateFailedFuture(e);
         }
     }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ChannelsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ChannelsTest.java
@@ -97,12 +97,12 @@ public final class ChannelsTest {
     public void bad_channels_cant_throw() {
         Channel badUserImplementation = new Channel() {
             @Override
-            public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+            public ListenableFuture<Response> execute(Endpoint _endpoint, Request _request) {
                 throw new IllegalStateException("Always throw");
             }
         };
 
-        Channel channel =
+        channel =
                 Channels.create(ImmutableList.of(badUserImplementation), USER_AGENT, new DefaultTaggedMetricRegistry());
 
         // this should never throw

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ChannelsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ChannelsTest.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -42,6 +43,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class ChannelsTest {
+
+    public static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of("foo", "1.0.0"));
 
     @Mock
     private Channel delegate;
@@ -79,10 +82,7 @@ public final class ChannelsTest {
 
     @Before
     public void before() {
-        channel = Channels.create(
-                ImmutableList.of(delegate),
-                UserAgent.of(UserAgent.Agent.of("foo", "1.0.0")),
-                new DefaultTaggedMetricRegistry());
+        channel = Channels.create(ImmutableList.of(delegate), USER_AGENT, new DefaultTaggedMetricRegistry());
 
         ListenableFuture<Response> expectedResponse = Futures.immediateFuture(response);
         when(delegate.execute(eq(endpoint), any())).thenReturn(expectedResponse);
@@ -91,5 +91,24 @@ public final class ChannelsTest {
     @Test
     public void testRequestMakesItThrough() throws ExecutionException, InterruptedException {
         assertThat(channel.execute(endpoint, request).get()).isEqualTo(response);
+    }
+
+    @Test
+    public void bad_channels_cant_throw() {
+        Channel badUserImplementation = new Channel() {
+            @Override
+            public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+                throw new IllegalStateException("Always throw");
+            }
+        };
+
+        Channel channel =
+                Channels.create(ImmutableList.of(badUserImplementation), USER_AGENT, new DefaultTaggedMetricRegistry());
+
+        // this should never throw
+        ListenableFuture<Response> future = channel.execute(endpoint, request);
+
+        // only when we access things do we allow exceptions
+        assertThatThrownBy(() -> Futures.getUnchecked(future)).hasCauseInstanceOf(IllegalStateException.class);
     }
 }


### PR DESCRIPTION
## Before this PR

This repo uses the paradigm of ListenableFutures everywhere, and tries to avoid exceptions. Unfortunately java doesn't make it easy to completely avoid exceptions using static analysis, and we've already had some unintentional preconditions that would blast through the nice abstractions we set up in Channel.

## After this PR

Whatever strange implementations get passed into `Channels#create`, clients should always be able to assume that failures will come out as failed listenable futures, not as the _occasional_ exception!
