### PR TITLE
Simplify InstrumentedChannel

### DIFF
--- a/changelog/@unreleased/pr-359.v2.yml
+++ b/changelog/@unreleased/pr-359.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Simplify InstrumentedChannel and provide flexibility for custom clocks.
+  links:
+  - https://github.com/palantir/dialogue/pull/359


### PR DESCRIPTION
Instead of a Guava stopwatch we use a codahale Timer.Context. This
allows the InstrumentedChannel to use the timer provided by
simulation tests.

Because the same code is executed for both success and failure
we can use the simple ListenableFuture.addListener function.

==COMMIT_MSG==
Simplify InstrumentedChannel and provide flexibility for custom clocks.
==COMMIT_MSG==
