### PR TITLE
Dialogue supports optional binary responses

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -221,3 +221,17 @@ acceptedBreaks:
     com.palantir.dialogue:dialogue-okhttp-client: []
     com.palantir.dialogue:dialogue-serde: []
     com.palantir.dialogue:dialogue-target: []
+  "0.18.0":
+    com.palantir.dialogue:dialogue-apache-hc4-client: []
+    com.palantir.dialogue:dialogue-blocking-channels: []
+    com.palantir.dialogue:dialogue-core: []
+    com.palantir.dialogue:dialogue-httpurlconnection-client: []
+    com.palantir.dialogue:dialogue-java-client: []
+    com.palantir.dialogue:dialogue-okhttp-client: []
+    com.palantir.dialogue:dialogue-serde: []
+    com.palantir.dialogue:dialogue-target:
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method com.palantir.dialogue.Deserializer<java.util.Optional<java.io.InputStream>>\
+        \ com.palantir.dialogue.BodySerDe::optionalInputStreamDeserializer()"
+      justification: "ConjureBodySerDe is not meant for extension"

--- a/changelog/@unreleased/pr-501.v2.yml
+++ b/changelog/@unreleased/pr-501.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue supports optional binary responses using a new method on ConjureBodySerDe
+    which must be used by generated code.
+  links:
+  - https://github.com/palantir/dialogue/pull/501

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -47,6 +47,7 @@ final class ConjureBodySerDe implements BodySerDe {
     private final ErrorDecoder errorDecoder;
     private final Encoding defaultEncoding;
     private final Deserializer<InputStream> binaryInputStreamDeserializer;
+    private final Deserializer<Optional<InputStream>> optionalBinaryInputStreamDeserializer;
 
     /**
      * Selects the first (based on input order) of the provided encodings that
@@ -65,6 +66,8 @@ final class ConjureBodySerDe implements BodySerDe {
         this.defaultEncoding = encodings.get(0).encoding();
         this.binaryInputStreamDeserializer = new EncodingDeserializerRegistry<>(
                 ImmutableList.of(BinaryEncoding.INSTANCE), errorDecoder, BinaryEncoding.MARKER);
+        this.optionalBinaryInputStreamDeserializer = new EncodingDeserializerRegistry<>(
+                ImmutableList.of(BinaryEncoding.INSTANCE), errorDecoder, BinaryEncoding.OPTIONAL_MARKER);
     }
 
     private ImmutableList<Encoding> sortByWeight(List<WeightedEncoding> encodings) {
@@ -93,6 +96,11 @@ final class ConjureBodySerDe implements BodySerDe {
     @Override
     public Deserializer<InputStream> inputStreamDeserializer() {
         return binaryInputStreamDeserializer;
+    }
+
+    @Override
+    public Deserializer<Optional<InputStream>> optionalInputStreamDeserializer() {
+        return optionalBinaryInputStreamDeserializer;
     }
 
     @Override

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -165,6 +165,37 @@ public class ConjureBodySerDeTest {
                 .isThrownBy(() -> serializers.deserializer(TYPE).deserialize(response));
     }
 
+    @Test
+    public void testBinary() {
+        TestResponse response = new TestResponse();
+        response.code = 200;
+        response.contentType("application/octet-stream");
+        BodySerDe serializers =
+                new ConjureBodySerDe(ImmutableList.of(WeightedEncoding.of(new StubEncoding("application/json"))));
+        assertThat(serializers.inputStreamDeserializer().deserialize(response)).hasContent("");
+    }
+
+    @Test
+    public void testBinary_optional_present() {
+        TestResponse response = new TestResponse();
+        response.code = 200;
+        response.contentType("application/octet-stream");
+        BodySerDe serializers =
+                new ConjureBodySerDe(ImmutableList.of(WeightedEncoding.of(new StubEncoding("application/json"))));
+        assertThat(serializers.optionalInputStreamDeserializer().deserialize(response))
+                .hasValueSatisfying(stream -> assertThat(stream).hasContent(""));
+    }
+
+    @Test
+    public void testBinary_optional_empty() {
+        TestResponse response = new TestResponse();
+        response.code = 204;
+        BodySerDe serializers =
+                new ConjureBodySerDe(ImmutableList.of(WeightedEncoding.of(new StubEncoding("application/json"))));
+        assertThat(serializers.optionalInputStreamDeserializer().deserialize(response))
+                .isEmpty();
+    }
+
     /** Deserializes requests as the configured content type. */
     public static final class StubEncoding implements Encoding {
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/BodySerDe.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BodySerDe.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 /** Request and response Deserialization and Serialization functionality used by generated code. */
 public interface BodySerDe {
@@ -39,6 +40,9 @@ public interface BodySerDe {
      * to support future streaming binary bindings without conflicting method signatures.
      */
     Deserializer<InputStream> inputStreamDeserializer();
+
+    /** Same as {@link #inputStreamDeserializer()} with support for 204 responses. */
+    Deserializer<Optional<InputStream>> optionalInputStreamDeserializer();
 
     /** Serializes a {@link BinaryRequestBody} to <pre>application/octet-stream</pre>. */
     RequestBody serialize(BinaryRequestBody value);


### PR DESCRIPTION
==COMMIT_MSG==
Dialogue supports optional binary responses using a new method on ConjureBodySerDe which must be used by generated code.
==COMMIT_MSG==
