### PR TITLE
Dialogue avoids wrapping all runtime exceptions for cleaner results

### DIFF
--- a/changelog/@unreleased/pr-538.v2.yml
+++ b/changelog/@unreleased/pr-538.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue avoids wrapping all runtime exceptions for cleaner results
+  links:
+  - https://github.com/palantir/dialogue/pull/538

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -94,12 +94,18 @@ enum DefaultClients implements Clients {
                 throw newUnknownRemoteException((UnknownRemoteException) cause);
             }
 
+            // In this case we provide a suppressed exception to mark the site where the failure was rethrown
+            // to avoid losing data while retaining the original failure information.
+            if (cause instanceof RuntimeException) {
+                cause.addSuppressed(new SafeRuntimeException("Rethrown by dialogue"));
+                throw (RuntimeException) cause;
+            }
+
             // This matches the behavior in Futures.getUnchecked(Future)
             if (cause instanceof Error) {
-                throw new ExecutionError(message, (Error) cause);
-            } else {
-                throw new UncheckedExecutionException(message, cause);
+                throw new ExecutionError(cause.getMessage(), (Error) cause);
             }
+            throw new UncheckedExecutionException(message, cause);
         }
     }
 

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
@@ -76,8 +76,11 @@ public class DefaultClientsBlockingTest {
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(runtimeException);
 
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
-                .isInstanceOf(UncheckedExecutionException.class)
-                .hasCauseInstanceOf(RuntimeException.class);
+                .isSameAs(runtimeException)
+                .satisfies(exception -> assertThat(exception.getSuppressed()).hasSize(1))
+                .satisfies(exception -> assertThat(exception.getSuppressed()[0])
+                        .isInstanceOf(SafeRuntimeException.class)
+                        .hasMessage("Rethrown by dialogue"));
     }
 
     @Test


### PR DESCRIPTION
In converting to dialogue I found several tests failed, even using
blocking clients, because the expected exception was wrapped in
an UncheckedExecutionException.
We can allow runtime exceptions but attach a suppressed exception
with the stack trace of the rewrap to avoid the complexity of
supporting re-creating all types while preserving the original
information.

This is most problematic in infrastructure code (e.g. always-throwing channels prior to the service being configured) where we expect to throw a particular type.

## Before this PR
All non-conjure runtime exceptions were wrapped.

## After this PR
==COMMIT_MSG==
Dialogue avoids wrapping all runtime exceptions for cleaner results
==COMMIT_MSG==

## Possible downsides?
The stack trace may not be as obvious when some data is recorded in a suppressed cause.