### PR TITLE
fix #392: QueuedChannel no longer leaks responses on cancel

### DIFF
--- a/changelog/@unreleased/pr-393.v2.yml
+++ b/changelog/@unreleased/pr-393.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: QueuedChannel no longer leaks responses on cancel
+  links:
+  - https://github.com/palantir/dialogue/pull/393

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -165,13 +165,17 @@ final class QueuedChannel implements Channel {
 
         @Override
         public void onSuccess(Response result) {
-            response.set(result);
+            if (!response.set(result)) {
+                result.close();
+            }
             schedule();
         }
 
         @Override
         public void onFailure(Throwable throwable) {
-            response.setException(throwable);
+            if (!response.setException(throwable)) {
+                log.info("Call failed after the future completed", throwable);
+            }
             schedule();
         }
     }


### PR DESCRIPTION
==COMMIT_MSG==
QueuedChannel no longer leaks responses on cancel
==COMMIT_MSG==

Still a lot of bugs here...