### PR TITLE
Remove unused methods from PlainSerDe

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -26,3 +26,120 @@ acceptedBreaks:
       old: "class com.palantir.dialogue.RemoteExceptions"
       new: null
       justification: "alpha"
+  "0.12.3":
+    com.palantir.dialogue:dialogue-apache-hc4-client: []
+    com.palantir.dialogue:dialogue-blocking-channels: []
+    com.palantir.dialogue:dialogue-core: []
+    com.palantir.dialogue:dialogue-httpurlconnection-client: []
+    com.palantir.dialogue:dialogue-java-client: []
+    com.palantir.dialogue:dialogue-okhttp-client: []
+    com.palantir.dialogue:dialogue-serde: []
+    com.palantir.dialogue:dialogue-target:
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeBearerTokenList(java.util.List<com.palantir.tokens.auth.BearerToken>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeBearerTokenSet(java.util.Set<com.palantir.tokens.auth.BearerToken>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeBooleanList(java.util.List<java.lang.Boolean>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeBooleanSet(java.util.Set<java.lang.Boolean>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeDateTimeList(java.util.List<java.time.OffsetDateTime>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeDateTimeSet(java.util.Set<java.time.OffsetDateTime>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeDoubleList(java.util.List<java.lang.Double>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeDoubleSet(java.util.Set<java.lang.Double>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeIntegerList(java.util.List<java.lang.Integer>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeIntegerSet(java.util.Set<java.lang.Integer>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeRidList(java.util.List<com.palantir.ri.ResourceIdentifier>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeRidSet(java.util.Set<com.palantir.ri.ResourceIdentifier>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeSafeLongList(java.util.List<com.palantir.conjure.java.lib.SafeLong>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeSafeLongSet(java.util.Set<com.palantir.conjure.java.lib.SafeLong>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeStringList(java.util.List<java.lang.String>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeStringSet(java.util.Set<java.lang.String>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeUuidList(java.util.List<java.util.UUID>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.List<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeUuidSet(java.util.Set<java.util.UUID>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalBearerToken(java.util.Optional<com.palantir.tokens.auth.BearerToken>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalBoolean(java.util.Optional<java.lang.Boolean>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalDateTime(java.util.Optional<java.time.OffsetDateTime>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalDouble(java.util.OptionalDouble)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalInteger(java.util.OptionalInt)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalRid(java.util.Optional<com.palantir.ri.ResourceIdentifier>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalSafeLong(java.util.Optional<com.palantir.conjure.java.lib.SafeLong>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalString(java.util.Optional<java.lang.String>)"
+      new: null
+      justification: "unused methods"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalUuid(java.util.Optional<java.util.UUID>)"
+      new: null
+      justification: "unused methods"

--- a/changelog/@unreleased/pr-479.v2.yml
+++ b/changelog/@unreleased/pr-479.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Remove unused methods from PlainSerDe
+  links:
+  - https://github.com/palantir/dialogue/pull/479

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjurePlainSerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjurePlainSerDe.java
@@ -21,15 +21,7 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
 
 /** Package private internal API. */
 enum ConjurePlainSerDe implements PlainSerDe {
@@ -41,38 +33,8 @@ enum ConjurePlainSerDe implements PlainSerDe {
     }
 
     @Override
-    public Optional<String> serializeOptionalBearerToken(Optional<BearerToken> in) {
-        return in.map(this::serializeBearerToken);
-    }
-
-    @Override
-    public List<String> serializeBearerTokenList(List<BearerToken> in) {
-        return toList(in, this::serializeBearerToken);
-    }
-
-    @Override
-    public List<String> serializeBearerTokenSet(Set<BearerToken> in) {
-        return toList(in, this::serializeBearerToken);
-    }
-
-    @Override
     public String serializeBoolean(boolean in) {
         return in ? "true" : "false";
-    }
-
-    @Override
-    public Optional<String> serializeOptionalBoolean(Optional<Boolean> in) {
-        return in.map(this::serializeBoolean);
-    }
-
-    @Override
-    public List<String> serializeBooleanList(List<Boolean> in) {
-        return toList(in, this::serializeBoolean);
-    }
-
-    @Override
-    public List<String> serializeBooleanSet(Set<Boolean> in) {
-        return toList(in, this::serializeBoolean);
     }
 
     @Override
@@ -81,38 +43,8 @@ enum ConjurePlainSerDe implements PlainSerDe {
     }
 
     @Override
-    public Optional<String> serializeOptionalDateTime(Optional<OffsetDateTime> in) {
-        return in.map(this::serializeDateTime);
-    }
-
-    @Override
-    public List<String> serializeDateTimeList(List<OffsetDateTime> in) {
-        return toList(in, this::serializeDateTime);
-    }
-
-    @Override
-    public List<String> serializeDateTimeSet(Set<OffsetDateTime> in) {
-        return toList(in, this::serializeDateTime);
-    }
-
-    @Override
     public String serializeDouble(double in) {
         return Double.toString(in);
-    }
-
-    @Override
-    public Optional<String> serializeOptionalDouble(OptionalDouble in) {
-        return in.isPresent() ? Optional.of(serializeDouble(in.getAsDouble())) : Optional.empty();
-    }
-
-    @Override
-    public List<String> serializeDoubleList(List<Double> in) {
-        return toList(in, this::serializeDouble);
-    }
-
-    @Override
-    public List<String> serializeDoubleSet(Set<Double> in) {
-        return toList(in, this::serializeDouble);
     }
 
     @Override
@@ -121,38 +53,8 @@ enum ConjurePlainSerDe implements PlainSerDe {
     }
 
     @Override
-    public Optional<String> serializeOptionalInteger(OptionalInt in) {
-        return in.isPresent() ? Optional.of(serializeInteger(in.getAsInt())) : Optional.empty();
-    }
-
-    @Override
-    public List<String> serializeIntegerList(List<Integer> in) {
-        return toList(in, this::serializeInteger);
-    }
-
-    @Override
-    public List<String> serializeIntegerSet(Set<Integer> in) {
-        return toList(in, this::serializeInteger);
-    }
-
-    @Override
     public String serializeRid(ResourceIdentifier in) {
         return in.toString();
-    }
-
-    @Override
-    public Optional<String> serializeOptionalRid(Optional<ResourceIdentifier> in) {
-        return in.map(this::serializeRid);
-    }
-
-    @Override
-    public List<String> serializeRidList(List<ResourceIdentifier> in) {
-        return toList(in, this::serializeRid);
-    }
-
-    @Override
-    public List<String> serializeRidSet(Set<ResourceIdentifier> in) {
-        return toList(in, this::serializeRid);
     }
 
     @Override
@@ -161,65 +63,12 @@ enum ConjurePlainSerDe implements PlainSerDe {
     }
 
     @Override
-    public Optional<String> serializeOptionalSafeLong(Optional<SafeLong> in) {
-        return in.map(this::serializeSafeLong);
-    }
-
-    @Override
-    public List<String> serializeSafeLongList(List<SafeLong> in) {
-        return toList(in, this::serializeSafeLong);
-    }
-
-    @Override
-    public List<String> serializeSafeLongSet(Set<SafeLong> in) {
-        return toList(in, this::serializeSafeLong);
-    }
-
-    @Override
     public String serializeString(String in) {
         return in;
     }
 
     @Override
-    public Optional<String> serializeOptionalString(Optional<String> in) {
-        return in;
-    }
-
-    @Override
-    public List<String> serializeStringList(List<String> in) {
-        return in;
-    }
-
-    @Override
-    public List<String> serializeStringSet(Set<String> in) {
-        return new ArrayList<>(in);
-    }
-
-    @Override
     public String serializeUuid(UUID in) {
         return in.toString();
-    }
-
-    @Override
-    public Optional<String> serializeOptionalUuid(Optional<UUID> in) {
-        return in.map(this::serializeUuid);
-    }
-
-    @Override
-    public List<String> serializeUuidList(List<UUID> in) {
-        return toList(in, this::serializeUuid);
-    }
-
-    @Override
-    public List<String> serializeUuidSet(Set<UUID> in) {
-        return toList(in, this::serializeUuid);
-    }
-
-    private static <T> List<String> toList(Collection<T> in, Function<T, String> toString) {
-        List<String> out = new ArrayList<>(in.size());
-        for (T i : in) {
-            out.add(toString.apply(i));
-        }
-        return out;
     }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/PlainSerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/PlainSerDeTest.java
@@ -18,17 +18,12 @@ package com.palantir.conjure.java.dialogue.serde;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.dialogue.PlainSerDe;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
@@ -42,9 +37,6 @@ public final class PlainSerDeTest {
         BearerToken in = BearerToken.valueOf("token");
         String out = "token";
         assertThat(PLAIN.serializeBearerToken(in)).isEqualTo(out);
-        assertThat(PLAIN.serializeOptionalBearerToken(Optional.of(in))).isEqualTo(Optional.of(out));
-        assertThat(PLAIN.serializeBearerTokenList(ImmutableList.of(in))).containsExactly(out);
-        assertThat(PLAIN.serializeBearerTokenSet(ImmutableSet.of(in))).containsExactly(out);
     }
 
     @Test
@@ -53,9 +45,6 @@ public final class PlainSerDeTest {
             boolean in = inOut.getLeft();
             String out = inOut.getRight();
             assertThat(PLAIN.serializeBoolean(in)).isEqualTo(out);
-            assertThat(PLAIN.serializeOptionalBoolean(Optional.of(in))).isEqualTo(Optional.of(out));
-            assertThat(PLAIN.serializeBooleanList(ImmutableList.of(in))).containsExactly(out);
-            assertThat(PLAIN.serializeBooleanSet(ImmutableSet.of(in))).containsExactly(out);
         }
     }
 
@@ -64,9 +53,6 @@ public final class PlainSerDeTest {
         OffsetDateTime in = OffsetDateTime.parse("2018-07-19T08:11:21+00:00");
         String out = "2018-07-19T08:11:21Z";
         assertThat(PLAIN.serializeDateTime(in)).isEqualTo(out);
-        assertThat(PLAIN.serializeOptionalDateTime(Optional.of(in))).isEqualTo(Optional.of(out));
-        assertThat(PLAIN.serializeDateTimeList(ImmutableList.of(in))).containsExactly(out);
-        assertThat(PLAIN.serializeDateTimeSet(ImmutableSet.of(in))).containsExactly(out);
     }
 
     @Test
@@ -75,9 +61,6 @@ public final class PlainSerDeTest {
             double in = inOut.getLeft();
             String out = inOut.getRight();
             assertThat(PLAIN.serializeDouble(in)).isEqualTo(out);
-            assertThat(PLAIN.serializeOptionalDouble(OptionalDouble.of(in))).isEqualTo(Optional.of(out));
-            assertThat(PLAIN.serializeDoubleList(ImmutableList.of(in))).containsExactly(out);
-            assertThat(PLAIN.serializeDoubleSet(ImmutableSet.of(in))).containsExactly(out);
         }
     }
 
@@ -87,9 +70,6 @@ public final class PlainSerDeTest {
             int in = inOut.getLeft();
             String out = inOut.getRight();
             assertThat(PLAIN.serializeInteger(in)).isEqualTo(out);
-            assertThat(PLAIN.serializeOptionalInteger(OptionalInt.of(in))).isEqualTo(Optional.of(out));
-            assertThat(PLAIN.serializeIntegerList(ImmutableList.of(in))).containsExactly(out);
-            assertThat(PLAIN.serializeIntegerSet(ImmutableSet.of(in))).containsExactly(out);
         }
     }
 
@@ -98,9 +78,6 @@ public final class PlainSerDeTest {
         ResourceIdentifier in = ResourceIdentifier.of("ri.service.instance.folder.foo");
         String out = "ri.service.instance.folder.foo";
         assertThat(PLAIN.serializeRid(in)).isEqualTo(out);
-        assertThat(PLAIN.serializeOptionalRid(Optional.of(in))).isEqualTo(Optional.of(out));
-        assertThat(PLAIN.serializeRidList(ImmutableList.of(in))).containsExactly(out);
-        assertThat(PLAIN.serializeRidSet(ImmutableSet.of(in))).containsExactly(out);
     }
 
     @Test
@@ -108,9 +85,6 @@ public final class PlainSerDeTest {
         SafeLong in = SafeLong.of(9007199254740990L);
         String out = "9007199254740990";
         assertThat(PLAIN.serializeSafeLong(in)).isEqualTo(out);
-        assertThat(PLAIN.serializeOptionalSafeLong(Optional.of(in))).isEqualTo(Optional.of(out));
-        assertThat(PLAIN.serializeSafeLongList(ImmutableList.of(in))).containsExactly(out);
-        assertThat(PLAIN.serializeSafeLongSet(ImmutableSet.of(in))).containsExactly(out);
     }
 
     @Test
@@ -118,9 +92,6 @@ public final class PlainSerDeTest {
         String in = "hello world!";
         String out = "hello world!";
         assertThat(PLAIN.serializeString(in)).isEqualTo(out);
-        assertThat(PLAIN.serializeOptionalString(Optional.of(in))).isEqualTo(Optional.of(out));
-        assertThat(PLAIN.serializeStringList(ImmutableList.of(in))).containsExactly(out);
-        assertThat(PLAIN.serializeStringSet(ImmutableSet.of(in))).containsExactly(out);
     }
 
     @Test
@@ -128,8 +99,5 @@ public final class PlainSerDeTest {
         UUID in = UUID.fromString("90a8481a-2ef5-4c64-83fc-04a9b369e2b8");
         String out = "90a8481a-2ef5-4c64-83fc-04a9b369e2b8";
         assertThat(PLAIN.serializeUuid(in)).isEqualTo(out);
-        assertThat(PLAIN.serializeOptionalUuid(Optional.of(in))).isEqualTo(Optional.of(out));
-        assertThat(PLAIN.serializeUuidList(ImmutableList.of(in))).containsExactly(out);
-        assertThat(PLAIN.serializeUuidSet(ImmutableSet.of(in))).containsExactly(out);
     }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/PlainSerDe.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/PlainSerDe.java
@@ -20,11 +20,6 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -37,73 +32,19 @@ public interface PlainSerDe {
 
     String serializeBearerToken(BearerToken in);
 
-    Optional<String> serializeOptionalBearerToken(Optional<BearerToken> in);
-
-    List<String> serializeBearerTokenList(List<BearerToken> in);
-
-    List<String> serializeBearerTokenSet(Set<BearerToken> in);
-
     String serializeBoolean(boolean in);
-
-    Optional<String> serializeOptionalBoolean(Optional<Boolean> in);
-
-    List<String> serializeBooleanList(List<Boolean> in);
-
-    List<String> serializeBooleanSet(Set<Boolean> in);
 
     String serializeDateTime(OffsetDateTime in);
 
-    Optional<String> serializeOptionalDateTime(Optional<OffsetDateTime> in);
-
-    List<String> serializeDateTimeList(List<OffsetDateTime> in);
-
-    List<String> serializeDateTimeSet(Set<OffsetDateTime> in);
-
     String serializeDouble(double in);
-
-    Optional<String> serializeOptionalDouble(OptionalDouble in);
-
-    List<String> serializeDoubleList(List<Double> in);
-
-    List<String> serializeDoubleSet(Set<Double> in);
 
     String serializeInteger(int in);
 
-    Optional<String> serializeOptionalInteger(OptionalInt in);
-
-    List<String> serializeIntegerList(List<Integer> in);
-
-    List<String> serializeIntegerSet(Set<Integer> in);
-
     String serializeRid(ResourceIdentifier in);
-
-    Optional<String> serializeOptionalRid(Optional<ResourceIdentifier> in);
-
-    List<String> serializeRidList(List<ResourceIdentifier> in);
-
-    List<String> serializeRidSet(Set<ResourceIdentifier> in);
 
     String serializeSafeLong(SafeLong in);
 
-    Optional<String> serializeOptionalSafeLong(Optional<SafeLong> in);
-
-    List<String> serializeSafeLongList(List<SafeLong> in);
-
-    List<String> serializeSafeLongSet(Set<SafeLong> in);
-
     String serializeString(String in);
 
-    Optional<String> serializeOptionalString(Optional<String> in);
-
-    List<String> serializeStringList(List<String> in);
-
-    List<String> serializeStringSet(Set<String> in);
-
     String serializeUuid(UUID in);
-
-    Optional<String> serializeOptionalUuid(Optional<UUID> in);
-
-    List<String> serializeUuidList(List<UUID> in);
-
-    List<String> serializeUuidSet(Set<UUID> in);
 }


### PR DESCRIPTION
List and Set serializers:
Generated code uses loops in order to handle nonstandard types,
aliases and external type imports. A subset of cases could be
updated to use these specific methods, but it would increase
complexity of the generator, and require more specific test coverage.
The loop-based approach has the fringe benefit of avoiding
intermediate collection allocation, relying on the builders internal
state instead.

Optional serializers:
The request object does not support optional values, so writes
to the request builder always involve checking optional.isPresent
before calling standard serializers on the result of optional.get.
The optional serializer methods aren't currently used, nor would
they reduce the complexity of the generated code if they were.

## After this PR
==COMMIT_MSG==
Remove unused methods from PlainSerDe
==COMMIT_MSG==

## Possible downsides?
break
