### PR TITLE
ApacheHttpClientChannels no longer complains about `Unsupported ciphersuite`

### DIFF
--- a/changelog/@unreleased/pr-415.v2.yml
+++ b/changelog/@unreleased/pr-415.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: ApacheHttpClientChannels no longer complains about `Unsupported ciphersuite`
+  links:
+  - https://github.com/palantir/dialogue/pull/415

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -153,13 +153,17 @@ public final class ApacheHttpClientChannels {
             }
         }
 
-        log.info(
-                "Skipping unsupported cipher suites",
-                SafeArg.of("numEnabled", enabled.size()),
-                SafeArg.of("numUnsupported", unsupported.size()),
-                SafeArg.of("cipher", unsupported),
-                SafeArg.of("javaVendor", System.getProperty("java.vendor")),
-                SafeArg.of("javaVersion", System.getProperty("java.version")));
+        if (!unsupported.isEmpty()) {
+            log.info(
+                    "Skipping unsupported cipher suites",
+                    SafeArg.of("numEnabled", enabled.size()),
+                    SafeArg.of("numUnsupported", unsupported.size()),
+                    SafeArg.of("cipher", unsupported),
+                    SafeArg.of("javaVendor", System.getProperty("java.vendor")),
+                    SafeArg.of("javaVersion", System.getProperty("java.version")));
+        }
+
+        Preconditions.checkState(!enabled.isEmpty(), "Zero supported cipher suites");
         return enabled.toArray(new String[0]);
     }
 


### PR DESCRIPTION
## Before this PR

In my witchcraft PR, I'm unable to make calls using ApacheHttpClientChannels due to:

```
Caused by: java.lang.IllegalArgumentException: Unsupported ciphersuite TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
	at sun.security.ssl.CipherSuite.valueOf(CipherSuite.java:228)
	at sun.security.ssl.CipherSuiteList.<init>(CipherSuiteList.java:79)
	at sun.security.ssl.SSLSocketImpl.setEnabledCipherSuites(SSLSocketImpl.java:2491)
	at org.apache.http.conn.ssl.SSLConnectionSocketFactory.createLayeredSocket(SSLConnectionSocketFactory.java:414)
	at org.apache.http.conn.ssl.SSLConnectionSocketFactory.connectSocket(SSLConnectionSocketFactory.java:384)
	at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:142)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)
	at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
	at com.palantir.dialogue.hc4.ApacheHttpClientBlockingChannel.execute(ApacheHttpClientBlockingChannel.java:76)
	at com.palantir.dialogue.blocking.BlockingChannelAdapter$BlockingChannelAdapterChannel$BlockingChannelAdapterTask.call(BlockingChannelAdapter.java:90)
	at com.palantir.dialogue.blocking.BlockingChannelAdapter$BlockingChannelAdapterChannel$BlockingChannelAdapterTask.call(BlockingChannelAdapter.java:76)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at com.palantir.tracing.Tracers$TracingAwareRunnable.run(Tracers.java:501)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
```

## After this PR
==COMMIT_MSG==
ApacheHttpClientChannels no longer complains about `Unsupported ciphersuite`
==COMMIT_MSG==

- not really sure why the tests in this repo didn't trip this...

## Possible downsides?
