### PR TITLE
[improvement] QueuedChannel avoids queue contention in the fast path

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -44,8 +44,6 @@ import org.immutables.value.Value;
  * <ol>
  *     <li>On submission - allows execution when there is available capacity</li>
  *     <li>On request completion - allows execution when capacity has now become available</li>
- *     <li>Periodically (eg: every 100ms) - allows execution when there may have been no capaciy and no in-flight
- *     requests</li>
  * </ol>
  *
  * This implementation was chosen over alternatives for the following reasons:

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -107,7 +107,7 @@ public class QueuedChannelTest {
     public void testQueuedRequestExecutedOnNextSubmission() {
         mockNoCapacity();
         queuedChannel.execute(endpoint, request);
-        verify(delegate, times(1)).maybeExecute(endpoint, request);
+        verify(delegate, times(2)).maybeExecute(endpoint, request);
 
         mockHasCapacity();
         queuedChannel.execute(endpoint, request);
@@ -123,11 +123,11 @@ public class QueuedChannelTest {
 
         mockNoCapacity();
         queuedChannel.execute(endpoint, request);
-        verify(delegate, times(2)).maybeExecute(endpoint, request);
+        verify(delegate, times(3)).maybeExecute(endpoint, request);
 
         futureResponse.set(mockResponse);
 
-        verify(delegate, times(3)).maybeExecute(endpoint, request);
+        verify(delegate, times(4)).maybeExecute(endpoint, request);
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
The queue was used for every request

## After this PR
The QueuedChannel queue is avoided unless an initial attempt to execute the request is limited.
This can produced unexpected order of execution when a limit is reached and recedes, but worth the trade-off to limit load.

When requests are limited, other requests are less likely to prompt the queue to allow them through as there's no backpressure signal from the delegate LimitedChannel, however this is no different from a request followed by no subsequent requests, which is a bug that should also be fixed. Ultimately LimitedChannels should be able to signal when they're ready to accept requests again.
