### PR TITLE
Interrupted calls properly close resources

### DIFF
--- a/changelog/@unreleased/pr-458.v2.yml
+++ b/changelog/@unreleased/pr-458.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Interrupted calls properly close resources
+  links:
+  - https://github.com/palantir/dialogue/pull/458

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
@@ -44,7 +44,7 @@ public final class RemoteExceptions {
      * Similar to {@link com.google.common.util.concurrent.Futures#getUnchecked(Future)}, except it propagates
      * {@link RemoteException}s directly, rather than wrapping them in an {@link UncheckedExecutionException}.
      */
-    @SuppressWarnings("deprecated") // match behavior of Futures.getUnchecked(Future)
+    @SuppressWarnings("deprecation") // match behavior of Futures.getUnchecked(Future)
     public static <T> T getUnchecked(ListenableFuture<T> future) {
         return getUnchecked((Future<T>) future);
     }
@@ -67,7 +67,7 @@ public final class RemoteExceptions {
                     ListenableFuture<T> listenable = (ListenableFuture<T>) future;
                     Futures.addCallback(listenable, CancelListener.INSTANCE, MoreExecutors.directExecutor());
                 } else {
-                    log.warn("Unable to ensure result of non-listenable future is closed");
+                    log.warn("Unable to ensure result of non-listenable future is closed", e);
                 }
             }
             throw new SafeRuntimeException("Interrupted waiting for future", e);

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
@@ -66,6 +66,8 @@ public final class RemoteExceptions {
                 if (future instanceof ListenableFuture) {
                     ListenableFuture<T> listenable = (ListenableFuture<T>) future;
                     Futures.addCallback(listenable, CancelListener.INSTANCE, MoreExecutors.directExecutor());
+                } else {
+                    log.warn("Unable to ensure result of non-listenable future is closed");
                 }
             }
             throw new SafeRuntimeException("Interrupted waiting for future", e);

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
@@ -17,15 +17,26 @@
 package com.palantir.dialogue;
 
 import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.UnknownRemoteException;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Provides utility functions for exception handling. */
 public final class RemoteExceptions {
+    private static final Logger log = LoggerFactory.getLogger(RemoteExceptions.class);
 
     private RemoteExceptions() {}
 
@@ -33,13 +44,30 @@ public final class RemoteExceptions {
      * Similar to {@link com.google.common.util.concurrent.Futures#getUnchecked(Future)}, except it propagates
      * {@link RemoteException}s directly, rather than wrapping them in an {@link UncheckedExecutionException}.
      */
+    @SuppressWarnings("deprecated") // match behavior of Futures.getUnchecked(Future)
+    public static <T> T getUnchecked(ListenableFuture<T> future) {
+        return getUnchecked((Future<T>) future);
+    }
+
+    /**
+     * Similar to {@link com.google.common.util.concurrent.Futures#getUnchecked(Future)}, except it propagates
+     * {@link RemoteException}s directly, rather than wrapping them in an {@link UncheckedExecutionException}.
+     *
+     * @deprecated Prefer {@link #getUnchecked(ListenableFuture)}
+     */
+    @Deprecated
     @SuppressWarnings("ThrowError") // match behavior of Futures.getUnchecked(Future)
     public static <T> T getUnchecked(Future<T> future) {
         try {
             return future.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            future.cancel(true);
+            if (!future.cancel(true)) {
+                if (future instanceof ListenableFuture) {
+                    ListenableFuture<T> listenable = (ListenableFuture<T>) future;
+                    Futures.addCallback(listenable, CancelListener.INSTANCE, MoreExecutors.directExecutor());
+                }
+            }
             throw new SafeRuntimeException("Interrupted waiting for future", e);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
@@ -75,5 +103,28 @@ public final class RemoteExceptions {
         UnknownRemoteException newException = new UnknownRemoteException(cause.getStatus(), cause.getBody());
         newException.initCause(cause);
         return newException;
+    }
+
+    enum CancelListener implements FutureCallback<Object> {
+        INSTANCE;
+
+        @Override
+        public void onSuccess(@Nullable Object result) {
+            if (result instanceof Closeable) {
+                try {
+                    ((Closeable) result).close();
+                } catch (IOException | RuntimeException e) {
+                    log.info(
+                            "Failed to close result of {} after the call was canceled",
+                            UnsafeArg.of("result", result),
+                            e);
+                }
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            log.info("Canceled call failed", t);
+        }
     }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RemoteExceptions.java
@@ -125,8 +125,8 @@ public final class RemoteExceptions {
         }
 
         @Override
-        public void onFailure(Throwable t) {
-            log.info("Canceled call failed", t);
+        public void onFailure(Throwable throwable) {
+            log.info("Canceled call failed", throwable);
         }
     }
 }


### PR DESCRIPTION
==COMMIT_MSG==
Interrupted calls properly close resources
==COMMIT_MSG==
