### PR TITLE
Support weighted encodings

### DIFF
--- a/changelog/@unreleased/pr-493.v2.yml
+++ b/changelog/@unreleased/pr-493.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support weighted encodings for `Accept` type preference.
+  links:
+  - https://github.com/palantir/dialogue/pull/493

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
@@ -22,7 +22,6 @@ import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.Clients;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.PlainSerDe;
-import com.palantir.logsafe.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -71,7 +70,7 @@ public final class DefaultConjureRuntime implements ConjureRuntime {
 
         @CanIgnoreReturnValue
         public Builder encodings(Encoding value) {
-            encodings.add(WeightedEncoding.of(Preconditions.checkNotNull(value, "Value is required")));
+            encodings.add(WeightedEncoding.of(value));
             return this;
         }
 
@@ -81,7 +80,7 @@ public final class DefaultConjureRuntime implements ConjureRuntime {
          */
         @CanIgnoreReturnValue
         public Builder encodings(Encoding value, double weight) {
-            encodings.add(WeightedEncoding.of(Preconditions.checkNotNull(value, "Value is required"), weight));
+            encodings.add(WeightedEncoding.of(value, weight));
             return this;
         }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
@@ -37,7 +37,10 @@ public final class DefaultConjureRuntime implements ConjureRuntime {
         this.bodySerDe = new ConjureBodySerDe(
                 // TODO(rfink): The default thing here is a little odd
                 builder.encodings.isEmpty()
-                        ? ImmutableList.of(Encodings.json(), Encodings.smile(), Encodings.cbor())
+                        ? ImmutableList.of(
+                                WeightedEncoding.of(Encodings.json(), 1),
+                                WeightedEncoding.of(Encodings.smile(), .9),
+                                WeightedEncoding.of(Encodings.cbor(), .7))
                         : builder.encodings);
     }
 
@@ -62,13 +65,23 @@ public final class DefaultConjureRuntime implements ConjureRuntime {
 
     public static final class Builder {
 
-        private final List<Encoding> encodings = new ArrayList<>();
+        private final List<WeightedEncoding> encodings = new ArrayList<>();
 
         private Builder() {}
 
         @CanIgnoreReturnValue
         public Builder encodings(Encoding value) {
-            encodings.add(Preconditions.checkNotNull(value, "Value is required"));
+            encodings.add(WeightedEncoding.of(Preconditions.checkNotNull(value, "Value is required")));
+            return this;
+        }
+
+        /**
+         * Register an {@link Encoding} with a weight value between zero and one (inclusive). The weight is used to
+         * determine preference in content-type negotiation.
+         */
+        @CanIgnoreReturnValue
+        public Builder encodings(Encoding value, double weight) {
+            encodings.add(WeightedEncoding.of(Preconditions.checkNotNull(value, "Value is required"), weight));
             return this;
         }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/WeightedEncoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/WeightedEncoding.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import com.palantir.logsafe.Preconditions;
+import java.util.Objects;
+
+/**
+ * Represents an encoding with a weight for <code>Accept</code> types.
+ * Note that the weight may not be applied to the Accept header, rather
+ * used to order values.
+ */
+final class WeightedEncoding {
+
+    private final Encoding encoding;
+    private final double weight;
+
+    private WeightedEncoding(Encoding encoding, double weight) {
+        this.encoding = Preconditions.checkNotNull(encoding, "Encoding is required");
+        this.weight = weight;
+        Preconditions.checkArgument(weight >= 0 && weight <= 1, "Weight must be between zero and one (inclusive)");
+    }
+
+    static WeightedEncoding of(Encoding encoding, double weight) {
+        return new WeightedEncoding(encoding, weight);
+    }
+
+    static WeightedEncoding of(Encoding encoding) {
+        return new WeightedEncoding(encoding, 1);
+    }
+
+    Encoding encoding() {
+        return encoding;
+    }
+
+    double weight() {
+        return weight;
+    }
+
+    @Override
+    public String toString() {
+        return "WeightedEncoding{encoding=" + encoding + ", weight=" + weight + '}';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        WeightedEncoding that = (WeightedEncoding) other;
+        return Double.compare(that.weight, weight) == 0 && encoding.equals(that.encoding);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(encoding, weight);
+    }
+}


### PR DESCRIPTION
==COMMIT_MSG==
Support weighted encodings for `Accept` type preference.
==COMMIT_MSG==
