### PR TITLE
Response metrics include service name

### DIFF
--- a/changelog/@unreleased/pr-530.v2.yml
+++ b/changelog/@unreleased/pr-530.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tag response metrics by channel, service name
+  links:
+  - https://github.com/palantir/dialogue/pull/530

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -7,7 +7,7 @@ namespaces:
     metrics:
       response:
         type: timer
-        tags: [channel-name]
+        tags: [channel-name, service-name]
         docs: Request time, note that this does not include time spent reading the response body.
       request.active:
         type: counter

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
@@ -54,9 +54,12 @@ public final class InstrumentedChannelTest {
 
     @Test
     public void addsMetricsForSuccessfulAndUnsuccessfulExecution() {
+        when(endpoint.serviceName()).thenReturn("my-service");
+
         MetricName name = MetricName.builder()
                 .safeName("dialogue.client.response")
                 .putSafeTags("channel-name", "my-channel")
+                .putSafeTags("service-name", endpoint.serviceName())
                 .build();
         Timer timer = registry.timer(name);
 

--- a/simulation/src/main/java/com/palantir/dialogue/core/Benchmark.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/Benchmark.java
@@ -240,7 +240,10 @@ public final class Benchmark {
                                     .getCount();
                     return ImmutableBenchmarkResult.builder()
                             .clientHistogram(clientMetrics
-                                    .response(SimulationUtils.CHANNEL_NAME)
+                                    .response()
+                                    .channelName(SimulationUtils.CHANNEL_NAME)
+                                    .serviceName(SimulationUtils.SERVICE_NAME)
+                                    .build()
                                     .getSnapshot())
                             .endTime(Duration.ofNanos(simulation.clock().read()))
                             .statusCodes(statusCodes)


### PR DESCRIPTION
## Before this PR
We tagged response metrics by channel

## After this PR
==COMMIT_MSG==
Tag response metrics by channel, service name
==COMMIT_MSG==

## Possible downsides?
I only expect this to result in an increase in metric cardinality if there are multiple servers implementing the same service.