### PR TITLE
simulate one big spike of requests

### DIFF
--- a/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20a921ce89d50a6ffccad98191c1f2e0bbba565f55850e1ef1e923a1f2458988
+size 144985

--- a/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
+++ b/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42a252359f01c7b5942ed33d95ba86a6a8c8ca12f48e5fe39259ba961ee3eec0
+size 169529

--- a/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0e907ccb15f61b4da04eb0e3428c9d5f1095c79596fce4ce7ea7fac45370c82
+size 145164

--- a/simulation/src/test/resources/one_big_spike[UNLIMITED_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/one_big_spike[UNLIMITED_ROUND_ROBIN].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64f592b2e3d91ceb4103685e84bde2419fe64edaecd61279913b6e6cc4743c55
+size 105098

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -21,6 +21,10 @@
                live_reloading[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=54.2%	client_mean=PT2.947366793S 	server_cpu=PT1H45M11.292359783S	client_received=2500/2500	server_resps=2229	codes={200=1355, 500=874, Failed to make a request=271}
                    live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=52.0%	client_mean=PT2.915893225S 	server_cpu=PT1H43M13.659598627S	client_received=2500/2500	server_resps=2197	codes={200=1301, 500=896, Failed to make a request=303}
                              live_reloading[UNLIMITED_ROUND_ROBIN].txt:	success=58.4%	client_mean=PT2.8396S      	server_cpu=PT1H58M19S     	client_received=2500/2500	server_resps=2500	codes={200=1461, 500=1039}
+          one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].txt:	success=79.0%	client_mean=PT1.478050977S 	server_cpu=PT1M59.71393673S	client_received=1000/1000	server_resps=790	codes={200=790, Failed to make a request=210}
+                one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=78.9%	client_mean=PT1.47737782S  	server_cpu=PT1M59.563042645S	client_received=1000/1000	server_resps=789	codes={200=789, Failed to make a request=211}
+                    one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=79.0%	client_mean=PT1.478050977S 	server_cpu=PT1M59.71393673S	client_received=1000/1000	server_resps=790	codes={200=790, Failed to make a request=210}
+                              one_big_spike[UNLIMITED_ROUND_ROBIN].txt:	success=99.5%	client_mean=PT1.213878171S 	server_cpu=PT6M57.305927328S	client_received=1000/1000	server_resps=2757	codes={200=995, 429=5}
 one_endpoint_dies_on_each_server[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].txt:	success=46.4%	client_mean=PT1.302954516S 	server_cpu=PT15M22.396603327S	client_received=2500/2500	server_resps=1536	codes={200=1161, 500=375, Failed to make a request=964}
 one_endpoint_dies_on_each_server[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=63.8%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1594, 500=906}
  one_endpoint_dies_on_each_server[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=65.5%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1638, 500=862}
@@ -143,6 +147,26 @@ slowdown_and_error_thresholds[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=
 ## `live_reloading[UNLIMITED_ROUND_ROBIN]`
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/live_reloading[UNLIMITED_ROUND_ROBIN].png" /></td><td><image width=400 src="live_reloading[UNLIMITED_ROUND_ROBIN].png" /></td></tr></table>
+
+
+## `one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].png" /></td><td><image width=400 src="one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].png" /></td></tr></table>
+
+
+## `one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## `one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN].png" /></td><td><image width=400 src="one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN].png" /></td></tr></table>
+
+
+## `one_big_spike[UNLIMITED_ROUND_ROBIN]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/one_big_spike[UNLIMITED_ROUND_ROBIN].png" /></td><td><image width=400 src="one_big_spike[UNLIMITED_ROUND_ROBIN].png" /></td></tr></table>
 
 
 ## `one_endpoint_dies_on_each_server[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN]`

--- a/simulation/src/test/resources/txt/one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].txt
@@ -1,0 +1,1 @@
+success=79.0%	client_mean=PT1.478050977S 	server_cpu=PT1M59.71393673S	client_received=1000/1000	server_resps=790	codes={200=790, Failed to make a request=210}

--- a/simulation/src/test/resources/txt/one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
+++ b/simulation/src/test/resources/txt/one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
@@ -1,0 +1,1 @@
+success=78.9%	client_mean=PT1.47737782S  	server_cpu=PT1M59.563042645S	client_received=1000/1000	server_resps=789	codes={200=789, Failed to make a request=211}

--- a/simulation/src/test/resources/txt/one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/one_big_spike[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
@@ -1,0 +1,1 @@
+success=79.0%	client_mean=PT1.478050977S 	server_cpu=PT1M59.71393673S	client_received=1000/1000	server_resps=790	codes={200=790, Failed to make a request=210}

--- a/simulation/src/test/resources/txt/one_big_spike[UNLIMITED_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/one_big_spike[UNLIMITED_ROUND_ROBIN].txt
@@ -1,0 +1,1 @@
+success=99.5%	client_mean=PT1.213878171S 	server_cpu=PT6M57.305927328S	client_received=1000/1000	server_resps=2757	codes={200=995, 429=5}


### PR DESCRIPTION
## Before this PR
From the `#dev-rpc` slack channel, this is intended to be somewhat representative of alta clients.

## After this PR
==COMMIT_MSG==
New simulation case 'one_big_spike' demonstrates the workflow where a single client may kick off a ton of requests in a hot loop and just wait for them all to come back before being able to return to the user.
==COMMIT_MSG==

# [GRAPHS](https://github.com/palantir/dialogue/blob/dfox/simulate-one-big-spike/simulation/src/test/resources/report.md#one_big_spikeconcurrency_limiter_blacklist_round_robin)

show 79% success rate

## Possible downsides?

