### PR TITLE
JavaChannels respects the client configuration `enableHttp2` flag

### DIFF
--- a/changelog/@unreleased/pr-354.v2.yml
+++ b/changelog/@unreleased/pr-354.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: JavaChannels respects the client configuration `enableHttp2` flag
+  links:
+  - https://github.com/palantir/dialogue/pull/354

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/JavaChannels.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/JavaChannels.java
@@ -33,6 +33,8 @@ import javax.net.ssl.TrustManager;
 
 public final class JavaChannels {
 
+    private static final boolean DEFAULT_ENABLE_HTTP2 = false;
+
     private JavaChannels() {}
 
     public static Channel create(ClientConfiguration conf, UserAgent baseAgent, TaggedMetricRegistry metrics) {
@@ -48,6 +50,10 @@ public final class JavaChannels {
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .connectTimeout(conf.connectTimeout())
                 .proxy(conf.proxy())
+                .version(
+                        conf.enableHttp2().orElse(DEFAULT_ENABLE_HTTP2)
+                                ? HttpClient.Version.HTTP_2
+                                : HttpClient.Version.HTTP_1_1)
                 .sslContext(createSslContext(conf.trustManager()))
                 .build();
 


### PR DESCRIPTION
This changes the default to disabled as the client fails to make requests
to a standard witchcraft server otherwise.

==COMMIT_MSG==
JavaChannels respects the client configuration `enableHttp2` flag
==COMMIT_MSG==
