### PR TITLE
NullAway

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.png filter=lfs diff=lfs merge=lfs -text
+versions.props merge=union
+versions.lock merge=union

--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,16 @@ subprojects {
     tasks.withType(JavaCompile) {
         options.compilerArgs += ['-Werror']
     }
+
+    plugins.withId('com.palantir.baseline-error-prone', {
+        dependencies {
+            errorprone 'com.uber.nullaway:nullaway'
+        }
+
+        tasks.withType(JavaCompile).configureEach {
+            options.errorprone.errorproneArgs += [
+                !name.toLowerCase().contains("test") ? '-XepOpt:NullAway:AnnotatedPackages=com.palantir' : '-Xep:NullAway:OFF'
+            ]
+        }
+    })
 }

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -76,6 +77,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private static final class HttpClientResponse implements Response {
 
         private final CloseableHttpResponse response;
+        @Nullable
         private Map<String, List<String>> headers;
 
         HttpClientResponse(CloseableHttpResponse response) {
@@ -167,6 +169,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
         }
 
         @Override
+        @Nullable
         public Header getContentEncoding() {
             return null;
         }

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
@@ -77,6 +77,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private static final class HttpClientResponse implements Response {
 
         private final CloseableHttpResponse response;
+
         @Nullable
         private Map<String, List<String>> headers;
 

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import org.apache.http.Header;
@@ -191,6 +192,7 @@ public final class ApacheHttpClientChannels {
         public void setCredentials(AuthScope _authscope, Credentials _credentials) {}
 
         @Override
+        @Nullable
         public Credentials getCredentials(AuthScope _authscope) {
             return null;
         }

--- a/dialogue-client-test-lib/build.gradle
+++ b/dialogue-client-test-lib/build.gradle
@@ -10,3 +10,7 @@ dependencies {
     compile 'org.assertj:assertj-core'
     compile 'org.mockito:mockito-core'
 }
+
+tasks.withType(JavaCompile) {
+    options.errorprone.errorproneArgs += '-Xep:NullAway:OFF'
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -27,6 +27,7 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 
 public final class Channels {
 
@@ -99,6 +100,7 @@ public final class Channels {
     }
 
     private static final class DeferredLimitedChannelListener implements LimitedChannelListener {
+        @Nullable
         private LimitedChannelListener delegate;
 
         @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 final class ConcurrencyLimitedChannel implements LimitedChannel {
     @Nullable
     private static final Void NO_CONTEXT = null;
+
     private static final Ticker SYSTEM_NANOTIME = System::nanoTime;
 
     private final Meter limitedMeter;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -30,6 +30,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * A channel that monitors the successes and failures of requests in order to determine the number of concurrent
@@ -37,6 +38,7 @@ import java.util.concurrent.TimeUnit;
  * {@link #maybeExecute} method returns empty.
  */
 final class ConcurrencyLimitedChannel implements LimitedChannel {
+    @Nullable
     private static final Void NO_CONTEXT = null;
     private static final Ticker SYSTEM_NANOTIME = System::nanoTime;
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,12 +146,14 @@ final class ContentDecodingChannel implements Channel {
     private static class DeferredGzipInputStream extends InputStream {
         private static final int BUFFER_SIZE = 8 * 1024;
         private final InputStream original;
+        @Nullable
         private InputStream delegate;
 
         DeferredGzipInputStream(InputStream original) {
             this.original = original;
         }
 
+        @Nonnull
         private InputStream getDelegate() throws IOException {
             if (delegate == null) {
                 // Buffer the GZIPInputStream contents in order to reduce expensive native Deflater interactions.

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -146,6 +146,7 @@ final class ContentDecodingChannel implements Channel {
     private static class DeferredGzipInputStream extends InputStream {
         private static final int BUFFER_SIZE = 8 * 1024;
         private final InputStream original;
+
         @Nullable
         private InputStream delegate;
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/MemoizingComposingSupplier.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/MemoizingComposingSupplier.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue.core;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Returns the result of applying the given function to the result of calling {@link Supplier#get()}}, only reapplying
@@ -28,7 +29,9 @@ final class MemoizingComposingSupplier<T, V> implements Supplier<V> {
     private final Supplier<T> delegate;
     private final Function<T, V> function;
 
+    @Nullable
     private volatile T input = null;
+    @Nullable
     private volatile V result = null;
 
     MemoizingComposingSupplier(Supplier<T> delegate, Function<T, V> function) {
@@ -37,6 +40,7 @@ final class MemoizingComposingSupplier<T, V> implements Supplier<V> {
     }
 
     @Override
+    @Nullable
     public V get() {
         if (!delegate.get().equals(input)) {
             synchronized (this) {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/MemoizingComposingSupplier.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/MemoizingComposingSupplier.java
@@ -31,6 +31,7 @@ final class MemoizingComposingSupplier<T, V> implements Supplier<V> {
 
     @Nullable
     private volatile T input = null;
+
     @Nullable
     private volatile V result = null;
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PathTemplateTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PathTemplateTest.java
@@ -23,6 +23,7 @@ import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.dialogue.PathTemplate;
 import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.IOException;
 import java.net.URL;
@@ -71,7 +72,7 @@ public final class PathTemplateTest {
         PathTemplate template =
                 PathTemplate.builder().variable("a").variable("b").build();
         assertThatThrownBy(() -> fill(template, A))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(SafeNullPointerException.class)
                 .isInstanceOf(SafeLoggable.class)
                 .hasMessage("Provided parameter map does not contain segment variable name: {variable=b}");
     }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -76,6 +76,7 @@ final class ConjureBodySerDe implements BodySerDe {
     }
 
     @Override
+    @SuppressWarnings("NullAway") // empty body is a special case
     public Deserializer<Void> emptyBodyDeserializer() {
         return input -> {
             // We should not fail if a server that previously returned nothing starts returning a response

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
@@ -109,6 +109,7 @@ public final class DefaultErrorDecoderTest {
     }
 
     @Test
+    @SuppressWarnings("NullAway") // intentionally testing null body
     public void doesNotHandleNullBody() {
         assertThatThrownBy(() -> decoder.decode(response(500, "application/json", null)))
                 .isInstanceOf(SafeRuntimeException.class)
@@ -120,7 +121,7 @@ public final class DefaultErrorDecoderTest {
         Preconditions.checkArgument(!(exception instanceof ServiceException), "Use SerializableError#forException");
         Object error = SerializableError.builder()
                 .errorCode(exception.getClass().getName())
-                .errorName(exception.getMessage())
+                .errorName(Preconditions.checkNotNull(exception.getMessage(), "exception message"))
                 .build();
         String json;
         try {

--- a/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 public final class PathTemplate {
 
@@ -56,11 +57,11 @@ public final class PathTemplate {
             if (segment.fixed != null) {
                 url.pathSegment(segment.fixed);
             } else {
-                Preconditions.checkArgument(
-                        parameters.containsKey(segment.variable),
+                String variableSegment = Preconditions.checkNotNull(
+                        parameters.get(segment.variable),
                         "Provided parameter map does not contain segment variable name",
                         SafeArg.of("variable", segment.variable));
-                url.pathSegment(parameters.get(segment.variable));
+                url.pathSegment(variableSegment);
                 numVariableSegments += 1;
             }
         }
@@ -86,10 +87,13 @@ public final class PathTemplate {
     }
 
     public static final class Segment {
+        @Nullable
         private final String fixed;
+
+        @Nullable
         private final String variable;
 
-        private Segment(String fixed, String variable) {
+        private Segment(@Nullable String fixed, @Nullable String variable) {
             this.fixed = fixed;
             this.variable = variable;
         }

--- a/simulation/build.gradle
+++ b/simulation/build.gradle
@@ -20,5 +20,5 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.errorprone.errorproneArgs += '-Xep:Slf4jLogsafeArgs:OFF'
+    options.errorprone.errorproneArgs += [ '-Xep:Slf4jLogsafeArgs:OFF', '-Xep:NullAway:OFF' ]
 }

--- a/versions.props
+++ b/versions.props
@@ -4,17 +4,22 @@ com.google.code.findbugs:jsr305 = 3.0.2
 com.google.guava:guava = 27.0.1-jre
 com.netflix.concurrency-limits:* = 0.2.0
 com.palantir.baseline:* = 0.39.1
+com.palantir.conjure.java:* = 5.6.0
 com.palantir.conjure.java.api:* = 2.11.1
 com.palantir.conjure.java.runtime:* = 4.65.1
+<<<<<<< HEAD
 com.palantir.conjure.java:* = 5.7.0
+=======
+>>>>>>> b731f67... Add nullaway
 com.palantir.ri:resource-identifier = 1.1.0
 com.palantir.safe-logging:* = 1.13.0
 com.palantir.tokens:auth-tokens = 3.6.1
 com.palantir.tracing:* = 4.4.0
+com.uber.nullaway:nullaway = 0.7.9
 io.dropwizard.metrics:metrics-core = 3.2.6
+org.apache.httpcomponents:httpclient = 4.5.11
 org.immutables:* = 2.8.3
 org.slf4j:* = 1.7.30
-org.apache.httpcomponents:httpclient = 4.5.11
 
 # test deps
 junit:junit = 4.12

--- a/versions.props
+++ b/versions.props
@@ -4,13 +4,9 @@ com.google.code.findbugs:jsr305 = 3.0.2
 com.google.guava:guava = 27.0.1-jre
 com.netflix.concurrency-limits:* = 0.2.0
 com.palantir.baseline:* = 0.39.1
-com.palantir.conjure.java:* = 5.6.0
+com.palantir.conjure.java:* = 5.7.0
 com.palantir.conjure.java.api:* = 2.11.1
 com.palantir.conjure.java.runtime:* = 4.65.1
-<<<<<<< HEAD
-com.palantir.conjure.java:* = 5.7.0
-=======
->>>>>>> b731f67... Add nullaway
 com.palantir.ri:resource-identifier = 1.1.0
 com.palantir.safe-logging:* = 1.13.0
 com.palantir.tokens:auth-tokens = 3.6.1


### PR DESCRIPTION
## Before this PR

We generally run NullAway on most infra libraries, just to hold ourselves to the highest standard we can, but it wasn't yet enabled on dialogue yet.

https://github.com/uber/NullAway

## After this PR
==COMMIT_MSG==
Dialogue now passes Uber's NullAway static analysis
==COMMIT_MSG==

## Possible downsides?
- if it gets annoying for local iteration, people might need to start using `./gradlew test -Dcom.palantir.baseline-error-prone.disable`
