### PR TITLE
fix #353: Response is closeable

### DIFF
--- a/changelog/@unreleased/pr-360.v2.yml
+++ b/changelog/@unreleased/pr-360.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Response is closeable
+  links:
+  - https://github.com/palantir/dialogue/pull/360

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Adds support for transparently requesting and decoding <code>Content-Encoding: gzip</code> responses
@@ -45,6 +47,8 @@ import java.util.zip.GZIPInputStream;
  * https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
  */
 final class ContentDecodingChannel implements Channel {
+
+    private static final Logger log = LoggerFactory.getLogger(ContentDecodingChannel.class);
 
     private static final String ACCEPT_ENCODING = "accept-encoding";
     private static final String CONTENT_ENCODING = "content-encoding";
@@ -98,9 +102,6 @@ final class ContentDecodingChannel implements Channel {
 
         @Override
         public InputStream body() {
-            if (body == null) {
-                delegate.body();
-            }
             return body;
         }
 
@@ -125,6 +126,17 @@ final class ContentDecodingChannel implements Channel {
         @Override
         public String toString() {
             return "ContentDecodingResponse{delegate=" + delegate + '}';
+        }
+
+        @Override
+        public void close() {
+            try {
+                body.close();
+            } catch (IOException e) {
+                log.warn("Failed to close encoded body", e);
+            } finally {
+                delegate.close();
+            }
         }
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -193,6 +193,9 @@ final class QueuedChannel implements Channel {
         public Map<String, List<String>> headers() {
             return ImmutableMap.of();
         }
+
+        @Override
+        public void close() {}
     }
 
     @Value.Immutable

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentDecodingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentDecodingChannelTest.java
@@ -183,6 +183,9 @@ public final class ContentDecodingChannelTest {
             return ImmutableMap.of();
         }
 
+        @Override
+        default void close() {}
+
         class Builder extends ImmutableStubResponse.Builder {}
 
         static Builder builder() {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -132,13 +132,12 @@ public class RetryingChannelTest {
         ListenableFuture<Response> response = retryer.execute(ENDPOINT, REQUEST);
         assertThat(response.get(1, TimeUnit.SECONDS).code()).isEqualTo(200);
 
-        verify(response1.body(), times(1)).close();
-        verify(response2.body(), times(1)).close();
+        verify(response1, times(1)).close();
+        verify(response2, times(1)).close();
     }
 
     private static Response mockResponse(int status) {
         Response response = mock(Response.class);
-        when(response.body()).thenReturn(mock(InputStream.class));
         when(response.code()).thenReturn(status);
         return response;
     }
@@ -158,6 +157,9 @@ public class RetryingChannelTest {
         public Map<String, List<String>> headers() {
             return ImmutableMap.of();
         }
+
+        @Override
+        public void close() {}
     }
 
     private static final class TestEndpoint implements Endpoint {

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -31,8 +31,11 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class HttpChannel implements Channel {
+    private static final Logger log = LoggerFactory.getLogger(HttpChannel.class);
 
     private final HttpClient client;
     private final Duration requestTimeout;
@@ -116,6 +119,15 @@ public final class HttpChannel implements Channel {
             @Override
             public Map<String, List<String>> headers() {
                 return response.headers().map();
+            }
+
+            @Override
+            public void close() {
+                try {
+                    body().close();
+                } catch (IOException e) {
+                    log.warn("Failed to close response", e);
+                }
             }
         };
     }

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
@@ -48,4 +48,9 @@ public final class OkHttpResponse implements Response {
     public Map<String, List<String>> headers() {
         return delegate.headers().toMultimap();
     }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -195,6 +195,9 @@ public class ConjureBodySerDeTest {
             return headers;
         }
 
+        @Override
+        public void close() {}
+
         public void contentType(String contentType) {
             this.headers = ImmutableMap.of(HttpHeaders.CONTENT_TYPE, ImmutableList.of(contentType));
         }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
@@ -157,6 +157,9 @@ public final class DefaultErrorDecoderTest {
             public Map<String, List<String>> headers() {
                 return ImmutableMap.of(HttpHeaders.CONTENT_TYPE, ImmutableList.of(mediaType));
             }
+
+            @Override
+            public void close() {}
         };
     }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -17,12 +17,13 @@
 package com.palantir.dialogue;
 
 import com.google.common.collect.ImmutableList;
+import java.io.Closeable;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public interface Response {
+public interface Response extends Closeable {
     /** The HTTP body for this response. */
     InputStream body();
 
@@ -39,4 +40,12 @@ public interface Response {
 
         return headerList.isEmpty() ? Optional.empty() : Optional.of(headerList.get(0));
     }
+
+    /**
+     * Releases all resources associated with this response. If the {@link #body()} is still open, {@link #close()}
+     * should {@link InputStream#close() close the stream}.
+     * Implementations must not throw, preferring to catch and log internally.
+     */
+    @Override
+    void close();
 }

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationUtils.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationUtils.java
@@ -48,6 +48,9 @@ final class SimulationUtils {
                 }
                 return ImmutableMap.of("server", ImmutableList.of("foundry-catalog/" + version));
             }
+
+            @Override
+            public void close() {}
         };
     }
 


### PR DESCRIPTION
Implementations are expected not to throw in order to simplify
response handling. By making it easy to close responses it's more
likely consumers will actually do it.

## Before this PR
Easy to forget to close Responses, and difficult to close them.

## After this PR
The Response object is Closeable, and doesn't require special IOException handling to do.

==COMMIT_MSG==
Response is closeable
==COMMIT_MSG==
