### PR TITLE
ConcurrencyLimitedChannel has no maximum limit value

### DIFF
--- a/changelog/@unreleased/pr-522.v2.yml
+++ b/changelog/@unreleased/pr-522.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ConcurrencyLimitedChannel has no maximum limit value
+  links:
+  - https://github.com/palantir/dialogue/pull/522

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -65,10 +65,12 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
                 // Explicitly set values to prevent library changes from breaking us
                 .initialLimit(20)
                 .minLimit(1)
-                .maxLimit(200)
                 .backoffRatio(0.9)
                 // Don't count slow calls as a sign of the server being overloaded
                 .timeout(Long.MAX_VALUE, TimeUnit.DAYS)
+                // Don't limit the maximum concurrency to a fixed value. This allows the client and server
+                // to negotiate a reasonable capacity based on traffic.
+                .maxLimit(Integer.MAX_VALUE)
                 .build();
         return SimpleLimiter.newBuilder()
                 .clock(nanoTimeClock::read)


### PR DESCRIPTION
The client and server may negotiate a reasonable value based on
load.
Limits apply per channel (host) rather than per-endpoint, so
200 was incredibly restrictive.

## Before this PR
Limit of 200 requests per host.

## After this PR
==COMMIT_MSG==
ConcurrencyLimitedChannel has no maximum limit value
==COMMIT_MSG==

## Possible downsides?
Possible to grow load when servers fail to respond with 429 or 5xx. Our primary server does not allow requests to queue, responding 503 when incoming requests cannot be processed immediately. It's possible although unlikely and already suboptimal that some systems do not behave in this way.
