### PR TITLE
Apache connection pool instrumentation

### DIFF
--- a/changelog/@unreleased/pr-457.v2.yml
+++ b/changelog/@unreleased/pr-457.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Each closeable apache client now exposes methods which reveal statistics
+    about the connection pool.
+  links:
+  - https://github.com/palantir/dialogue/pull/457

--- a/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ApacheHttpClientChannelsTest.java
@@ -15,8 +15,11 @@
  */
 package com.palantir.dialogue.hc4;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
@@ -28,6 +31,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestConfigurations;
 import com.palantir.dialogue.UrlBuilder;
+import com.palantir.tritium.metrics.registry.MetricName;
 import java.net.UnknownHostException;
 import java.util.Map;
 import org.junit.Test;
@@ -56,6 +60,36 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
         ListenableFuture<Response> again =
                 channel.execute(new TestEndpoint(), Request.builder().build());
         assertThatThrownBy(() -> again.get()).hasMessageContaining("Connection pool shut down");
+    }
+
+    @Test
+    public void metrics() throws Exception {
+        ClientConfiguration conf = TestConfigurations.create("http://unused");
+
+        Channel channel;
+        Map<MetricName, Metric> metrics;
+        try (ApacheHttpClientChannels.CloseableClient client =
+                ApacheHttpClientChannels.createCloseableHttpClient(conf)) {
+
+            channel = ApacheHttpClientChannels.createSingleUri("http://neverssl.com", client);
+            ListenableFuture<Response> response =
+                    channel.execute(new TestEndpoint(), Request.builder().build());
+            assertThat(Futures.getUnchecked(response).code()).isEqualTo(200);
+
+            metrics = client.getMetrics();
+            assertThat(getGauge(metrics, "routes")).describedAs("routes").isEqualTo(1);
+            assertThat(getGauge(metrics, "available")).describedAs("available").isEqualTo(0);
+            assertThat(getGauge(metrics, "leased")).describedAs("leased").isEqualTo(1);
+        }
+        assertThat(getGauge(metrics, "leased"))
+                .describedAs("number of leased connections after client closed is 0")
+                .isEqualTo(0);
+    }
+
+    private Integer getGauge(Map<MetricName, Metric> metrics, String metricName) {
+        Gauge<Integer> gauge = (Gauge<Integer>)
+                metrics.get(MetricName.builder().safeName(metricName).build());
+        return gauge.getValue();
     }
 
     private static final class TestEndpoint implements Endpoint {


### PR DESCRIPTION
## Before this PR

We have hypotheses that connection re-use has a big impact on our most performance-sensitive services like timelock. Currently, we just use the tls.handshake graphs to 

## After this PR
==COMMIT_MSG==
Each closeable apache client now exposes methods which reveal statistics about the connection pool.
==COMMIT_MSG==

After merging, we'll have to carefully wire these up to gauges in witchcraft, ensuring that we don't prevent objects from being GC'd just by having a reference in a tritium registry somewhere.

## Possible downsides?
- if the apache defaults change then by building our connection manager ourself we might miss out on improvements
