### PR TITLE
Use default port if one is not provided

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ apply plugin: 'com.palantir.git-version'
 
 allprojects {
     apply plugin: 'com.palantir.java-format'
-    version gitVersion()
+    version System.env.CIRCLE_TAG ?: gitVersion()
     group 'com.palantir.dialogue'
 
     repositories {

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -58,7 +58,7 @@ public final class HttpChannel implements Channel {
                 null == Strings.emptyToNull(baseUrl.getUserInfo()), "baseUrl user info must be empty");
         this.baseUrl = UrlBuilder.withProtocol(baseUrl.getProtocol())
                 .host(baseUrl.getHost())
-                .port(baseUrl.getPort());
+                .port(getPortOrDefault(baseUrl));
         String strippedBasePath = stripSlashes(baseUrl.getPath());
         if (!strippedBasePath.isEmpty()) {
             this.baseUrl.encodedPathSegments(strippedBasePath);
@@ -195,5 +195,12 @@ public final class HttpChannel implements Channel {
         public int read(byte[] bytes, int off, int len) throws IOException {
             return delegate.get().read(bytes, off, len);
         }
+    }
+
+    private static int getPortOrDefault(URL url) {
+        if (url.getPort() == -1) {
+            return url.getDefaultPort();
+        }
+        return url.getPort();
     }
 }

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -16,11 +16,9 @@
 
 package com.palantir.dialogue;
 
-import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,24 +43,7 @@ public final class HttpChannel implements Channel {
     private HttpChannel(HttpClient client, URL baseUrl, Duration requestTimeout) {
         this.client = client;
         this.requestTimeout = requestTimeout;
-        // Sanitize path syntax and strip all irrelevant URL components
-        Preconditions.checkArgument(
-                null == Strings.emptyToNull(baseUrl.getQuery()),
-                "baseUrl query must be empty",
-                UnsafeArg.of("query", baseUrl.getQuery()));
-        Preconditions.checkArgument(
-                null == Strings.emptyToNull(baseUrl.getRef()),
-                "baseUrl ref must be empty",
-                UnsafeArg.of("ref", baseUrl.getRef()));
-        Preconditions.checkArgument(
-                null == Strings.emptyToNull(baseUrl.getUserInfo()), "baseUrl user info must be empty");
-        this.baseUrl = UrlBuilder.withProtocol(baseUrl.getProtocol())
-                .host(baseUrl.getHost())
-                .port(getPortOrDefault(baseUrl));
-        String strippedBasePath = stripSlashes(baseUrl.getPath());
-        if (!strippedBasePath.isEmpty()) {
-            this.baseUrl.encodedPathSegments(strippedBasePath);
-        }
+        this.baseUrl = UrlBuilder.from(baseUrl);
     }
 
     public static HttpChannel of(HttpClient client, URL baseUrl) {
@@ -160,18 +141,6 @@ public final class HttpChannel implements Channel {
         }
     }
 
-    private String stripSlashes(String path) {
-        if (path.isEmpty()) {
-            return path;
-        } else if (path.equals("/")) {
-            return "";
-        } else {
-            int stripStart = path.startsWith("/") ? 1 : 0;
-            int stripEnd = path.endsWith("/") ? 1 : 0;
-            return path.substring(stripStart, path.length() - stripEnd);
-        }
-    }
-
     /** Wraps a {@link java.util.zip.GZIPInputStream} deferring initialization until first byte is read. */
     private static class DeferredGzipInputStream extends InputStream {
         private final Supplier<GZIPInputStream> delegate;
@@ -195,12 +164,5 @@ public final class HttpChannel implements Channel {
         public int read(byte[] bytes, int off, int len) throws IOException {
             return delegate.get().read(bytes, off, len);
         }
-    }
-
-    private static int getPortOrDefault(URL url) {
-        if (url.getPort() == -1) {
-            return url.getDefaultPort();
-        }
-        return url.getPort();
     }
 }

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
@@ -16,12 +16,10 @@
 
 package com.palantir.dialogue;
 
-import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.UnsafeArg;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
@@ -41,24 +39,7 @@ public final class OkHttpChannel implements Channel {
 
     private OkHttpChannel(OkHttpClient client, URL baseUrl) {
         this.client = client;
-        // Sanitize path syntax and strip all irrelevant URL components
-        Preconditions.checkArgument(
-                null == Strings.emptyToNull(baseUrl.getQuery()),
-                "baseUrl query must be empty",
-                UnsafeArg.of("query", baseUrl.getQuery()));
-        Preconditions.checkArgument(
-                null == Strings.emptyToNull(baseUrl.getRef()),
-                "baseUrl ref must be empty",
-                UnsafeArg.of("ref", baseUrl.getRef()));
-        Preconditions.checkArgument(
-                null == Strings.emptyToNull(baseUrl.getUserInfo()), "baseUrl user info must be empty");
-        this.baseUrl = UrlBuilder.withProtocol(baseUrl.getProtocol())
-                .host(baseUrl.getHost())
-                .port(baseUrl.getPort());
-        String strippedBasePath = stripSlashes(baseUrl.getPath());
-        if (!strippedBasePath.isEmpty()) {
-            this.baseUrl.encodedPathSegments(strippedBasePath);
-        }
+        this.baseUrl = UrlBuilder.from(baseUrl);
     }
 
     /** Creates a new channel with the given underlying client, baseUrl, and error decoder. Note that */
@@ -135,17 +116,5 @@ public final class OkHttpChannel implements Channel {
             }
         });
         return future;
-    }
-
-    private String stripSlashes(String path) {
-        if (path.isEmpty()) {
-            return path;
-        } else if (path.equals("/")) {
-            return "";
-        } else {
-            int stripStart = path.startsWith("/") ? 1 : 0;
-            int stripEnd = path.endsWith("/") ? 1 : 0;
-            return path.substring(stripStart, path.length() - stripEnd);
-        }
     }
 }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/PathTemplateTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/PathTemplateTest.java
@@ -22,6 +22,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import java.io.IOException;
+import java.net.URL;
 import java.util.Map;
 import org.junit.Test;
 
@@ -82,8 +85,12 @@ public final class PathTemplateTest {
     }
 
     private static String fill(PathTemplate template, Map<String, String> params) {
-        UrlBuilder url = UrlBuilder.http().host("unused").port(1);
-        template.fill(params, url);
-        return url.build().getPath();
+        try {
+            UrlBuilder url = UrlBuilder.from(new URL("http://unused:1"));
+            template.fill(params, url);
+            return url.build().getPath();
+        } catch (IOException e) {
+            throw new SafeRuntimeException("failed to construct url", e);
+        }
     }
 }


### PR DESCRIPTION
## Before this PR
We would fail to execute a request if the provided uri did not include an explicit port number

## After this PR
We fallback to the protocol's default port number if one is not provided
