### PR TITLE
Record metrics any time a channel limits an outgoing request

### DIFF
--- a/changelog/@unreleased/pr-409.v2.yml
+++ b/changelog/@unreleased/pr-409.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Record metrics any time a channel limits an outgoing request
+  links:
+  - https://github.com/palantir/dialogue/pull/409

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -53,7 +53,7 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
     ConcurrencyLimitedChannel(
             LimitedChannel delegate, Supplier<Limiter<Void>> limiterSupplier, DialogueClientMetrics metrics) {
         this.delegate = new NeverThrowLimitedChannel(delegate);
-        this.limitedMeter = metrics.limited("ConcurrencyLimitedChannel");
+        this.limitedMeter = metrics.limited(getClass().getSimpleName());
         this.limiters =
                 Caffeine.newBuilder().expireAfterAccess(Duration.ofMinutes(5)).build(key -> limiterSupplier.get());
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
@@ -43,7 +43,7 @@ final class FixedLimitedChannel implements LimitedChannel {
     FixedLimitedChannel(LimitedChannel delegate, int totalPermits, DialogueClientMetrics metrics) {
         this.delegate = delegate;
         this.totalPermits = totalPermits;
-        this.limitedMeter = metrics.limited("FixedLimitedChannel");
+        this.limitedMeter = metrics.limited(getClass().getSimpleName());
         // Doesn't check for integer overflow, we don't have enough threads for that to occur.
         Preconditions.checkArgument(totalPermits <= 1_000_000, "total permits must not exceed one million");
         this.returnPermit = usedPermits::decrementAndGet;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/FixedLimitedChannel.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.dialogue.core;
 
+import com.codahale.metrics.Meter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.dialogue.Endpoint;
@@ -35,12 +36,14 @@ final class FixedLimitedChannel implements LimitedChannel {
 
     private final LimitedChannel delegate;
     private final AtomicInteger usedPermits = new AtomicInteger(0);
+    private final Meter limitedMeter;
     private final int totalPermits;
     private final Runnable returnPermit;
 
-    FixedLimitedChannel(LimitedChannel delegate, int totalPermits) {
+    FixedLimitedChannel(LimitedChannel delegate, int totalPermits, DialogueClientMetrics metrics) {
         this.delegate = delegate;
         this.totalPermits = totalPermits;
+        this.limitedMeter = metrics.limited("FixedLimitedChannel");
         // Doesn't check for integer overflow, we don't have enough threads for that to occur.
         Preconditions.checkArgument(totalPermits <= 1_000_000, "total permits must not exceed one million");
         this.returnPermit = usedPermits::decrementAndGet;
@@ -51,6 +54,7 @@ final class FixedLimitedChannel implements LimitedChannel {
         boolean optimisticallyAcquiredPermit = usedPermits.incrementAndGet() > totalPermits;
         if (optimisticallyAcquiredPermit) {
             returnPermit.run();
+            limitedMeter.mark();
             logExhaustion(endpoint);
             return Optional.empty();
         }

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -23,3 +23,7 @@ namespaces:
         type: meter
         tags: [service-name]
         docs: Rate of deprecated endpoints being invoked.
+      limited:
+        type: meter
+        tags: [reason]
+        docs: Rate of client-side request rejection.

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -26,4 +26,4 @@ namespaces:
       limited:
         type: meter
         tags: [reason]
-        docs: Rate of client-side request rejection.
+        docs: Rate that client-side requests are deferred to be retried later.

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -29,6 +29,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class ConcurrencyLimitedChannelTest {
+
+    private final DialogueClientMetrics metrics = DialogueClientMetrics.of(new DefaultTaggedMetricRegistry());
 
     @Mock
     private Endpoint endpoint;
@@ -62,7 +65,7 @@ public class ConcurrencyLimitedChannelTest {
 
     @BeforeEach
     public void before() {
-        channel = new ConcurrencyLimitedChannel(new LimitedChannelAdapter(delegate), () -> limiter);
+        channel = new ConcurrencyLimitedChannel(new LimitedChannelAdapter(delegate), () -> limiter, metrics);
 
         responseFuture = SettableFuture.create();
         lenient().when(delegate.execute(endpoint, request)).thenReturn(responseFuture);
@@ -105,7 +108,7 @@ public class ConcurrencyLimitedChannelTest {
 
     @Test
     public void testWithDefaultLimiter() {
-        channel = ConcurrencyLimitedChannel.create(new LimitedChannelAdapter(delegate));
+        channel = ConcurrencyLimitedChannel.create(new LimitedChannelAdapter(delegate), metrics);
 
         assertThat(channel.maybeExecute(endpoint, request)).contains(responseFuture);
     }


### PR DESCRIPTION
## Before this PR
Difficult to tell which LimitedChannel resulted in a delayed request.

## After this PR
==COMMIT_MSG==
Record metrics any time a channel limits an outgoing request
==COMMIT_MSG==

## Possible downsides?
This only adds support for ConcurrencyLimitedChannel and
FixedLimitChannel to avoid conflicts with work that's currently
in progress.
