### PR TITLE
[break][improvement] RequestBody.length uses OptionalLong

### DIFF
--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -66,8 +67,8 @@ public abstract class AbstractChannelTest {
 
     private final RequestBody body = new RequestBody() {
         @Override
-        public Optional<Long> length() {
-            return Optional.of((long) CONTENT.length);
+        public OptionalLong length() {
+            return OptionalLong.of(CONTENT.length);
         }
 
         @Override

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import javax.ws.rs.core.HttpHeaders;
 
 /** Package private internal API. */
@@ -95,8 +96,8 @@ final class ConjureBodySerDe implements BodySerDe {
         Preconditions.checkNotNull(value, "A BinaryRequestBody value is required");
         return new RequestBody() {
             @Override
-            public Optional<Long> length() {
-                return Optional.empty();
+            public OptionalLong length() {
+                return OptionalLong.empty();
             }
 
             @Override
@@ -145,8 +146,8 @@ final class ConjureBodySerDe implements BodySerDe {
 
             return new RequestBody() {
                 @Override
-                public Optional<Long> length() {
-                    return Optional.of((long) bytes.size());
+                public OptionalLong length() {
+                    return OptionalLong.of(bytes.size());
                 }
 
                 @Override

--- a/dialogue-target/src/main/java/com/palantir/dialogue/EmptyBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/EmptyBody.java
@@ -18,7 +18,7 @@ package com.palantir.dialogue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Optional;
+import java.util.OptionalLong;
 
 /** A singleton object that always serializes to an empty byte array. */
 public enum EmptyBody {
@@ -27,8 +27,8 @@ public enum EmptyBody {
     public static Serializer<EmptyBody> serializer(String contentType) {
         return value -> new RequestBody() {
             @Override
-            public Optional<Long> length() {
-                return Optional.of(0L);
+            public OptionalLong length() {
+                return OptionalLong.of(0L);
             }
 
             @Override

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
@@ -17,11 +17,11 @@
 package com.palantir.dialogue;
 
 import java.io.InputStream;
-import java.util.Optional;
+import java.util.OptionalLong;
 
 public interface RequestBody {
     /** The number of bytes in the {@link #content}, or absent if unknown. */
-    Optional<Long> length();
+    OptionalLong length();
 
     /** The content of this request body, possibly empty. */
     InputStream content();

--- a/dialogue-target/src/test/java/com/palantir/dialogue/EmptyBodyTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/EmptyBodyTest.java
@@ -32,7 +32,7 @@ public final class EmptyBodyTest {
         assertThat(EmptyBody.serializer("application/json")
                         .serialize(EmptyBody.INSTANCE)
                         .length())
-                .contains(0L);
+                .hasValue(0L);
         assertThat(EmptyBody.serializer("application/json")
                         .serialize(EmptyBody.INSTANCE)
                         .contentType())


### PR DESCRIPTION
## Before this PR
`Optional<Long>`

## After this PR
`OptionalLong` is a more specific type.
