### PR TITLE
Properly support optional empty response

### DIFF
--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/TypeMarkers.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/TypeMarkers.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+final class TypeMarkers {
+
+    static boolean isOptional(TypeMarker<?> marker) {
+        Type type = marker.getType();
+        if (OptionalDouble.class.equals(type) || OptionalInt.class.equals(type) || OptionalLong.class.equals(type)) {
+            return true;
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            return Optional.class.equals(parameterizedType.getRawType());
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T getEmptyOptional(TypeMarker<T> marker) {
+        Type type = marker.getType();
+        if (type instanceof ParameterizedType && Optional.class.equals(((ParameterizedType) type).getRawType())) {
+            return (T) Optional.empty();
+        } else if (OptionalDouble.class.equals(type)) {
+            return (T) OptionalDouble.empty();
+        } else if (OptionalInt.class.equals(type)) {
+            return (T) OptionalInt.empty();
+        } else if (OptionalLong.class.equals(type)) {
+            return (T) OptionalLong.empty();
+        }
+        throw new SafeIllegalArgumentException(
+                "Expected a TypeMarker representing an optional type", SafeArg.of("marker", marker));
+    }
+
+    private TypeMarkers() {}
+}

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -38,6 +38,7 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import javax.ws.rs.core.HttpHeaders;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +49,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class ConjureBodySerDeTest {
 
     private static final TypeMarker<String> TYPE = new TypeMarker<String>() {};
+    private static final TypeMarker<Optional<String>> OPTIONAL_TYPE = new TypeMarker<Optional<String>>() {};
 
     @Mock
     private ErrorDecoder errorDecoder;
@@ -63,6 +65,16 @@ public class ConjureBodySerDeTest {
                 new ConjureBodySerDe(ImmutableList.of(WeightedEncoding.of(json), WeightedEncoding.of(plain)));
         String value = serializers.deserializer(TYPE).deserialize(response);
         assertThat(value).isEqualTo(plain.getContentType());
+    }
+
+    @Test
+    public void testRequestOptionalEmpty() {
+        TestResponse response = new TestResponse();
+        response.code = 204;
+        BodySerDe serializers =
+                new ConjureBodySerDe(ImmutableList.of(WeightedEncoding.of(new StubEncoding("application/json"))));
+        Optional<String> value = serializers.deserializer(OPTIONAL_TYPE).deserialize(response);
+        assertThat(value).isEmpty();
     }
 
     @Test

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/TypeMarkersTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/TypeMarkersTest.java
@@ -1,0 +1,95 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import org.junit.Test;
+
+public class TypeMarkersTest {
+
+    @Test
+    public void testIsOptional_optional() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<Optional<String>>() {}))
+                .isTrue();
+    }
+
+    @Test
+    public void testIsOptional_optionalDouble() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<OptionalDouble>() {})).isTrue();
+    }
+
+    @Test
+    public void testIsOptional_optionalLong() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<OptionalLong>() {})).isTrue();
+    }
+
+    @Test
+    public void testIsOptional_optionalInt() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<OptionalInt>() {})).isTrue();
+    }
+
+    @Test
+    public void testIsOptional_object() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<Object>() {})).isFalse();
+    }
+
+    @Test
+    public void testIsOptional_listOptional() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<List<Optional<String>>>() {}))
+                .isFalse();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optional() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<Optional<String>>() {}))
+                .isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optionalDouble() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<OptionalDouble>() {}))
+                .isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optionalLong() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<OptionalLong>() {}))
+                .isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optionalInt() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<OptionalInt>() {}))
+                .isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_notOptionalType() {
+        assertThatLoggableExceptionThrownBy(() -> TypeMarkers.getEmptyOptional(new TypeMarker<String>() {}))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasLogMessage("Expected a TypeMarker representing an optional type");
+    }
+}


### PR DESCRIPTION
## Before this PR
We would throw if a server responded with a 204

## After this PR
==COMMIT_MSG==
Handle 204s when the expected response type is an optional
==COMMIT_MSG==

We do not properly support cases where a server responds with a 204 but the response type is an alias or any other collection. In practice, it does not seem that any server follows the recommendation of the conjure spec

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
