### PR TITLE
client tolerates unexpected body

### DIFF
--- a/changelog/@unreleased/pr-388.v2.yml
+++ b/changelog/@unreleased/pr-388.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clients are tolerant of unexpected response body
+  links:
+  - https://github.com/palantir/dialogue/pull/388

--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractSampleServiceClientTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractSampleServiceClientTest.java
@@ -142,6 +142,18 @@ public abstract class AbstractSampleServiceClientTest {
     }
 
     @Test
+    public void testBlocking_voidToVoid_doesNotThrowsWhenResponseBodyIsNonEmpty() {
+        server.enqueue(new MockResponse().setBody("Unexpected response"));
+        blockingClient.voidToVoid();
+    }
+
+    @Test
+    public void testAsync_voidToVoid_doesNotThrowWhenResponseBodyIsNonEmpty() throws Exception {
+        server.enqueue(new MockResponse().setBody("Unexpected response"));
+        assertThat(asyncClient.voidToVoid().get()).isNull();
+    }
+
+    @Test
     public void testAsync_stringToString_throwsWhenResponseBodyIsEmpty() {
         server.enqueue(new MockResponse().addHeader(Headers.CONTENT_TYPE, "application/json"));
         assertThatThrownBy(() ->
@@ -169,20 +181,6 @@ public abstract class AbstractSampleServiceClientTest {
     public void testAsync_voidToVoid_expectedCase() throws Exception {
         server.enqueue(new MockResponse());
         assertThat(asyncClient.voidToVoid().get()).isNull();
-    }
-
-    @Test
-    public void testBlocking_voidToVoid_throwsWhenResponseBodyIsNonEmpty() {
-        server.enqueue(new MockResponse().setBody("Unexpected response"));
-        assertThatThrownBy(() -> blockingClient.voidToVoid())
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("Expected empty response body");
-    }
-
-    @Test
-    public void testAsync_voidToVoid_throwsWhenResponseBodyIsNonEmpty() {
-        server.enqueue(new MockResponse().setBody("Unexpected response"));
-        assertThatThrownBy(() -> asyncClient.voidToVoid().get()).hasMessageContaining("Expected empty response body");
     }
 
     @Test(timeout = 2_000)

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -78,6 +78,7 @@ final class ConjureBodySerDe implements BodySerDe {
     @Override
     public Deserializer<Void> emptyBodyDeserializer() {
         return input -> {
+            // We should not fail if a server that previously return nothing starts returning a response
             input.close();
             return null;
         };

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -78,13 +78,7 @@ final class ConjureBodySerDe implements BodySerDe {
     @Override
     public Deserializer<Void> emptyBodyDeserializer() {
         return input -> {
-            try (Response response = input) {
-                if (response.body().read() != -1) {
-                    throw new SafeRuntimeException("Expected empty response body");
-                }
-            } catch (IOException e) {
-                throw new SafeRuntimeException("Failed to read from response body", e);
-            }
+            input.close();
             return null;
         };
     }


### PR DESCRIPTION
## Before this PR
If a client received a response but was not expecting one it would throw

## After this PR
==COMMIT_MSG==
Clients are tolerant of unexpected response body
==COMMIT_MSG==

## Possible downsides?
N/A
