### PR TITLE
Metrics for PinUntilErrorChannel

### DIFF
--- a/changelog/@unreleased/pr-437.v2.yml
+++ b/changelog/@unreleased/pr-437.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Users of the PinUntilError channel now have metrics available capturing
+    when the list reshuffles, when node switches (including a reason) and how many
+    successful requests we see on each channel.
+  links:
+  - https://github.com/palantir/dialogue/pull/437

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Channels.java
@@ -37,8 +37,9 @@ public final class Channels {
         Preconditions.checkArgument(!channels.isEmpty(), "channels must not be empty");
         Preconditions.checkArgument(config.userAgent().isPresent(), "config.userAgent() must be specified");
 
-        DialogueClientMetrics clientMetrics =
-                DialogueClientMetrics.of(new VersionedTaggedMetricRegistry(config.taggedMetricRegistry()));
+        VersionedTaggedMetricRegistry taggedMetrics = new VersionedTaggedMetricRegistry(config.taggedMetricRegistry());
+        DialogueClientMetrics clientMetrics = DialogueClientMetrics.of(taggedMetrics);
+
         List<LimitedChannel> limitedChannels = channels.stream()
                 // Instrument inner-most channel with metrics so that we measure only the over-the-wire-time
                 .map(channel -> new InstrumentedChannel(channel, clientMetrics))
@@ -50,7 +51,7 @@ public final class Channels {
                 .map(channel -> new FixedLimitedChannel(channel, MAX_REQUESTS_PER_CHANNEL, clientMetrics))
                 .collect(ImmutableList.toImmutableList());
 
-        LimitedChannel limited = nodeSelectionStrategy(config, limitedChannels, clientMetrics);
+        LimitedChannel limited = nodeSelectionStrategy(config, limitedChannels, taggedMetrics);
         Channel channel = new LimitedChannelToChannelAdapter(limited);
         channel = new TracedChannel(channel, "Dialogue-request-attempt");
         if (config.maxNumRetries() > 0) {
@@ -67,18 +68,19 @@ public final class Channels {
     }
 
     private static LimitedChannel nodeSelectionStrategy(
-            ClientConfiguration config, List<LimitedChannel> channels, DialogueClientMetrics metrics) {
+            ClientConfiguration config, List<LimitedChannel> channels, VersionedTaggedMetricRegistry metrics) {
         if (channels.size() == 1) {
             return channels.get(0); // no fancy node selection heuristic can save us if our one node goes down
         }
 
         switch (config.nodeSelectionStrategy()) {
             case PIN_UNTIL_ERROR:
-                return PinUntilErrorChannel.pinUntilError(channels, metrics);
+                return PinUntilErrorChannel.pinUntilError(channels, DialoguePinuntilerrorMetrics.of(metrics));
             case ROUND_ROBIN:
                 return new RoundRobinChannel(channels);
             case PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE:
-                return PinUntilErrorChannel.pinUntilErrorWithoutReshuffle(channels, metrics);
+                return PinUntilErrorChannel.pinUntilErrorWithoutReshuffle(
+                        channels, DialoguePinuntilerrorMetrics.of(metrics));
         }
         throw new SafeRuntimeException(
                 "Unknown NodeSelectionStrategy", SafeArg.of("unknown", config.nodeSelectionStrategy()));

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
@@ -16,6 +16,7 @@
 
 package com.palantir.dialogue.core;
 
+import com.codahale.metrics.Meter;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -59,19 +60,21 @@ final class PinUntilErrorChannel implements LimitedChannel {
     // TODO(dfox): could we make this endpoint-specific?
     private final AtomicInteger currentHost = new AtomicInteger(0); // always positive
     private final NodeList nodeList;
+    private final Instrumentation instrumentation;
 
     @VisibleForTesting
-    PinUntilErrorChannel(NodeList nodeList, DialogueClientMetrics metrics) {
+    PinUntilErrorChannel(NodeList nodeList, DialoguePinuntilerrorMetrics metrics) {
         this.nodeList = nodeList;
+        this.instrumentation = new Instrumentation(metrics);
         Preconditions.checkArgument(
                 nodeList.size() >= 2,
                 "PinUntilError is pointless if you have zero or 1 channels."
                         + " Use an always throwing channel or just pick the only channel in the list.");
     }
 
-    static LimitedChannel pinUntilError(List<LimitedChannel> channels, DialogueClientMetrics metrics) {
+    static LimitedChannel pinUntilError(List<LimitedChannel> channels, DialoguePinuntilerrorMetrics metrics) {
         ReshufflingNodeList shufflingNodeList =
-                new ReshufflingNodeList(channels, SafeThreadLocalRandom.get(), System::nanoTime);
+                new ReshufflingNodeList(channels, SafeThreadLocalRandom.get(), System::nanoTime, metrics);
         return new PinUntilErrorChannel(shufflingNodeList, metrics);
     }
 
@@ -80,7 +83,8 @@ final class PinUntilErrorChannel implements LimitedChannel {
      * @deprecated prefer {@link #pinUntilError}
      */
     @Deprecated
-    static LimitedChannel pinUntilErrorWithoutReshuffle(List<LimitedChannel> channels, DialogueClientMetrics metrics) {
+    static LimitedChannel pinUntilErrorWithoutReshuffle(
+            List<LimitedChannel> channels, DialoguePinuntilerrorMetrics metrics) {
         ConstantNodeList constantNodeList = new ConstantNodeList(channels, SafeThreadLocalRandom.get());
         return new PinUntilErrorChannel(constantNodeList, metrics);
     }
@@ -93,7 +97,7 @@ final class PinUntilErrorChannel implements LimitedChannel {
         Optional<ListenableFuture<Response>> maybeFuture = channel.maybeExecute(endpoint, request);
         if (!maybeFuture.isPresent()) {
             OptionalInt next = incrementHostIfNecessary(currentIndex);
-            debugLogCurrentChannelRejected(currentIndex, channel, next);
+            instrumentation.currentChannelRejected(currentIndex, channel, next);
             return Optional.empty(); // if the caller retries immediately, we'll get the next host
         }
 
@@ -103,15 +107,17 @@ final class PinUntilErrorChannel implements LimitedChannel {
             public void onSuccess(Response response) {
                 if (Responses.isQosStatus(response) || Responses.isServerError(response)) {
                     OptionalInt next = incrementHostIfNecessary(currentIndex);
-                    debugLogReceivedErrorStatus(currentIndex, channel, response, next);
+                    instrumentation.receivedErrorStatus(currentIndex, channel, response, next);
                     // TODO(dfox): handle 308 See Other somehow, as we currently don't have a host -> channel mapping
+                } else {
+                    instrumentation.instrumentSuccessfulResponse(currentIndex, nodeList);
                 }
             }
 
             @Override
             public void onFailure(Throwable throwable) {
                 OptionalInt next = incrementHostIfNecessary(currentIndex);
-                debugLogReceivedThrowable(currentIndex, channel, throwable, next);
+                instrumentation.receivedThrowable(currentIndex, channel, throwable, next);
             }
         }));
     }
@@ -164,11 +170,13 @@ final class PinUntilErrorChannel implements LimitedChannel {
         private final Random random;
         private final long intervalWithJitter;
         private final int channelsSize;
+        private final Instrumentation instrumentation;
 
         private final AtomicLong nextReshuffle;
         private volatile ImmutableList<LimitedChannel> channels;
 
-        ReshufflingNodeList(List<LimitedChannel> channels, Random random, Ticker clock) {
+        ReshufflingNodeList(
+                List<LimitedChannel> channels, Random random, Ticker clock, DialoguePinuntilerrorMetrics metrics) {
             this.channels = shuffleImmutableList(channels, random);
             this.channelsSize = channels.size();
             this.random = random;
@@ -177,6 +185,7 @@ final class PinUntilErrorChannel implements LimitedChannel {
                     .toNanos();
             this.nextReshuffle = new AtomicLong(clock.read() + intervalWithJitter);
             this.clock = clock;
+            this.instrumentation = new Instrumentation(metrics);
         }
 
         @Override
@@ -198,12 +207,7 @@ final class PinUntilErrorChannel implements LimitedChannel {
 
             if (nextReshuffle.compareAndSet(reshuffleTime, clock.read() + intervalWithJitter)) {
                 ImmutableList<LimitedChannel> newList = shuffleImmutableList(channels, random);
-                if (log.isDebugEnabled()) {
-                    log.debug(
-                            "Reshuffling channels {} {}",
-                            SafeArg.of("nextReshuffle", Duration.ofNanos(intervalWithJitter)),
-                            UnsafeArg.of("newList", newList));
-                }
+                instrumentation.reshuffled(newList, intervalWithJitter);
                 channels = newList;
             }
         }
@@ -216,59 +220,102 @@ final class PinUntilErrorChannel implements LimitedChannel {
         return ImmutableList.copyOf(mutableList);
     }
 
-    private void debugLogCurrentChannelRejected(int currentIndex, LimitedChannel channel, OptionalInt next) {
-        if (log.isDebugEnabled()) {
-            if (next.isPresent()) {
+    /** Purely for metric and service log observability. */
+    private static final class Instrumentation {
+        private final DialoguePinuntilerrorMetrics metrics;
+        private final Meter reshuffleMeter;
+        private final Meter nextNodeBecauseLimited;
+        private final Meter nextNodeBecauseResponseCode;
+        private final Meter nextNodeBecauseThrowable;
+
+        Instrumentation(DialoguePinuntilerrorMetrics metrics) {
+            this.metrics = metrics;
+            this.reshuffleMeter = metrics.reshuffle();
+            this.nextNodeBecauseLimited = metrics.nextNode("limited");
+            this.nextNodeBecauseResponseCode = metrics.nextNode("responseCode");
+            this.nextNodeBecauseThrowable = metrics.nextNode("throwable");
+        }
+
+        private void reshuffled(ImmutableList<LimitedChannel> newList, long intervalWithJitter) {
+            reshuffleMeter.mark();
+            if (log.isDebugEnabled()) {
                 log.debug(
-                        "Current channel rejected request, switching to next channel",
-                        SafeArg.of("currentIndex", currentIndex),
-                        UnsafeArg.of("current", channel),
-                        SafeArg.of("nextIndex", next.getAsInt()));
-            } else {
-                log.debug(
-                        "Current channel rejected request, but we've already switched",
-                        SafeArg.of("currentIndex", currentIndex),
-                        UnsafeArg.of("current", channel));
+                        "Reshuffled channels {} {}",
+                        SafeArg.of("nextReshuffle", Duration.ofNanos(intervalWithJitter)),
+                        UnsafeArg.of("newList", newList));
             }
         }
-    }
 
-    private void debugLogReceivedErrorStatus(
-            int currentIndex, LimitedChannel channel, Response response, OptionalInt next) {
-        if (log.isDebugEnabled()) {
+        private void currentChannelRejected(int currentIndex, LimitedChannel channel, OptionalInt next) {
             if (next.isPresent()) {
-                log.debug(
-                        "Received error status code, switching to next channel",
-                        SafeArg.of("status", response.code()),
-                        SafeArg.of("currentIndex", currentIndex),
-                        UnsafeArg.of("current", channel),
-                        SafeArg.of("nextIndex", next.getAsInt()));
-            } else {
-                log.debug(
-                        "Received error status code, but we've already switched",
-                        SafeArg.of("status", response.code()),
-                        SafeArg.of("currentIndex", currentIndex),
-                        UnsafeArg.of("current", channel));
+                nextNodeBecauseLimited.mark();
+            }
+            if (log.isDebugEnabled()) {
+                if (next.isPresent()) {
+                    log.debug(
+                            "Current channel rejected request, switching to next channel",
+                            SafeArg.of("currentIndex", currentIndex),
+                            UnsafeArg.of("current", channel),
+                            SafeArg.of("nextIndex", next.getAsInt()));
+                } else {
+                    log.debug(
+                            "Current channel rejected request, but we've already switched",
+                            SafeArg.of("currentIndex", currentIndex),
+                            UnsafeArg.of("current", channel));
+                }
             }
         }
-    }
 
-    private void debugLogReceivedThrowable(
-            int currentIndex, LimitedChannel channel, Throwable throwable, OptionalInt next) {
-        if (log.isDebugEnabled()) {
+        private void receivedErrorStatus(
+                int currentIndex, LimitedChannel channel, Response response, OptionalInt next) {
             if (next.isPresent()) {
-                log.debug(
-                        "Received throwable, switching to next channel",
-                        SafeArg.of("currentIndex", currentIndex),
-                        UnsafeArg.of("current", channel),
-                        SafeArg.of("nextIndex", next.getAsInt()),
-                        throwable);
-            } else {
-                log.debug(
-                        "Received throwable, but already switched",
-                        SafeArg.of("currentIndex", currentIndex),
-                        UnsafeArg.of("current", channel),
-                        throwable);
+                nextNodeBecauseResponseCode.mark();
+            }
+            if (log.isDebugEnabled()) {
+                if (next.isPresent()) {
+                    log.debug(
+                            "Received error status code, switching to next channel",
+                            SafeArg.of("status", response.code()),
+                            SafeArg.of("currentIndex", currentIndex),
+                            UnsafeArg.of("current", channel),
+                            SafeArg.of("nextIndex", next.getAsInt()));
+                } else {
+                    log.debug(
+                            "Received error status code, but we've already switched",
+                            SafeArg.of("status", response.code()),
+                            SafeArg.of("currentIndex", currentIndex),
+                            UnsafeArg.of("current", channel));
+                }
+            }
+        }
+
+        private void receivedThrowable(
+                int currentIndex, LimitedChannel channel, Throwable throwable, OptionalInt next) {
+            if (next.isPresent()) {
+                nextNodeBecauseThrowable.mark();
+            }
+            if (log.isDebugEnabled()) {
+                if (next.isPresent()) {
+                    log.debug(
+                            "Received throwable, switching to next channel",
+                            SafeArg.of("currentIndex", currentIndex),
+                            UnsafeArg.of("current", channel),
+                            SafeArg.of("nextIndex", next.getAsInt()),
+                            throwable);
+                } else {
+                    log.debug(
+                            "Received throwable, but already switched",
+                            SafeArg.of("currentIndex", currentIndex),
+                            UnsafeArg.of("current", channel),
+                            throwable);
+                }
+            }
+        }
+
+        private void instrumentSuccessfulResponse(int currentIndex, NodeList nodeList) {
+            if (nodeList.size() < 10) {
+                // hard limit ensures we don't create unbounded tags
+                metrics.success(Integer.toString(currentIndex));
             }
         }
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
@@ -61,7 +61,7 @@ final class PinUntilErrorChannel implements LimitedChannel {
     private final NodeList nodeList;
 
     @VisibleForTesting
-    PinUntilErrorChannel(NodeList nodeList) {
+    PinUntilErrorChannel(NodeList nodeList, DialogueClientMetrics metrics) {
         this.nodeList = nodeList;
         Preconditions.checkArgument(
                 nodeList.size() >= 2,
@@ -69,10 +69,10 @@ final class PinUntilErrorChannel implements LimitedChannel {
                         + " Use an always throwing channel or just pick the only channel in the list.");
     }
 
-    static LimitedChannel pinUntilError(List<LimitedChannel> channels) {
+    static LimitedChannel pinUntilError(List<LimitedChannel> channels, DialogueClientMetrics metrics) {
         ReshufflingNodeList shufflingNodeList =
                 new ReshufflingNodeList(channels, SafeThreadLocalRandom.get(), System::nanoTime);
-        return new PinUntilErrorChannel(shufflingNodeList);
+        return new PinUntilErrorChannel(shufflingNodeList, metrics);
     }
 
     /**
@@ -80,9 +80,9 @@ final class PinUntilErrorChannel implements LimitedChannel {
      * @deprecated prefer {@link #pinUntilError}
      */
     @Deprecated
-    static LimitedChannel pinUntilErrorWithoutReshuffle(List<LimitedChannel> channels) {
+    static LimitedChannel pinUntilErrorWithoutReshuffle(List<LimitedChannel> channels, DialogueClientMetrics metrics) {
         ConstantNodeList constantNodeList = new ConstantNodeList(channels, SafeThreadLocalRandom.get());
-        return new PinUntilErrorChannel(constantNodeList);
+        return new PinUntilErrorChannel(constantNodeList, metrics);
     }
 
     @Override

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -17,3 +17,19 @@ namespaces:
         type: meter
         tags: [reason]
         docs: Rate that client-side requests are deferred to be retried later.
+
+  dialogue.pinuntilerror:
+    docs: Instrumentation for the PIN_UNTIL_ERROR node selection strategy.
+    metrics:
+      success:
+        type: meter
+        tags: [hostIndex]
+        docs: Meter of the requests that were successfully, tagged by the index of the inner channel. (Note if there are >10 nodes this metric will not be recorded).
+      nextNode:
+        type: meter
+        tags: [reason]
+        docs: Marked every time we switch to a new node, includes the reason why we switched (limited, responseCode, throwable).
+        # TODO(dfox): can we plumb the serviceName in here e.g. GatekeeperService?
+      reshuffle:
+        type: meter
+        docs: Marked every time we reshuffle all the nodes.

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Response;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -55,14 +56,19 @@ public class PinUntilErrorChannelTest {
 
     private PinUntilErrorChannel pinUntilErrorWithoutReshuffle;
     private PinUntilErrorChannel pinUntilError;
+    private DialogueClientMetrics metrics = DialogueClientMetrics.of(new DefaultTaggedMetricRegistry());
 
     @BeforeEach
     public void before() {
         List<LimitedChannel> channels = ImmutableList.of(channel1, channel2);
-        pinUntilErrorWithoutReshuffle =
-                new PinUntilErrorChannel(new PinUntilErrorChannel.ConstantNodeList(channels, new Random(12345L)));
-        pinUntilError = new PinUntilErrorChannel(
-                new PinUntilErrorChannel.ReshufflingNodeList(channels, new Random(12893712L), clock));
+
+        PinUntilErrorChannel.ConstantNodeList constantList =
+                new PinUntilErrorChannel.ConstantNodeList(channels, new Random(12345L));
+        PinUntilErrorChannel.ReshufflingNodeList shufflingList =
+                new PinUntilErrorChannel.ReshufflingNodeList(channels, new Random(12893712L), clock);
+
+        pinUntilErrorWithoutReshuffle = new PinUntilErrorChannel(constantList, metrics);
+        pinUntilError = new PinUntilErrorChannel(shufflingList, metrics);
     }
 
     @Test

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
@@ -56,7 +56,7 @@ public class PinUntilErrorChannelTest {
 
     private PinUntilErrorChannel pinUntilErrorWithoutReshuffle;
     private PinUntilErrorChannel pinUntilError;
-    private DialogueClientMetrics metrics = DialogueClientMetrics.of(new DefaultTaggedMetricRegistry());
+    private DialoguePinuntilerrorMetrics metrics = DialoguePinuntilerrorMetrics.of(new DefaultTaggedMetricRegistry());
 
     @BeforeEach
     public void before() {
@@ -65,7 +65,7 @@ public class PinUntilErrorChannelTest {
         PinUntilErrorChannel.ConstantNodeList constantList =
                 new PinUntilErrorChannel.ConstantNodeList(channels, new Random(12345L));
         PinUntilErrorChannel.ReshufflingNodeList shufflingList =
-                new PinUntilErrorChannel.ReshufflingNodeList(channels, new Random(12893712L), clock);
+                new PinUntilErrorChannel.ReshufflingNodeList(channels, new Random(12893712L), clock, metrics);
 
         pinUntilErrorWithoutReshuffle = new PinUntilErrorChannel(constantList, metrics);
         pinUntilError = new PinUntilErrorChannel(shufflingList, metrics);

--- a/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
@@ -85,7 +85,8 @@ public enum Strategy {
                     .map(addFixedLimiter(sim))
                     .collect(Collectors.toList());
             LimitedChannel limited = new PinUntilErrorChannel(
-                    new PinUntilErrorChannel.ReshufflingNodeList(limitedChannels, psuedoRandom, sim.clock()));
+                    new PinUntilErrorChannel.ReshufflingNodeList(limitedChannels, psuedoRandom, sim.clock()),
+                    DialogueClientMetrics.of(sim.taggedMetrics()));
             return retryingChannel(sim, limited);
         });
     }

--- a/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
@@ -84,9 +84,10 @@ public enum Strategy {
                     .map(addConcurrencyLimiter(sim))
                     .map(addFixedLimiter(sim))
                     .collect(Collectors.toList());
+            DialoguePinuntilerrorMetrics metrics = DialoguePinuntilerrorMetrics.of(sim.taggedMetrics());
             LimitedChannel limited = new PinUntilErrorChannel(
-                    new PinUntilErrorChannel.ReshufflingNodeList(limitedChannels, psuedoRandom, sim.clock()),
-                    DialogueClientMetrics.of(sim.taggedMetrics()));
+                    new PinUntilErrorChannel.ReshufflingNodeList(limitedChannels, psuedoRandom, sim.clock(), metrics),
+                    metrics);
             return retryingChannel(sim, limited);
         });
     }


### PR DESCRIPTION
## Before this PR
The vast majority of services will use this channel. I'd like to be able to look at graphs to see how it behaves in production.

## After this PR
==COMMIT_MSG==
Users of the PinUntilError channel now have metrics available capturing when the list reshuffles, when node switches (including a reason) and how many successful requests we see on each channel.
==COMMIT_MSG==

## Possible downsides?
- more metrics = more money. I _think_ we could build a flag to switch some of these metrics on/off later, but I think it's OK to keep em for now as we do a gradual rollout of dialogue.
