### PR TITLE
Tag concurrency-limiter metrics with the channel name

### DIFF
--- a/changelog/@unreleased/pr-543.v2.yml
+++ b/changelog/@unreleased/pr-543.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tag concurrency-limiter metrics with the channel name
+  links:
+  - https://github.com/palantir/dialogue/pull/543

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -119,7 +119,12 @@ public final class DialogueChannel implements Channel {
 
         LimitedChannel limitedChannel = new ChannelToLimitedChannelAdapter(channel);
         return concurrencyLimiter(
-                clientConfiguration, limitedChannel, clientConfiguration.taggedMetricRegistry(), clock, uriIndex);
+                clientConfiguration,
+                limitedChannel,
+                clientConfiguration.taggedMetricRegistry(),
+                clock,
+                channelName,
+                uriIndex);
     }
 
     private static LimitedChannel getUpdatedNodeSelectionStrategy(
@@ -161,12 +166,13 @@ public final class DialogueChannel implements Channel {
             LimitedChannel channel,
             TaggedMetricRegistry metrics,
             Ticker clock,
+            String channelName,
             int uriIndex) {
         ClientConfiguration.ClientQoS clientQoS = config.clientQoS();
         switch (clientQoS) {
             case ENABLED:
                 return new ConcurrencyLimitedChannel(
-                        channel, ConcurrencyLimitedChannel.createLimiter(clock), uriIndex, metrics);
+                        channel, ConcurrencyLimitedChannel.createLimiter(clock), channelName, uriIndex, metrics);
             case DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS:
                 return channel;
         }

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -30,7 +30,7 @@ namespaces:
         docs: Rate of deprecated endpoints being invoked.
       limited:
         type: meter
-        tags: [reason]
+        tags: [channel-name, reason]
         docs: Rate that client-side requests are deferred to be retried later.
 
   dialogue.concurrencylimiter:
@@ -38,11 +38,11 @@ namespaces:
     metrics:
       utilization:
         type: gauge
-        tags: [hostIndex]
+        tags: [channel-name, hostIndex]
         docs: The proportion of the available concurrency which is currently being used, i.e. if there are 20 permits and only one inflight call, this will be 0.05.
       max:
         type: gauge
-        tags: [hostIndex]
+        tags: [channel-name, hostIndex]
         docs: The maximum number of concurrent requests which are currently permitted. Additively increases with successes and multiplicatively decreases with failures.
 
   dialogue.pinuntilerror:

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -67,7 +67,8 @@ public class ConcurrencyLimitedChannelTest {
 
     @BeforeEach
     public void before() {
-        channel = new ConcurrencyLimitedChannel(new ChannelToLimitedChannelAdapter(delegate), mockLimiter, 0, metrics);
+        channel = new ConcurrencyLimitedChannel(
+                new ChannelToLimitedChannelAdapter(delegate), mockLimiter, "channel", 0, metrics);
 
         responseFuture = SettableFuture.create();
         lenient().when(delegate.execute(endpoint, request)).thenReturn(responseFuture);
@@ -113,6 +114,7 @@ public class ConcurrencyLimitedChannelTest {
         channel = new ConcurrencyLimitedChannel(
                 new ChannelToLimitedChannelAdapter(delegate),
                 ConcurrencyLimitedChannel.createLimiter(System::nanoTime),
+                "channel",
                 0,
                 metrics);
 
@@ -144,6 +146,7 @@ public class ConcurrencyLimitedChannelTest {
     private Number getUtilization() {
         Gauge<Object> gauge = metrics.gauge(MetricName.builder()
                         .safeName("dialogue.concurrencylimiter.utilization")
+                        .putSafeTags("channel-name", "channel")
                         .putSafeTags("hostIndex", "0")
                         .build())
                 .get();
@@ -153,6 +156,7 @@ public class ConcurrencyLimitedChannelTest {
     private Number getMax() {
         MetricName metricName = MetricName.builder()
                 .safeName("dialogue.concurrencylimiter.max")
+                .putSafeTags("channel-name", "channel")
                 .putSafeTags("hostIndex", "0")
                 .build();
         assertThat(metrics.getMetrics().keySet()).contains(metricName);


### PR DESCRIPTION
## Before this PR
Concurrency limiter metrics provided a uri, but given uri `0` we couldn't tell which requests were impacted.

## After this PR
==COMMIT_MSG==
Tag concurrency-limiter metrics with the channel name
==COMMIT_MSG==

## Possible downsides?
no.