### PR TITLE
UnknownRemoteException

### DIFF
--- a/changelog/@unreleased/pr-454.v2.yml
+++ b/changelog/@unreleased/pr-454.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: DefaultErrorDecoder throws UnknownRemoteExceptions when we can't deserialize
+    json into our expected `SerializableError` type.
+  links:
+  - https://github.com/palantir/dialogue/pull/454

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoder.java
@@ -20,11 +20,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.dialogue.ErrorDecoder;
 import com.palantir.dialogue.Response;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,11 +57,7 @@ public enum DefaultErrorDecoder implements ErrorDecoder {
                 SerializableError serializableError = MAPPER.readValue(body, SerializableError.class);
                 return new RemoteException(serializableError, response.code());
             } catch (Exception e) {
-                throw new SafeRuntimeException(
-                        "Failed to deserialize response body as JSON, could not deserialize SerializableError",
-                        e,
-                        SafeArg.of("code", response.code()),
-                        UnsafeArg.of("body", body));
+                throw new UnknownRemoteException(response.code(), body);
             }
         }
 

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultErrorDecoderTest.java
@@ -19,7 +19,7 @@ package com.palantir.conjure.java.dialogue.serde;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.shouldHaveThrown;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -106,7 +106,7 @@ public final class DefaultErrorDecoderTest {
     public void doesNotHandleUnparseableBody() {
         try {
             decoder.decode(response(500, "application/json/", "not json"));
-            shouldHaveThrown(UnknownRemoteException.class);
+            failBecauseExceptionWasNotThrown(UnknownRemoteException.class);
         } catch (UnknownRemoteException expected) {
             assertThat(expected.getStatus()).isEqualTo(500);
             assertThat(expected.getBody()).isEqualTo("not json");
@@ -127,7 +127,7 @@ public final class DefaultErrorDecoderTest {
     public void handlesUnexpectedJson() {
         try {
             decoder.decode(response(502, "application/json", "{\"error\":\"some-unknown-json\"}"));
-            shouldHaveThrown(UnknownRemoteException.class);
+            failBecauseExceptionWasNotThrown(UnknownRemoteException.class);
         } catch (UnknownRemoteException expected) {
             assertThat(expected.getStatus()).isEqualTo(502);
             assertThat(expected.getBody()).isEqualTo("{\"error\":\"some-unknown-json\"}");

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -50,6 +51,10 @@ public final class RemoteExceptions {
                 throw newRemoteException((RemoteException) cause);
             }
 
+            if (cause instanceof UnknownRemoteException) {
+                throw newUnknownRemoteException((UnknownRemoteException) cause);
+            }
+
             // This matches the behavior in Futures.getUnchecked(Future)
             if (cause instanceof Error) {
                 throw new ExecutionError(message, (Error) cause);
@@ -63,6 +68,12 @@ public final class RemoteExceptions {
     private static RemoteException newRemoteException(RemoteException remoteException) {
         RemoteException newException = new RemoteException(remoteException.getError(), remoteException.getStatus());
         newException.initCause(remoteException);
+        return newException;
+    }
+
+    private static UnknownRemoteException newUnknownRemoteException(UnknownRemoteException cause) {
+        UnknownRemoteException newException = new UnknownRemoteException(cause.getStatus(), cause.getBody());
+        newException.initCause(cause);
         return newException;
     }
 }


### PR DESCRIPTION
## Before this PR

A lot of people compile against conjure-java-runtime-api's UnknownRemoteException to cases outside the conjure ecosystem (e.g. nginx gateway timeout), but dialogue currently throws a made-up SafeRuntimeException instead.

https://internal-github/search?l=Java&q=org%3Afoundry+UnknownRemoteException&type=Code

## After this PR
==COMMIT_MSG==
DefaultErrorDecoder throws UnknownRemoteExceptions when we can't deserialize json into our expected `SerializableError` type.
==COMMIT_MSG==

## Possible downsides?

