### PR TITLE
convert client metrics to metric schema

### DIFF
--- a/changelog/@unreleased/pr-342.v2.yml
+++ b/changelog/@unreleased/pr-342.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Migrate client metrics to metric schema and move the metrics to `dialogue.client`
+    namespace to avoid conflict with existing clients
+  links:
+  - https://github.com/palantir/dialogue/pull/342

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -29,10 +29,11 @@ public final class Channels {
 
     public static Channel create(
             Collection<? extends Channel> channels, UserAgent userAgent, TaggedMetricRegistry metrics) {
+        DialogueClientMetrics clientMetrics = DialogueClientMetrics.of(metrics);
         List<LimitedChannel> limitedChannels = channels.stream()
                 // Instrument inner-most channel with metrics so that we measure only the over-the-wire-time
-                .map(channel -> new InstrumentedChannel(channel, metrics))
-                .map(channel -> new DeprecationWarningChannel(channel, metrics))
+                .map(channel -> new InstrumentedChannel(channel, clientMetrics))
+                .map(channel -> new DeprecationWarningChannel(channel, clientMetrics))
                 .map(channel -> new TracedChannel(channel, "Concurrency-Limited Dialogue Request"))
                 .map(TracedRequestChannel::new)
                 .map(ConcurrencyLimitedChannel::create)

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -12,3 +12,14 @@ namespaces:
       calls.running:
         type: gauge
         docs: Number of active outgoing requests.
+  dialogue.client:
+    docs: Dialogue client response metrics.
+    metrics:
+      response:
+        type: timer
+        tags: [service-name]
+        docs: Request time, note that this does not include time spent reading the response body.
+      deprecations:
+        type: meter
+        tags: [service-name]
+        docs: Rate of deprecated endpoints being invoked.

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
@@ -27,7 +27,6 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,16 +49,16 @@ public final class InstrumentedChannelTest {
     @Before
     public void before() {
         registry = new DefaultTaggedMetricRegistry();
-        channel = new InstrumentedChannel(delegate, registry);
+        channel = new InstrumentedChannel(delegate, DialogueClientMetrics.of(registry));
     }
 
     @Test
-    public void addsMetricsForSuccessfulAndUnsuccessfulExecution() throws IOException {
+    public void addsMetricsForSuccessfulAndUnsuccessfulExecution() {
         when(endpoint.serviceName()).thenReturn("my-service");
 
         MetricName name = MetricName.builder()
-                .safeName(InstrumentedChannel.CLIENT_RESPONSE_METRIC_NAME)
-                .putSafeTags(InstrumentedChannel.SERVICE_NAME_TAG, endpoint.serviceName())
+                .safeName("dialogue.client.response")
+                .putSafeTags("service-name", endpoint.serviceName())
                 .build();
         Timer timer = registry.timer(name);
 


### PR DESCRIPTION
## Before this PR
We had client metrics defined in code under `client` namespace. 

## After this PR
==COMMIT_MSG==
Migrate client metrics to metric schema and move the metrics to `dialogue.client` namespace to avoid conflict with existing clients
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
