### PR TITLE
fix #312: RoundRobinChannel fails when no targets are available

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RoundRobinChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RoundRobinChannel.java
@@ -17,10 +17,12 @@
 package com.palantir.dialogue.core;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.logsafe.exceptions.SafeIoException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,7 +42,7 @@ final class RoundRobinChannel implements LimitedChannel {
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
         if (delegates.isEmpty()) {
-            return Optional.empty();
+            return Optional.of(Futures.immediateFailedFuture(new SafeIoException("No targets are available")));
         }
 
         int host = currentHost.getAndUpdate(value -> toIndex(value + 1));

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RoundRobinChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RoundRobinChannelTest.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -25,6 +26,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.logsafe.exceptions.SafeIoException;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,6 +90,8 @@ public class RoundRobinChannelTest {
     public void testNoChannelsConfigured() {
         loadBalancer = new RoundRobinChannel(ImmutableList.of());
 
-        assertThat(loadBalancer.maybeExecute(endpoint, request)).isEmpty();
+        assertThatThrownBy(
+                        () -> loadBalancer.maybeExecute(endpoint, request).get().get())
+                .hasCauseInstanceOf(SafeIoException.class);
     }
 }


### PR DESCRIPTION
## Before this PR
Previously it would respond as though it was not ready and allow
requests to potentially queue.

## After this PR
Requests fail when there's nowhere to send them
