### PR TITLE
Instrument the retryer with a histogram of the number of retries

### DIFF
--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -24,6 +24,10 @@ namespaces:
         type: meter
         tags: [reason]
         docs: Rate that client-side requests are deferred to be retried later.
+      retry:
+        type: histogram
+        tags: [service-name]
+        docs: Histogram which reports the number of retries used by individual requests tagged by service.
 
   dialogue.pinuntilerror:
     docs: Instrumentation for the PIN_UNTIL_ERROR node selection strategy.


### PR DESCRIPTION
==COMMIT_MSG==
Instrument the retryer with a histogram of the number of retries
==COMMIT_MSG==

## Possible downsides?
Metrics aren't free, especially histograms.
