### PR TITLE
Clean up channel chain ergonomics

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAdapter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAdapter.java
@@ -24,11 +24,11 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 
 /** Adapter from {@link Channel} to {@link LimitedChannel} which always returns a {@link Optional#isPresent() value}. */
-final class UnlimitedChannel implements LimitedChannel {
+final class LimitedChannelAdapter implements LimitedChannel {
 
     private final Channel delegate;
 
-    UnlimitedChannel(Channel delegate) {
+    LimitedChannelAdapter(Channel delegate) {
         this.delegate = Preconditions.checkNotNull(delegate, "Channel");
     }
 
@@ -39,6 +39,6 @@ final class UnlimitedChannel implements LimitedChannel {
 
     @Override
     public String toString() {
-        return "UnlimitedChannel{delegate=" + delegate + '}';
+        return "LimitedChannelAdapter{delegate=" + delegate + '}';
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -62,7 +62,7 @@ public class ConcurrencyLimitedChannelTest {
 
     @BeforeEach
     public void before() {
-        channel = new ConcurrencyLimitedChannel(delegate, () -> limiter);
+        channel = new ConcurrencyLimitedChannel(new LimitedChannelAdapter(delegate), () -> limiter);
 
         responseFuture = SettableFuture.create();
         lenient().when(delegate.execute(endpoint, request)).thenReturn(responseFuture);
@@ -105,7 +105,7 @@ public class ConcurrencyLimitedChannelTest {
 
     @Test
     public void testWithDefaultLimiter() {
-        channel = ConcurrencyLimitedChannel.create(delegate);
+        channel = ConcurrencyLimitedChannel.create(new LimitedChannelAdapter(delegate));
 
         assertThat(channel.maybeExecute(endpoint, request)).contains(responseFuture);
     }

--- a/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
@@ -102,8 +102,8 @@ public enum Strategy {
     }
 
     private static Function<Channel, LimitedChannel> addConcurrencyLimiter(Simulation sim) {
-        return channel ->
-                new ConcurrencyLimitedChannel(channel, () -> ConcurrencyLimitedChannel.createLimiter(sim.clock()));
+        return channel -> new ConcurrencyLimitedChannel(
+                new LimitedChannelAdapter(channel), () -> ConcurrencyLimitedChannel.createLimiter(sim.clock()));
     }
 
     private static Function<LimitedChannel, LimitedChannel> addFixedLimiter() {


### PR DESCRIPTION
ConcurrencyLimitedChannel is no longer a bridge between limited channels and standard channels, allowing us to more easily optimize order moving forward.
Shuffles channel order to avoid re-evaluating higher level functionality for each retry.
Fixes a potential leak in concurrency limited channel if the
next channel in the chain happens to throw.
