### PR TITLE
fix #386: Limit connections-per-host using a LimitedChannel

### DIFF
--- a/changelog/@unreleased/pr-395.v2.yml
+++ b/changelog/@unreleased/pr-395.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Limit connections-per-host using a LimitedChannel
+  links:
+  - https://github.com/palantir/dialogue/pull/395

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -83,7 +83,7 @@ public final class ApacheHttpClientChannels {
                 .setDefaultSocketConfig(
                         SocketConfig.custom().setSoKeepAlive(true).build())
                 .evictIdleConnections(55, TimeUnit.SECONDS)
-                .setMaxConnPerRoute(1000)
+                .setMaxConnPerRoute(Integer.MAX_VALUE)
                 .setMaxConnTotal(Integer.MAX_VALUE)
                 // TODO(ckozak): proxy credentials
                 .setRoutePlanner(new SystemDefaultRoutePlanner(null, conf.proxy()))

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -27,11 +27,10 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class Channels {
-    private static final Logger log = LoggerFactory.getLogger(Channels.class);
+
+    private static final int MAX_REQUESTS_PER_CHANNEL = 256;
 
     private Channels() {}
 
@@ -49,6 +48,7 @@ public final class Channels {
                 .map(channel -> new TracedChannel(channel, "Dialogue-http-request"))
                 .map(ContentDecodingChannel::new)
                 .map(concurrencyLimiter(config))
+                .map(channel -> new FixedLimitedChannel(channel, MAX_REQUESTS_PER_CHANNEL))
                 .collect(ImmutableList.toImmutableList());
 
         LimitedChannel limited = nodeSelectionStrategy(config, limitedChannels);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
@@ -42,7 +42,7 @@ final class FixedLimitedChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
-        // Doesn't check for integer underflow, we don't have enough threads for that to be possible
+        // Doesn't check for integer overflow, we don't have enough threads for that to occur.
         if (availablePermits.decrementAndGet() < 0) {
             availablePermits.incrementAndGet();
             if (log.isDebugEnabled()) {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.logsafe.SafeArg;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Channel with a fixed number of available permits. This can be used to enforce a per-route request limit.
+ */
+final class FixedLimitedChannel implements LimitedChannel {
+    private static final Logger log = LoggerFactory.getLogger(FixedLimitedChannel.class);
+
+    private final LimitedChannel delegate;
+    private final AtomicInteger availablePermits;
+
+    FixedLimitedChannel(LimitedChannel delegate, int permits) {
+        this.delegate = delegate;
+        this.availablePermits = new AtomicInteger(permits);
+    }
+
+    @Override
+    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
+        // Doesn't check for integer underflow, we don't have enough threads for that to be possible
+        if (availablePermits.decrementAndGet() < 0) {
+            availablePermits.incrementAndGet();
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Permits have been exhausted",
+                        SafeArg.of("service", endpoint.serviceName()),
+                        SafeArg.of("endpoint", endpoint.endpointName()));
+            }
+            return Optional.empty();
+        }
+        boolean resetPermit = true;
+        try {
+            Optional<ListenableFuture<Response>> result = delegate.maybeExecute(endpoint, request);
+            if (result.isPresent()) {
+                result.get().addListener(availablePermits::incrementAndGet, MoreExecutors.directExecutor());
+                resetPermit = false;
+            }
+            return result;
+        } finally {
+            if (resetPermit) {
+                availablePermits.incrementAndGet();
+            }
+        }
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/FixedLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/FixedLimitedChannelTest.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class FixedLimitedChannelTest {
+
+    @Test
+    public void testExhaustion() {
+        SettableFuture<Response> result = SettableFuture.create();
+        LimitedChannel delegate = Mockito.mock(LimitedChannel.class);
+        when(delegate.maybeExecute(any(), any())).thenReturn(Optional.of(result));
+        LimitedChannel channel = new FixedLimitedChannel(delegate, 1);
+        // consume the single permit
+        assertThat(channel.maybeExecute(Mockito.mock(Endpoint.class), Mockito.mock(Request.class)))
+                .isPresent();
+        // no permits available
+        assertThat(channel.maybeExecute(Mockito.mock(Endpoint.class), Mockito.mock(Request.class)))
+                .isEmpty();
+        // after completing the future more requests can be sent
+        result.cancel(false);
+        assertThat(channel.maybeExecute(Mockito.mock(Endpoint.class), Mockito.mock(Request.class)))
+                .isPresent();
+    }
+}

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannels.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannels.java
@@ -77,10 +77,9 @@ public final class OkHttpChannels {
 
     static {
         dispatcher = new Dispatcher(executionExecutor);
-        // Restricting concurrency is done elsewhere in ConcurrencyLimiters.
+        // Restricting concurrency is done elsewhere in ConcurrencyLimiters and FixedLimitedChannel.
         dispatcher.setMaxRequests(Integer.MAX_VALUE);
-        // Must be less than maxRequests so a single slow host does not block all requests
-        dispatcher.setMaxRequestsPerHost(256);
+        dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
     }
 
     /** Shared connection pool. */


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Limit connections-per-host using a LimitedChannel
==COMMIT_MSG==

## Possible downsides?
Unlike the remoting-okhttp implementation there's no static global state, so two unique channels created for the same target will each get 256 requests.