### PR TITLE
Migrate some logic from generated code into the runtime library

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,15 @@
+versionOverrides: {}
+acceptedBreaks:
+  "0.12.1":
+    com.palantir.dialogue:dialogue-apache-hc4-client: []
+    com.palantir.dialogue:dialogue-blocking-channels: []
+    com.palantir.dialogue:dialogue-core: []
+    com.palantir.dialogue:dialogue-httpurlconnection-client: []
+    com.palantir.dialogue:dialogue-java-client: []
+    com.palantir.dialogue:dialogue-okhttp-client: []
+    com.palantir.dialogue:dialogue-serde: []
+    com.palantir.dialogue:dialogue-target:
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method com.palantir.dialogue.Clients com.palantir.dialogue.ConjureRuntime::clients()"
+      justification: "alpha software, runtime not meant for extension"

--- a/changelog/@unreleased/pr-475.v2.yml
+++ b/changelog/@unreleased/pr-475.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Migrate some logic from generated code into the runtime library
+  links:
+  - https://github.com/palantir/dialogue/pull/475

--- a/dialogue-example/src/main/java/com/palantir/dialogue/example/SampleServiceClient.java
+++ b/dialogue-example/src/main/java/com/palantir/dialogue/example/SampleServiceClient.java
@@ -135,15 +135,14 @@ public final class SampleServiceClient {
                         .body(sampleObjectToSampleObjectSerializer.serialize(body))
                         .build();
                 return runtime.clients()
-                        .blocking(runtime.clients()
+                        .block(runtime.clients()
                                 .call(channel, STRING_TO_STRING, request, sampleObjectToSampleObjectDeserializer));
             }
 
             @Override
             public void voidToVoid() {
                 Request request = Request.builder().build();
-                runtime.clients()
-                        .blocking(runtime.clients().call(channel, VOID_TO_VOID, request, voidToVoidDeserializer));
+                runtime.clients().block(runtime.clients().call(channel, VOID_TO_VOID, request, voidToVoidDeserializer));
             }
         };
     }

--- a/dialogue-example/src/main/java/com/palantir/dialogue/example/SampleServiceClient.java
+++ b/dialogue-example/src/main/java/com/palantir/dialogue/example/SampleServiceClient.java
@@ -135,13 +135,15 @@ public final class SampleServiceClient {
                         .body(sampleObjectToSampleObjectSerializer.serialize(body))
                         .build();
                 return runtime.clients()
-                        .blocking(channel, STRING_TO_STRING, request, sampleObjectToSampleObjectDeserializer);
+                        .blocking(runtime.clients()
+                                .call(channel, STRING_TO_STRING, request, sampleObjectToSampleObjectDeserializer));
             }
 
             @Override
             public void voidToVoid() {
                 Request request = Request.builder().build();
-                runtime.clients().blocking(channel, VOID_TO_VOID, request, voidToVoidDeserializer);
+                runtime.clients()
+                        .blocking(runtime.clients().call(channel, VOID_TO_VOID, request, voidToVoidDeserializer));
             }
         };
     }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Clients;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.RemoteExceptions;
+import com.palantir.dialogue.Request;
+
+enum DefaultClients implements Clients {
+    INSTANCE;
+
+    @Override
+    public <T> ListenableFuture<T> call(
+            Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer) {
+        return Futures.transform(
+                channel.execute(endpoint, request), deserializer::deserialize, MoreExecutors.directExecutor());
+    }
+
+    @Override
+    public <T> T blocking(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer) {
+        ListenableFuture<T> call = call(channel, endpoint, request, deserializer);
+        return RemoteExceptions.getUnchecked(call);
+    }
+}

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -38,8 +38,8 @@ enum DefaultClients implements Clients {
     }
 
     @Override
-    public <T> T blocking(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer) {
-        ListenableFuture<T> call = call(channel, endpoint, request, deserializer);
-        return RemoteExceptions.getUnchecked(call);
+    public <T> T blocking(ListenableFuture<T> future) {
+        // TODO(ckozak): remove RemoteExceptions from the codegen target module.
+        return RemoteExceptions.getUnchecked(future);
     }
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -38,7 +38,7 @@ enum DefaultClients implements Clients {
     }
 
     @Override
-    public <T> T blocking(ListenableFuture<T> future) {
+    public <T> T block(ListenableFuture<T> future) {
         // TODO(ckozak): remove RemoteExceptions from the codegen target module.
         return RemoteExceptions.getUnchecked(future);
     }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -26,6 +26,7 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.RemoteExceptions;
 import com.palantir.dialogue.Request;
 
+/** Package private internal API. */
 enum DefaultClients implements Clients {
     INSTANCE;
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.dialogue.serde;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.palantir.dialogue.BodySerDe;
+import com.palantir.dialogue.Clients;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.PlainSerDe;
 import com.palantir.logsafe.Preconditions;
@@ -50,6 +51,11 @@ public final class DefaultConjureRuntime implements ConjureRuntime {
     @Override
     public PlainSerDe plainSerDe() {
         return ConjurePlainSerDe.INSTANCE;
+    }
+
+    @Override
+    public Clients clients() {
+        return DefaultClients.INSTANCE;
     }
 
     public static final class Builder {

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class DefaultClientsTest {
+
+    @Mock
+    private Channel channel;
+
+    @Mock
+    private Endpoint endpoint;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private Deserializer<String> deserializer;
+
+    @Test
+    public void testAsync() throws ExecutionException, InterruptedException {
+        Request request = Request.builder().build();
+        when(deserializer.deserialize(eq(response))).thenReturn("value");
+        SettableFuture<Response> responseFuture = SettableFuture.create();
+        when(channel.execute(eq(endpoint), eq(request))).thenReturn(responseFuture);
+        ListenableFuture<String> result = DefaultClients.INSTANCE.call(channel, endpoint, request, deserializer);
+        assertThat(result).isNotDone();
+        responseFuture.set(response);
+        assertThat(result).isDone();
+        assertThat(result.get()).isEqualTo("value");
+    }
+
+    @Test
+    public void testBlocking() {
+        Request request = Request.builder().build();
+        when(deserializer.deserialize(eq(response))).thenReturn("value");
+        when(channel.execute(eq(endpoint), eq(request))).thenReturn(Futures.immediateFuture(response));
+        assertThat(DefaultClients.INSTANCE.blocking(channel, endpoint, request, deserializer))
+                .isEqualTo("value");
+    }
+}

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Channel;
@@ -50,7 +49,7 @@ public final class DefaultClientsTest {
     private Deserializer<String> deserializer;
 
     @Test
-    public void testAsync() throws ExecutionException, InterruptedException {
+    public void testCall() throws ExecutionException, InterruptedException {
         Request request = Request.builder().build();
         when(deserializer.deserialize(eq(response))).thenReturn("value");
         SettableFuture<Response> responseFuture = SettableFuture.create();
@@ -60,14 +59,5 @@ public final class DefaultClientsTest {
         responseFuture.set(response);
         assertThat(result).isDone();
         assertThat(result.get()).isEqualTo("value");
-    }
-
-    @Test
-    public void testBlocking() {
-        Request request = Request.builder().build();
-        when(deserializer.deserialize(eq(response))).thenReturn("value");
-        when(channel.execute(eq(endpoint), eq(request))).thenReturn(Futures.immediateFuture(response));
-        assertThat(DefaultClients.INSTANCE.blocking(channel, endpoint, request, deserializer))
-                .isEqualTo("value");
     }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
@@ -18,9 +18,22 @@ package com.palantir.dialogue;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+/**
+ * Provides functionality for generated code to make both blocking and asynchronous calls without
+ * duplicating logic.
+ */
 public interface Clients {
 
+    /**
+     * Makes a request to the specified {@link Endpoint} and deserializes the response using a provided deserializer.
+     */
     <T> ListenableFuture<T> call(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
 
+    /**
+     * Semantics match {@link #call(Channel, Endpoint, Request, Deserializer)} but also blocks until
+     * the {@link ListenableFuture} has completed for blocking clients.
+     * This approach is used instead of using a separate method to block on a single future to simplify
+     * otherwise redundant generated code.
+     */
     <T> T blocking(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import java.util.concurrent.Future;
 
 /**
  * Provides functionality for generated code to make both blocking and asynchronous calls without
@@ -30,10 +31,8 @@ public interface Clients {
     <T> ListenableFuture<T> call(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
 
     /**
-     * Semantics match {@link #call(Channel, Endpoint, Request, Deserializer)} but also blocks until
-     * the {@link ListenableFuture} has completed for blocking clients.
-     * This approach is used instead of using a separate method to block on a single future to simplify
-     * otherwise redundant generated code.
+     * Similar to {@link com.google.common.util.concurrent.Futures#getUnchecked(Future)}, except with custom handling
+     * for conjure exceptions and cancellation on interruption.
      */
-    <T> T blocking(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
+    <T> T blocking(ListenableFuture<T> future);
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface Clients {
+
+    <T> ListenableFuture<T> call(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
+
+    <T> T blocking(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
+}

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
@@ -34,5 +34,5 @@ public interface Clients {
      * Similar to {@link com.google.common.util.concurrent.Futures#getUnchecked(Future)}, except with custom handling
      * for conjure exceptions and cancellation on interruption.
      */
-    <T> T blocking(ListenableFuture<T> future);
+    <T> T block(ListenableFuture<T> future);
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/ConjureRuntime.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/ConjureRuntime.java
@@ -29,4 +29,7 @@ public interface ConjureRuntime {
 
     /** Provides the {@link PlainSerDe} used to parse request path, query, and header parameters. */
     PlainSerDe plainSerDe();
+
+    /** Provides the {@link Clients} used to facilitate making requests. */
+    Clients clients();
 }


### PR DESCRIPTION
This approach tends to be easier to support, and safer to fix with
library upgrades.
Code reuse should be preferred over excessive generation because
it produces more readable code which the JVM is able to optimize
more efficiently.

## After this PR
==COMMIT_MSG==
Migrate some logic from generated code into the runtime library
==COMMIT_MSG==
