### PR TITLE
handle uri removal in pin until error update

### DIFF
--- a/changelog/@unreleased/pr-497.v2.yml
+++ b/changelog/@unreleased/pr-497.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: handle uri removal in pin until error update
+  links:
+  - https://github.com/palantir/dialogue/pull/497

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
@@ -75,6 +75,10 @@ final class PinUntilErrorChannel implements LimitedChannel {
                 nodeList.size() >= 2,
                 "PinUntilError is pointless if you have zero or 1 channels."
                         + " Use an always throwing channel or just pick the only channel in the list.");
+        Preconditions.checkArgument(
+                0 <= initialHost && initialHost < nodeList.size(),
+                "initialHost must be a valid index into nodeList",
+                SafeArg.of("initialHost", initialHost));
     }
 
     static PinUntilErrorChannel of(
@@ -100,6 +104,7 @@ final class PinUntilErrorChannel implements LimitedChannel {
         ImmutableList<LimitedChannel> initialShuffle = shuffleImmutableList(channels, random);
         // We only rely on reference equality since we expect LimitedChannels to be reused across updates
         int initialHost = initialShuffle.indexOf(initialChannel);
+        initialHost = initialHost == -1 ? 0 : initialHost;
 
         switch (strategy) {
             case PIN_UNTIL_ERROR:

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.dialogue.Response;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.time.Duration;
@@ -167,6 +168,12 @@ public class PinUntilErrorChannelTest {
         when(channel1.maybeExecute(any(), any())).thenReturn(Optional.empty());
         setResponse(channel2, 204);
         assertThat(pinUntilError.maybeExecute(null, null)).isPresent();
+    }
+
+    @Test
+    void handles_reconstruction_from_stale_state() {
+        PinUntilErrorChannel.from(
+                null, NodeSelectionStrategy.PIN_UNTIL_ERROR, ImmutableList.of(channel1, channel2), metrics, pseudo);
     }
 
     private static int getCode(PinUntilErrorChannel channel) {


### PR DESCRIPTION
## Before this PR
We would fail to make the requests if the previously pinned uri was removed during uri update

## After this PR
==COMMIT_MSG==
handle uri removal in pin until error update
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
