### PR TITLE
fixes #468: Dialogue clients send Accept headers

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -159,3 +159,10 @@ acceptedBreaks:
       old: "method java.util.Optional<java.lang.String> com.palantir.dialogue.PlainSerDe::serializeOptionalUuid(java.util.Optional<java.util.UUID>)"
       new: null
       justification: "unused methods"
+  "0.13.0":
+    com.palantir.dialogue:dialogue-blocking-channels: []
+    com.palantir.dialogue:dialogue-target:
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method com.palantir.dialogue.Deserializer<java.io.InputStream> com.palantir.dialogue.BodySerDe::inputStreamDeserializer()"
+      justification: "fixin' apis"

--- a/changelog/@unreleased/pr-482.v2.yml
+++ b/changelog/@unreleased/pr-482.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue clients send Accept headers
+  links:
+  - https://github.com/palantir/dialogue/pull/482

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/BinaryEncoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/BinaryEncoding.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import java.io.InputStream;
+
+/**
+ * Package-private internal api.
+ * This partial Encoding implementation exists to allow binary responses to share the same safety
+ * and validation provided by structured encodings. This is only consumed internally to create
+ * a binary-specific <pre>EncodingDeserializerRegistry</pre>.
+ */
+enum BinaryEncoding implements Encoding {
+    INSTANCE;
+
+    static final String CONTENT_TYPE = "application/octet-stream";
+    static final TypeMarker<InputStream> MARKER = new TypeMarker<InputStream>() {};
+
+    @Override
+    public <T> Serializer<T> serializer(TypeMarker<T> _type) {
+        throw new UnsupportedOperationException("BinaryEncoding does not support serializers");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
+        Preconditions.checkArgument(
+                InputStream.class.equals(type.getType()),
+                "BinaryEncoding only supports InputStream",
+                SafeArg.of("requested", type));
+        return input -> (T) input;
+    }
+
+    @Override
+    public String getContentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public boolean supportsContentType(String contentType) {
+        return Encodings.matchesContentType(CONTENT_TYPE, contentType);
+    }
+}

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
@@ -73,12 +73,15 @@ public final class DefaultClientsTest {
 
     @Test
     public void testAddsAcceptHeader() throws ExecutionException, InterruptedException {
-        Request request = Request.builder().build();
-        when(deserializer.deserialize(eq(response))).thenReturn("value");
         String expectedAccept = "application/json";
+        Request request = Request.builder().build();
+
+        when(deserializer.deserialize(eq(response))).thenReturn("value");
         when(deserializer.accepts()).thenReturn(Optional.of(expectedAccept));
         when(channel.execute(eq(endpoint), any())).thenReturn(Futures.immediateFuture(response));
+
         ListenableFuture<String> result = DefaultClients.INSTANCE.call(channel, endpoint, request, deserializer);
+
         assertThat(result).isDone();
         assertThat(result.get()).isEqualTo("value");
         verify(channel).execute(eq(endpoint), requestCaptor.capture());

--- a/dialogue-target/src/main/java/com/palantir/dialogue/BodySerDe.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BodySerDe.java
@@ -32,6 +32,14 @@ public interface BodySerDe {
      */
     Deserializer<Void> emptyBodyDeserializer();
 
+    /**
+     * Returns a {@link Deserializer} that reads an {@link InputStream} from the {@link Response} body.
+     * <p>
+     * This method is named <pre>inputStreamDeserializer</pre> not <pre>binaryDeserializer</pre>
+     * to support future streaming binary bindings without conflicting method signatures.
+     */
+    Deserializer<InputStream> inputStreamDeserializer();
+
     /** Serializes a {@link BinaryRequestBody} to <pre>application/octet-stream</pre>. */
     RequestBody serialize(BinaryRequestBody value);
 
@@ -40,6 +48,11 @@ public interface BodySerDe {
      * <p>
      * This method is named <pre>deserializeInputStream</pre> not <pre>deserializeBinary</pre>
      * to support future streaming binary bindings without conflicting method signatures.
+     *
+     * @deprecated Prefer {@link #inputStreamDeserializer()}
      */
-    InputStream deserializeInputStream(Response response);
+    @Deprecated
+    default InputStream deserializeInputStream(Response response) {
+        return inputStreamDeserializer().deserialize(response);
+    }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Deserializer.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Deserializer.java
@@ -29,5 +29,9 @@ public interface Deserializer<T> {
      * Values are structured for the <pre>Accept</pre> header based
      * on <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">rfc 7231 section 5.3.2</a>.
      */
-    Optional<String> accepts();
+    default Optional<String> accepts() {
+        // TODO(ckozak): This should not be a functional interface. This method is default
+        // only to allow the generator to be updated to avoid deserializer method references.
+        return Optional.empty();
+    }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Deserializer.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Deserializer.java
@@ -16,9 +16,18 @@
 
 package com.palantir.dialogue;
 
+import java.util.Optional;
+
 /** Reads objects from a response. */
 public interface Deserializer<T> {
 
     /** Deserializes the response body. */
     T deserialize(Response response);
+
+    /**
+     * Returns the content types this deserializer accepts, if any.
+     * Values are structured for the <pre>Accept</pre> header based
+     * on <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">rfc 7231 section 5.3.2</a>.
+     */
+    Optional<String> accepts();
 }


### PR DESCRIPTION
## Before this PR
1. Clients violate the conjure specification by excluding Accept headers.
2. Endpoints which return `binary` failed to parse errors, instead producing an illegal argument exception "Unsupported Content-Type" (with no response status check).

## After this PR
==COMMIT_MSG==
Dialogue clients send Accept headers
==COMMIT_MSG==

## Possible downsides?
api churn
