### PR TITLE
Autorelease most PRs

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,1 @@
+'autorelease': ['*/src/**/*.java']


### PR DESCRIPTION
## Before this PR

We're making a lot of bugfixes & quality of life improvements at the moment, and it's annoying if people report problems that we've already fixed but forgot to release.

I think we should get into the habit of assuming all PRs get released, and ask people to opt-out.

## After this PR
==COMMIT_MSG==
All PRs which touch non-test java files will get the 'autorelease' label applied by default. PR authors are free to take it off if they think their PR is trivial, but in general we want to bias towards releasing everything.
==COMMIT_MSG==

## Possible downsides?
- releases are pretty much free
