### PR TITLE
Centralize status code checks in a utility class

### DIFF
--- a/changelog/@unreleased/pr-402.v2.yml
+++ b/changelog/@unreleased/pr-402.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Centralize status code checks in a utility class
+  links:
+  - https://github.com/palantir/dialogue/pull/402

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BlacklistingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BlacklistingChannel.java
@@ -119,7 +119,7 @@ final class BlacklistingChannel implements LimitedChannel {
         @Override
         public void onSuccess(Response response) {
             // TODO(jellis): use the Retry-After header (if present) to determine how long to blacklist the channel
-            if (response.code() == 503 || response.code() == 500) {
+            if (Responses.isQosStatus(response) || Responses.isServerError(response)) {
                 log.debug(
                         "Blacklisting {} due to status code {}",
                         UnsafeArg.of("delegate", delegate),

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -20,7 +20,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.netflix.concurrency.limits.Limiter;
@@ -92,7 +91,6 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
      * Signals back to the {@link Limiter} whether or not the request was successfully handled.
      */
     private static final class LimiterCallback implements FutureCallback<Response> {
-        private static final ImmutableSet<Integer> DROP_CODES = ImmutableSet.of(429);
 
         private final Limiter.Listener listener;
 
@@ -102,7 +100,7 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
 
         @Override
         public void onSuccess(Response result) {
-            if (DROP_CODES.contains(result.code())) {
+            if (Responses.isTooManyRequests(result)) {
                 listener.onDropped();
             } else {
                 listener.onSuccess();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
@@ -101,7 +101,7 @@ final class PinUntilErrorChannel implements LimitedChannel {
         return Optional.of(DialogueFutures.addDirectCallback(future, new FutureCallback<Response>() {
             @Override
             public void onSuccess(Response response) {
-                if (response.code() >= 300) {
+                if (Responses.isQosStatus(response) || Responses.isServerError(response)) {
                     OptionalInt next = incrementHostIfNecessary(currentIndex);
                     debugLogReceivedErrorStatus(currentIndex, channel, response, next);
                     // TODO(dfox): handle 308 See Other somehow, as we currently don't have a host -> channel mapping

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.dialogue.core;
+
+import com.palantir.dialogue.Response;
+
+/** Utility functionality for {@link Response} handling. */
+final class Responses {
+
+    private static final int TOO_MANY_REQUESTS_429 = 429;
+    private static final int UNAVAILABLE_503 = 503;
+
+    static boolean isTooManyRequests(Response response) {
+        return response.code() == TOO_MANY_REQUESTS_429;
+    }
+
+    static boolean isUnavailable(Response response) {
+        return response.code() == UNAVAILABLE_503;
+    }
+
+    static boolean isQosStatus(Response response) {
+        return isTooManyRequests(response) || isUnavailable(response);
+    }
+
+    static boolean isServerError(Response response) {
+        return response.code() / 100 == 5;
+    }
+
+    private Responses() {}
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -37,9 +37,6 @@ final class RetryingChannel implements Channel {
 
     private static final Logger log = LoggerFactory.getLogger(RetryingChannel.class);
 
-    private static final int UNAVAILABLE_503 = 503;
-    private static final int TOO_MANY_REQUESTS_429 = 429;
-
     private final Channel delegate;
     private final int maxRetries;
     private final ClientConfiguration.ServerQoS serverQoS;
@@ -83,7 +80,7 @@ final class RetryingChannel implements Channel {
         ListenableFuture<Response> success(Response response) {
             // this condition should really match the BlacklistingChannel so that we don't hit the same host twice in
             // a row
-            if (response.code() == UNAVAILABLE_503 || response.code() == TOO_MANY_REQUESTS_429) {
+            if (Responses.isQosStatus(response)) {
                 response.close();
                 Throwable failure =
                         new SafeRuntimeException("Received retryable response", SafeArg.of("status", response.code()));

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
@@ -77,21 +77,26 @@ public class PinUntilErrorChannelTest {
 
     @Test
     public void various_error_status_codes_cause_node_switch() {
-        for (int errorStatus = 300; errorStatus < 600; errorStatus++) {
-            before();
-            setResponse(channel1, 100);
-            setResponse(channel2, 204);
-
-            assertThat(IntStream.range(0, 6).map(number -> getCode(pinUntilErrorWithoutReshuffle)))
-                    .describedAs("Should be locked on to channel2 initially")
-                    .contains(204, 204, 204, 204, 204, 204);
-
-            setResponse(channel2, errorStatus);
-
-            assertThat(IntStream.range(0, 6).map(number -> getCode(pinUntilErrorWithoutReshuffle)))
-                    .describedAs("A single error code should switch us to channel 1")
-                    .contains(errorStatus, 100, 100, 100, 100, 100);
+        testStatusCausesNodeSwitch(429);
+        for (int errorStatus = 500; errorStatus < 600; errorStatus++) {
+            testStatusCausesNodeSwitch(errorStatus);
         }
+    }
+
+    private void testStatusCausesNodeSwitch(int errorStatus) {
+        before();
+        setResponse(channel1, 100);
+        setResponse(channel2, 204);
+
+        assertThat(IntStream.range(0, 6).map(number -> getCode(pinUntilErrorWithoutReshuffle)))
+                .describedAs("Should be locked on to channel2 initially")
+                .contains(204, 204, 204, 204, 204, 204);
+
+        setResponse(channel2, errorStatus);
+
+        assertThat(IntStream.range(0, 6).map(number -> getCode(pinUntilErrorWithoutReshuffle)))
+                .describedAs("A single error code should switch us to channel 1")
+                .contains(errorStatus, 100, 100, 100, 100, 100);
     }
 
     @Test


### PR DESCRIPTION
Functional changes:
* ConcurrencyLimitedChannel uses both 503 and 429 (was only 429)
* Blacklisting channel reacts to 429 and all 5xx response codes
  (was 503 and 500)
* PinUntilErrorChannel rotates on 429 and all 500 response codes.
  (was everything >= 300)

## After this PR
==COMMIT_MSG==
Centralize status code checks in a utility class
==COMMIT_MSG==
