### PR TITLE
Add simple cost based routing scheme

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/CostBasedRouting.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/CostBasedRouting.java
@@ -1,0 +1,106 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Reservoir;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.logsafe.Preconditions;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongConsumer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class CostBasedRouting implements LimitedChannel {
+    private final ImmutableList<LimitedChannel> channels;
+    // Each Reservoir stores the perceived cost of making a request to a channel. We may want to consider bookkeeping at
+    // the endpoint level in the future
+    private final LoadingCache<LimitedChannel, Reservoir> costPerChannel;
+
+    CostBasedRouting(ImmutableList<LimitedChannel> channels, Clock clock) {
+        Preconditions.checkState(channels.size() >= 2, "At least two channels required");
+        this.channels = channels;
+        costPerChannel = Caffeine.newBuilder()
+                .maximumSize(1000)
+                .build(upstream -> new ExponentiallyDecayingReservoir(1028, 0.015, clock));
+    }
+
+    @Override
+    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
+        List<LimitedChannel> sortedChannelsByCost = sortChannelsByLowestUtilization();
+        // TODO(forozco): we'll probably want to tune how we determine the cost of a failure
+        long averageCost = (long) sortedChannelsByCost.stream()
+                .mapToDouble(
+                        channel -> costPerChannel.get(channel).getSnapshot().getMedian())
+                .average()
+                .getAsDouble();
+        for (LimitedChannel channel : sortedChannelsByCost) {
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            Optional<ListenableFuture<Response>> maybeResponse = channel.maybeExecute(endpoint, request);
+
+            if (maybeResponse.isPresent()) {
+                ListenableFuture<Response> response = maybeResponse.get();
+                return Optional.of(DialogueFutures.addDirectCallback(
+                        response,
+                        new CostBasedRoutingCallback(stopwatch, averageCost, costPerChannel.get(channel)::update)));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private List<LimitedChannel> sortChannelsByLowestUtilization() {
+        return channels.stream()
+                // Reading the reservoir so regularly may result in high lock contention
+                .sorted(Comparator.comparing(
+                        channel -> costPerChannel.get(channel).getSnapshot().getMedian()))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    static class CostBasedRoutingCallback implements FutureCallback<Response> {
+        private final Stopwatch stopwatch;
+        private final long errorCost;
+        private final LongConsumer costConsumer;
+
+        CostBasedRoutingCallback(Stopwatch stopwatch, long errorCost, LongConsumer costConsumer) {
+            this.stopwatch = stopwatch;
+            this.errorCost = errorCost;
+            this.costConsumer = costConsumer;
+        }
+
+        @Override
+        public void onSuccess(@Nullable Response _result) {
+            costConsumer.accept(stopwatch.elapsed(TimeUnit.MICROSECONDS));
+        }
+
+        @Override
+        public void onFailure(Throwable _throwable) {
+            costConsumer.accept(errorCost);
+        }
+    }
+}

--- a/simulation/src/test/resources/all_nodes_500[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/all_nodes_500[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2a5b8ff623d4bbc0bb69271da809621cd9d730c9a92162785408231c5f8b23a
+size 120198

--- a/simulation/src/test/resources/all_nodes_500[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/all_nodes_500[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=73.8%	client_mean=PT2.064885S    	server_cpu=PT20M          	client_received=2000/2000	server_resps=2000	codes={200=1476, 500=524}

--- a/simulation/src/test/resources/black_hole[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/black_hole[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d138a3e49d4ed9ec6c36807fbe451ae33e7d9625d3c522df88d3cb69b5d65b9
+size 101650

--- a/simulation/src/test/resources/black_hole[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/black_hole[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=89.1%	client_mean=PT0.600106621S 	server_cpu=PT17M49.2S     	client_received=1782/2000	server_resps=1782	codes={200=1782}

--- a/simulation/src/test/resources/drastic_slowdown[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/drastic_slowdown[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14787f3525d66dd6591d69f8f739229f3529c5f8a63960cd113fd084130a6fef
+size 106861

--- a/simulation/src/test/resources/drastic_slowdown[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/drastic_slowdown[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=100.0%	client_mean=PT2.063448999S 	server_cpu=PT2H17M33.79599998S	client_received=4000/4000	server_resps=4000	codes={200=4000}

--- a/simulation/src/test/resources/fast_500s_then_revert[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/fast_500s_then_revert[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9db341df9e949244ebeef93b6d1120b339eb48447076c477919c06f46787b008
+size 147570

--- a/simulation/src/test/resources/fast_500s_then_revert[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/fast_500s_then_revert[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=97.8%	client_mean=PT0.076461955S 	server_cpu=PT4M46.732333289S	client_received=3750/3750	server_resps=3750	codes={200=3668, 500=82}

--- a/simulation/src/test/resources/live_reloading[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/live_reloading[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32a4890b086b8608164a85ab94641248dd4a70c68b8365c8a8d6e105d642875d
+size 128445

--- a/simulation/src/test/resources/live_reloading[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/live_reloading[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=76.9%	client_mean=PT4.1678384S   	server_cpu=PT1H55M46.78S  	client_received=2500/2500	server_resps=2500	codes={200=1922, 500=578}

--- a/simulation/src/test/resources/one_endpoint_dies_on_each_server[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/one_endpoint_dies_on_each_server[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfadbcf6aabbf798f433713ca5fed2bf28103d338e8916eafe1e6130b8eee15f
+size 150807

--- a/simulation/src/test/resources/one_endpoint_dies_on_each_server[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/one_endpoint_dies_on_each_server[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=86.6%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=2166, 500=334}

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -3,30 +3,39 @@
 ```
                                 all_nodes_500[CONCURRENCY_LIMITER].txt:	success=50.0%	client_mean=PT0.6S         	server_cpu=PT20M          	client_received=2000/2000	server_resps=2000	codes={200=1000, 500=1000}
                                     all_nodes_500[PIN_UNTIL_ERROR].txt:	success=50.0%	client_mean=PT0.6S         	server_cpu=PT20M          	client_received=2000/2000	server_resps=2000	codes={200=1000, 500=1000}
+                                    all_nodes_500[PREFER_CHEAPEST].txt:	success=73.8%	client_mean=PT2.064885S    	server_cpu=PT20M          	client_received=2000/2000	server_resps=2000	codes={200=1476, 500=524}
                                         all_nodes_500[ROUND_ROBIN].txt:	success=50.0%	client_mean=PT0.6S         	server_cpu=PT20M          	client_received=2000/2000	server_resps=2000	codes={200=1000, 500=1000}
                                    black_hole[CONCURRENCY_LIMITER].txt:	success=89.9%	client_mean=PT0.600086254S 	server_cpu=PT17M58.2S     	client_received=1797/2000	server_resps=1797	codes={200=1797}
                                        black_hole[PIN_UNTIL_ERROR].txt:	success=88.7%	client_mean=PT0.600191765S 	server_cpu=PT17M43.8S     	client_received=1773/2000	server_resps=1773	codes={200=1773}
+                                       black_hole[PREFER_CHEAPEST].txt:	success=89.1%	client_mean=PT0.600106621S 	server_cpu=PT17M49.2S     	client_received=1782/2000	server_resps=1782	codes={200=1782}
                                            black_hole[ROUND_ROBIN].txt:	success=65.0%	client_mean=PT0.6S         	server_cpu=PT12M59.4S     	client_received=1299/2000	server_resps=1299	codes={200=1299}
                              drastic_slowdown[CONCURRENCY_LIMITER].txt:	success=100.0%	client_mean=PT2.069939083S 	server_cpu=PT2H17M59.756333311S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                                  drastic_slowdown[PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT2.053277999S 	server_cpu=PT2H16M53.111999959S	client_received=4000/4000	server_resps=4000	codes={200=4000}
+                                 drastic_slowdown[PREFER_CHEAPEST].txt:	success=100.0%	client_mean=PT2.063448999S 	server_cpu=PT2H17M33.79599998S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                                      drastic_slowdown[ROUND_ROBIN].txt:	success=100.0%	client_mean=PT8.353421749S 	server_cpu=PT9H16M53.686999978S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                         fast_500s_then_revert[CONCURRENCY_LIMITER].txt:	success=76.7%	client_mean=PT0.055463644S 	server_cpu=PT3M27.988666346S	client_received=3750/3750	server_resps=3750	codes={200=2876, 500=874}
                             fast_500s_then_revert[PIN_UNTIL_ERROR].txt:	success=99.7%	client_mean=PT0.080628266S 	server_cpu=PT5M2.355999997S	client_received=3750/3750	server_resps=3750	codes={200=3739, 500=11}
+                            fast_500s_then_revert[PREFER_CHEAPEST].txt:	success=97.8%	client_mean=PT0.076461955S 	server_cpu=PT4M46.732333289S	client_received=3750/3750	server_resps=3750	codes={200=3668, 500=82}
                                 fast_500s_then_revert[ROUND_ROBIN].txt:	success=76.7%	client_mean=PT0.055463644S 	server_cpu=PT3M27.988666346S	client_received=3750/3750	server_resps=3750	codes={200=2876, 500=874}
                                live_reloading[CONCURRENCY_LIMITER].txt:	success=58.6%	client_mean=PT3.5376608S   	server_cpu=PT1H58M19S     	client_received=2500/2500	server_resps=2500	codes={200=1466, 500=1034}
                                    live_reloading[PIN_UNTIL_ERROR].txt:	success=58.9%	client_mean=PT3.5763136S   	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1473, 500=1027}
+                                   live_reloading[PREFER_CHEAPEST].txt:	success=76.9%	client_mean=PT4.1678384S   	server_cpu=PT1H55M46.78S  	client_received=2500/2500	server_resps=2500	codes={200=1922, 500=578}
                                        live_reloading[ROUND_ROBIN].txt:	success=58.4%	client_mean=PT2.8396S      	server_cpu=PT1H58M19S     	client_received=2500/2500	server_resps=2500	codes={200=1461, 500=1039}
              one_endpoint_dies_on_each_server[CONCURRENCY_LIMITER].txt:	success=65.5%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1638, 500=862}
                  one_endpoint_dies_on_each_server[PIN_UNTIL_ERROR].txt:	success=63.8%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1596, 500=904}
+                 one_endpoint_dies_on_each_server[PREFER_CHEAPEST].txt:	success=86.6%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=2166, 500=334}
                      one_endpoint_dies_on_each_server[ROUND_ROBIN].txt:	success=65.5%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1638, 500=862}
                        simplest_possible_case[CONCURRENCY_LIMITER].txt:	success=100.0%	client_mean=PT0.799939393S 	server_cpu=PT2H55M59.2S   	client_received=13200/13200	server_resps=13200	codes={200=13200}
                            simplest_possible_case[PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.998696969S 	server_cpu=PT3H39M42.8S   	client_received=13200/13200	server_resps=13200	codes={200=13200}
+                           simplest_possible_case[PREFER_CHEAPEST].txt:	success=100.0%	client_mean=PT0.655878787S 	server_cpu=PT2H24M17.6S   	client_received=13200/13200	server_resps=13200	codes={200=13200}
                                simplest_possible_case[ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.799939393S 	server_cpu=PT2H55M59.2S   	client_received=13200/13200	server_resps=13200	codes={200=13200}
                         slow_503s_then_revert[CONCURRENCY_LIMITER].txt:	success=100.0%	client_mean=PT0.736112444S 	server_cpu=PT36M48.33733331S	client_received=3000/3000	server_resps=3416	codes={200=3000}
                             slow_503s_then_revert[PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.337337888S 	server_cpu=PT16M52.013666631S	client_received=3000/3000	server_resps=3197	codes={200=3000}
+                            slow_503s_then_revert[PREFER_CHEAPEST].txt:	success=100.0%	client_mean=PT0.442828888S 	server_cpu=PT22M8.486666639S	client_received=3000/3000	server_resps=3258	codes={200=3000}
                                 slow_503s_then_revert[ROUND_ROBIN].txt:	success=100.0%	client_mean=PT1.410522888S 	server_cpu=PT1H10M31.568666642S	client_received=3000/3000	server_resps=3810	codes={200=3000}
                 slowdown_and_error_thresholds[CONCURRENCY_LIMITER].txt:	success=1.2%	client_mean=PT16.859225466S	server_cpu=PT10H30M49.207333306S	client_received=10000/10000	server_resps=10000	codes={200=120, 500=9880}
                     slowdown_and_error_thresholds[PIN_UNTIL_ERROR].txt:	success=1.8%	client_mean=PT20.068609533S	server_cpu=PT10H35M7.200666646S	client_received=10000/10000	server_resps=10000	codes={200=176, 500=9824}
+                    slowdown_and_error_thresholds[PREFER_CHEAPEST].txt:	success=26.0%	client_mean=PT1M37.587816533S	server_cpu=PT10H8M58.773333204S	client_received=10000/10000	server_resps=10000	codes={200=2597, 500=7403}
                         slowdown_and_error_thresholds[ROUND_ROBIN].txt:	success=1.2%	client_mean=PT3.974119999S 	server_cpu=PT11H2M21.19999998S	client_received=10000/10000	server_resps=10000	codes={200=120, 500=9880}
 ```
 
@@ -40,6 +49,11 @@
 ## all_nodes_500[PIN_UNTIL_ERROR].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/all_nodes_500[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="all_nodes_500[PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## all_nodes_500[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/all_nodes_500[PREFER_CHEAPEST].png" /></td><td><image width=400 src="all_nodes_500[PREFER_CHEAPEST].png" /></td></tr></table>
 
 
 ## all_nodes_500[ROUND_ROBIN].png
@@ -57,6 +71,11 @@
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/black_hole[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="black_hole[PIN_UNTIL_ERROR].png" /></td></tr></table>
 
 
+## black_hole[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/black_hole[PREFER_CHEAPEST].png" /></td><td><image width=400 src="black_hole[PREFER_CHEAPEST].png" /></td></tr></table>
+
+
 ## black_hole[ROUND_ROBIN].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/black_hole[ROUND_ROBIN].png" /></td><td><image width=400 src="black_hole[ROUND_ROBIN].png" /></td></tr></table>
@@ -70,6 +89,11 @@
 ## drastic_slowdown[PIN_UNTIL_ERROR].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/drastic_slowdown[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="drastic_slowdown[PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## drastic_slowdown[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/drastic_slowdown[PREFER_CHEAPEST].png" /></td><td><image width=400 src="drastic_slowdown[PREFER_CHEAPEST].png" /></td></tr></table>
 
 
 ## drastic_slowdown[ROUND_ROBIN].png
@@ -87,6 +111,11 @@
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/fast_500s_then_revert[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="fast_500s_then_revert[PIN_UNTIL_ERROR].png" /></td></tr></table>
 
 
+## fast_500s_then_revert[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/fast_500s_then_revert[PREFER_CHEAPEST].png" /></td><td><image width=400 src="fast_500s_then_revert[PREFER_CHEAPEST].png" /></td></tr></table>
+
+
 ## fast_500s_then_revert[ROUND_ROBIN].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/fast_500s_then_revert[ROUND_ROBIN].png" /></td><td><image width=400 src="fast_500s_then_revert[ROUND_ROBIN].png" /></td></tr></table>
@@ -100,6 +129,11 @@
 ## live_reloading[PIN_UNTIL_ERROR].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/live_reloading[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="live_reloading[PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## live_reloading[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/live_reloading[PREFER_CHEAPEST].png" /></td><td><image width=400 src="live_reloading[PREFER_CHEAPEST].png" /></td></tr></table>
 
 
 ## live_reloading[ROUND_ROBIN].png
@@ -117,6 +151,11 @@
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/one_endpoint_dies_on_each_server[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="one_endpoint_dies_on_each_server[PIN_UNTIL_ERROR].png" /></td></tr></table>
 
 
+## one_endpoint_dies_on_each_server[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/one_endpoint_dies_on_each_server[PREFER_CHEAPEST].png" /></td><td><image width=400 src="one_endpoint_dies_on_each_server[PREFER_CHEAPEST].png" /></td></tr></table>
+
+
 ## one_endpoint_dies_on_each_server[ROUND_ROBIN].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/one_endpoint_dies_on_each_server[ROUND_ROBIN].png" /></td><td><image width=400 src="one_endpoint_dies_on_each_server[ROUND_ROBIN].png" /></td></tr></table>
@@ -130,6 +169,11 @@
 ## simplest_possible_case[PIN_UNTIL_ERROR].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/simplest_possible_case[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="simplest_possible_case[PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## simplest_possible_case[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/simplest_possible_case[PREFER_CHEAPEST].png" /></td><td><image width=400 src="simplest_possible_case[PREFER_CHEAPEST].png" /></td></tr></table>
 
 
 ## simplest_possible_case[ROUND_ROBIN].png
@@ -147,6 +191,11 @@
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/slow_503s_then_revert[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="slow_503s_then_revert[PIN_UNTIL_ERROR].png" /></td></tr></table>
 
 
+## slow_503s_then_revert[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/slow_503s_then_revert[PREFER_CHEAPEST].png" /></td><td><image width=400 src="slow_503s_then_revert[PREFER_CHEAPEST].png" /></td></tr></table>
+
+
 ## slow_503s_then_revert[ROUND_ROBIN].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/slow_503s_then_revert[ROUND_ROBIN].png" /></td><td><image width=400 src="slow_503s_then_revert[ROUND_ROBIN].png" /></td></tr></table>
@@ -160,6 +209,11 @@
 ## slowdown_and_error_thresholds[PIN_UNTIL_ERROR].png
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/slowdown_and_error_thresholds[PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="slowdown_and_error_thresholds[PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## slowdown_and_error_thresholds[PREFER_CHEAPEST].png
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/slowdown_and_error_thresholds[PREFER_CHEAPEST].png" /></td><td><image width=400 src="slowdown_and_error_thresholds[PREFER_CHEAPEST].png" /></td></tr></table>
 
 
 ## slowdown_and_error_thresholds[ROUND_ROBIN].png

--- a/simulation/src/test/resources/simplest_possible_case[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/simplest_possible_case[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aac6c2c676a64ccf4a00b06991073b27fd18cc32256be2e9b45191e41277644
+size 159722

--- a/simulation/src/test/resources/simplest_possible_case[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/simplest_possible_case[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=100.0%	client_mean=PT0.655878787S 	server_cpu=PT2H24M17.6S   	client_received=13200/13200	server_resps=13200	codes={200=13200}

--- a/simulation/src/test/resources/slow_503s_then_revert[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/slow_503s_then_revert[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:694960db5b34cb6845dd9294b8acd250af0d87e632ffebb7b4c3fa6c4e360542
+size 106109

--- a/simulation/src/test/resources/slow_503s_then_revert[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/slow_503s_then_revert[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=100.0%	client_mean=PT0.442828888S 	server_cpu=PT22M8.486666639S	client_received=3000/3000	server_resps=3258	codes={200=3000}

--- a/simulation/src/test/resources/slowdown_and_error_thresholds[PREFER_CHEAPEST].png
+++ b/simulation/src/test/resources/slowdown_and_error_thresholds[PREFER_CHEAPEST].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80a254d83db8a6fbaec4192f909f500d70450606e270229edb9398285e49db8d
+size 167126

--- a/simulation/src/test/resources/slowdown_and_error_thresholds[PREFER_CHEAPEST].txt
+++ b/simulation/src/test/resources/slowdown_and_error_thresholds[PREFER_CHEAPEST].txt
@@ -1,0 +1,1 @@
+success=26.0%	client_mean=PT1M37.587816533S	server_cpu=PT10H8M58.773333204S	client_received=10000/10000	server_resps=10000	codes={200=2597, 500=7403}


### PR DESCRIPTION
## Before this PR
Full disclaimer this was largely insipired by @iamdanfox awesome work and @markelliot's ideas. I thought it would be interesting to quickly whip up a cost based approach for routing where we attempt to make requests to channels that historically have been the cheapest. In this case we attribute cost for successful requests as the microseconds spent executing the request and for failures as the median cost of all known channels (very much a WIP of a heuristic).

As expected this heuristic doesn't behave incredibly well in some of the simulator cases since servers have constant response times. I expect that real world variance will lead to very interesting emergent behavior especially during upgrade windows.