### PR TITLE
fix #411: RemoteExceptions.getUnchecked cancels futures on interruption

### DIFF
--- a/changelog/@unreleased/pr-412.v2.yml
+++ b/changelog/@unreleased/pr-412.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: RemoteExceptions.getUnchecked cancels futures on interruption
+  links:
+  - https://github.com/palantir/dialogue/pull/412

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -37,7 +38,8 @@ public final class RemoteExceptions {
             return future.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
+            future.cancel(true);
+            throw new SafeRuntimeException("Interrupted waiting for future", e);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             String message = cause.getMessage();


### PR DESCRIPTION
## Before this PR
dangling futures.

## After this PR
==COMMIT_MSG==
RemoteExceptions.getUnchecked cancels futures on interruption
==COMMIT_MSG==

## Possible downsides?
RemoteExceptions.getUnchecked doesn't make a lot of sense for this utility. Perhaps `DialogueFutures` or `DialogueBlocking`?