### PR TITLE
Record metrics describing time spent queued

### DIFF
--- a/changelog/@unreleased/pr-534.v2.yml
+++ b/changelog/@unreleased/pr-534.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Record metrics describing time spent queued
+  links:
+  - https://github.com/palantir/dialogue/pull/534

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -54,8 +54,6 @@ import org.slf4j.LoggerFactory;
  *     <li>Schedule in a spin loop: this would allow us to schedule without delay, but requires a thread constantly
  *     doing work, much of which will be wasted</li>
  * </ul>
- *
- * TODO(jellis): record metrics for queue sizes, num requests in flight, time spent in queue, etc.
  */
 final class QueuedChannel implements LimitedChannel {
     private static final Logger log = LoggerFactory.getLogger(QueuedChannel.class);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -81,7 +81,7 @@ final class QueuedChannel implements LimitedChannel {
         this.queuedCalls = new ProtectedConcurrentLinkedDeque<>();
         this.maxQueueSize = maxQueueSize;
         this.queueSizeCounter = metrics.requestsQueued(channelName);
-        this.queuedTime = metrics.requestsQueuedTime(channelName);
+        this.queuedTime = metrics.requestQueuedTime(channelName);
     }
 
     /**

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -66,8 +66,8 @@ final class QueuedChannel implements LimitedChannel {
     // Tracks requests that are current executing in delegate and are not tracked in queuedCalls
     private final AtomicInteger queueSizeEstimate = new AtomicInteger(0);
     private final int maxQueueSize;
-    private Counter queueSizeCounter;
-    private Timer queuedTime;
+    private final Counter queueSizeCounter;
+    private final Timer queuedTime;
 
     QueuedChannel(LimitedChannel channel, String channelName, DialogueClientMetrics metrics) {
         this(channel, channelName, metrics, 1_000);

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -20,6 +20,10 @@ namespaces:
         type: counter
         tags: [channel-name]
         docs: Number of queued requests waiting to execute.
+      requests.queued.time:
+        type: timer
+        tags: [channel-name]
+        docs: Time spent waiting in the queue before execution.
       deprecations:
         type: meter
         tags: [service-name]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -20,7 +20,7 @@ namespaces:
         type: counter
         tags: [channel-name]
         docs: Number of queued requests waiting to execute.
-      requests.queued.time:
+      request.queued.time:
         type: timer
         tags: [channel-name]
         docs: Time spent waiting in the queue before execution.

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -210,7 +210,7 @@ public class QueuedChannelTest {
         queuedChannel.schedule();
         futureResponse.set(mockResponse);
 
-        Timer timer = metrics.requestsQueuedTime(channelName);
+        Timer timer = metrics.requestQueuedTime(channelName);
         assertThat(timer.getCount()).isOne();
         assertThat(timer.getSnapshot().getMax()).isPositive();
     }
@@ -229,7 +229,7 @@ public class QueuedChannelTest {
         result.get().cancel(true);
         queuedChannel.schedule();
 
-        Timer timer = metrics.requestsQueuedTime(channelName);
+        Timer timer = metrics.requestQueuedTime(channelName);
         assertThat(timer.getCount()).isOne();
         assertThat(timer.getSnapshot().getMax()).isPositive();
     }


### PR DESCRIPTION
This fixes a bug where tracing spans were not recorded when queued
requests were canceled.

## Before this PR
Only tracing provided insight into the time requests spent queued.

## After this PR
==COMMIT_MSG==
Record metrics describing time spent queued
==COMMIT_MSG==

## Possible downsides?
more complexity surrounding the queue.
