### PR TITLE
fix #328 Prevent request body resources from leaking

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -235,3 +235,20 @@ acceptedBreaks:
       new: "method com.palantir.dialogue.Deserializer<java.util.Optional<java.io.InputStream>>\
         \ com.palantir.dialogue.BodySerDe::optionalInputStreamDeserializer()"
       justification: "ConjureBodySerDe is not meant for extension"
+  "0.19.7":
+    com.palantir.dialogue:dialogue-apache-hc4-client: []
+    com.palantir.dialogue:dialogue-blocking-channels: []
+    com.palantir.dialogue:dialogue-core: []
+    com.palantir.dialogue:dialogue-httpurlconnection-client: []
+    com.palantir.dialogue:dialogue-java-client: []
+    com.palantir.dialogue:dialogue-okhttp-client: []
+    com.palantir.dialogue:dialogue-serde: []
+    com.palantir.dialogue:dialogue-target:
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method boolean com.palantir.dialogue.RequestBody::repeatable()"
+      justification: "internal interface not for extension"
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method void com.palantir.dialogue.RequestBody::close()"
+      justification: "internal interface not for extension"

--- a/changelog/@unreleased/pr-525.v2.yml
+++ b/changelog/@unreleased/pr-525.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Prevent request body resources from leaking
+  links:
+  - https://github.com/palantir/dialogue/pull/525

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
@@ -149,9 +149,9 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
 
         @Override
         public boolean isRepeatable() {
-            // TODO(#328): Binary bodies are not repeatable, however all our structured bodies are.
-            // Marking the entity repeatable allows proxy authentication to work.
-            return true;
+            // n.b. Proxy authentication can only be negotiated on repeatable requests.
+            // Subsequent requests needn't be repeatable as state is cached by the client.
+            return requestBody.repeatable();
         }
 
         @Override

--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -80,6 +80,14 @@ public abstract class AbstractChannelTest {
         public String contentType() {
             return "application/text";
         }
+
+        @Override
+        public boolean repeatable() {
+            return true;
+        }
+
+        @Override
+        public void close() {}
     };
 
     @Mock

--- a/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractProxyConfigTest.java
+++ b/dialogue-client-test-lib/src/main/java/com/palantir/dialogue/AbstractProxyConfigTest.java
@@ -50,6 +50,14 @@ public abstract class AbstractProxyConfigTest {
                 public String contentType() {
                     return "text/plain";
                 }
+
+                @Override
+                public boolean repeatable() {
+                    return true;
+                }
+
+                @Override
+                public void close() {}
             })
             .build();
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
@@ -16,14 +16,25 @@
 
 package com.palantir.dialogue;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public interface RequestBody {
+public interface RequestBody extends Closeable {
 
     /** The content of this request body, possibly empty. */
     void writeTo(OutputStream output) throws IOException;
 
     /** A HTTP/Conjure content type (e.g., "application/json") indicating the type of content. */
     String contentType();
+
+    /** Returns <pre>true</pre> if {@link #writeTo(OutputStream)} may be invoked multiple times. */
+    boolean repeatable();
+
+    /**
+     * Closes this {@link RequestBody} and releases all resources. Calling {@link #close()} should never throw,
+     * preferring to catch and log.
+     */
+    @Override
+    void close();
 }


### PR DESCRIPTION
Streamed binary request bodies are never retried because data
may have already been consumed.
BinaryRequestBody implementations may override `close` to release
resources. We provide a factory to create a BinaryRequestBody
from an InputStream which properly closes resources.

## After this PR
==COMMIT_MSG==
Prevent request body resources from leaking
==COMMIT_MSG==

## Possible downsides?
API is more complicated.
