### PR TITLE
Implement a LeakDetectingChannel to notify when responses are leaked

### DIFF
--- a/changelog/@unreleased/pr-545.v2.yml
+++ b/changelog/@unreleased/pr-545.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Log warnings and record metrics when resource leaks are discovered.
+  links:
+  - https://github.com/palantir/dialogue/pull/545

--- a/dialogue-core/build.gradle
+++ b/dialogue-core/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.assertj:assertj-guava'
+    testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -110,7 +110,8 @@ public final class DialogueChannel implements Channel {
 
     private LimitedChannel createLimitedChannel(String uri, int uriIndex) {
         Channel channel = channelFactory.create(uri);
-        // Instrument inner-most channel with metrics so that we measure only the over-the-wire-time
+        // Instrument inner-most channel with instrumentation channels so that we measure only the over-the-wire-time
+        channel = new LeakDetectingChannel(channel, channelName, clientMetrics);
         channel = new InstrumentedChannel(channel, channelName, clientMetrics);
         channel = new ActiveRequestInstrumentationChannel(channel, channelName, "running", clientMetrics);
         // TracedChannel must wrap TracedRequestChannel to ensure requests have tracing headers.

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
@@ -140,6 +140,7 @@ final class LeakDetectingChannel implements Channel {
 
         private final Response delegate;
         private final LeakDetector leakDetector;
+        @Nullable
         private InputStream leakDetectingStream;
 
         LeakDetectingResponse(Response delegate, LeakDetector leakDetector) {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
@@ -1,0 +1,167 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.collect.ListMultimap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.logsafe.SafeArg;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class LeakDetectingChannel implements Channel {
+
+    private static final Logger log = LoggerFactory.getLogger(LeakDetectingChannel.class);
+
+    private final Channel delegate;
+    private final String channelName;
+    private final DialogueClientMetrics metrics;
+
+    LeakDetectingChannel(Channel delegate, String channelName, DialogueClientMetrics metrics) {
+        this.delegate = delegate;
+        this.channelName = channelName;
+        this.metrics = metrics;
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+        return Futures.transform(
+                delegate.execute(endpoint, request),
+                response -> new LeakDetectingResponse(response, endpoint),
+                MoreExecutors.directExecutor());
+    }
+
+    /**
+     * {@link LeakDetector} object is shared between the {@link Response} and {@link Response#body()} to ensure
+     * at least one of the two has been closed.
+     */
+    private final class LeakDetector {
+
+        private final Endpoint endpoint;
+        private final Response response;
+        private boolean armed = true;
+
+        LeakDetector(Response response, Endpoint endpoint) {
+            this.response = response;
+            this.endpoint = endpoint;
+        }
+
+        void disarm() {
+            armed = false;
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            if (armed) {
+                metrics.responseLeak()
+                        .channelName(channelName)
+                        .serviceName(endpoint.serviceName())
+                        .endpoint(endpoint.endpointName())
+                        .build()
+                        .mark();
+                log.warn(
+                        "Detected a leaked response from service {} endpoint {} on channel {}",
+                        SafeArg.of("service", endpoint.serviceName()),
+                        SafeArg.of("endpoint", endpoint.endpointName()),
+                        SafeArg.of("channel", channelName));
+                response.close();
+            }
+            super.finalize();
+        }
+
+        @Override
+        public String toString() {
+            return "LeakDetector{endpoint=" + endpoint + ", response=" + response + ", armed=" + armed + '}';
+        }
+    }
+
+    private final class LeakDetectingInputStream extends FilterInputStream {
+
+        private final LeakDetector leakDetector;
+
+        LeakDetectingInputStream(InputStream delegate, LeakDetector leakDetector) {
+            super(delegate);
+            this.leakDetector = leakDetector;
+        }
+
+        @Override
+        public void close() throws IOException {
+            leakDetector.disarm();
+            super.close();
+        }
+
+        @Override
+        public String toString() {
+            return "LeakDetectingInputStream{leakDetector=" + leakDetector + ", in=" + in + '}';
+        }
+    }
+
+    private final class LeakDetectingResponse implements Response {
+
+        private final Response delegate;
+        private final LeakDetector leakDetector;
+        private InputStream leakDetectingStream;
+
+        LeakDetectingResponse(Response delegate, Endpoint endpoint) {
+            this.delegate = delegate;
+            leakDetector = new LeakDetector(delegate, endpoint);
+        }
+
+        @Override
+        public InputStream body() {
+            if (leakDetectingStream == null) {
+                leakDetectingStream = new LeakDetectingInputStream(delegate.body(), leakDetector);
+            }
+            return leakDetectingStream;
+        }
+
+        @Override
+        public int code() {
+            return delegate.code();
+        }
+
+        @Override
+        public ListMultimap<String, String> headers() {
+            return delegate.headers();
+        }
+
+        @Override
+        public Optional<String> getFirstHeader(String header) {
+            return delegate.getFirstHeader(header);
+        }
+
+        @Override
+        public void close() {
+            leakDetector.disarm();
+            delegate.close();
+        }
+
+        @Override
+        public String toString() {
+            return "LeakDetectingResponse{delegate=" + delegate + ", leakDetector=" + leakDetector + '}';
+        }
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
@@ -30,6 +30,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,10 @@ final class LeakDetectingChannel implements Channel {
 
         private final Endpoint endpoint;
         private final Response response;
+
+        @Nullable
         private final Throwable creationTrace;
+
         private boolean armed = true;
 
         LeakDetector(Response response, Endpoint endpoint) {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
@@ -50,7 +50,7 @@ final class LeakDetectingChannel implements Channel {
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
         return Futures.transform(
                 delegate.execute(endpoint, request),
-                response -> new LeakDetectingResponse(response, endpoint),
+                response -> new LeakDetectingResponse(response, new LeakDetector(response, endpoint)),
                 MoreExecutors.directExecutor());
     }
 
@@ -98,7 +98,7 @@ final class LeakDetectingChannel implements Channel {
         }
     }
 
-    private final class LeakDetectingInputStream extends FilterInputStream {
+    private static final class LeakDetectingInputStream extends FilterInputStream {
 
         private final LeakDetector leakDetector;
 
@@ -119,15 +119,15 @@ final class LeakDetectingChannel implements Channel {
         }
     }
 
-    private final class LeakDetectingResponse implements Response {
+    private static final class LeakDetectingResponse implements Response {
 
         private final Response delegate;
         private final LeakDetector leakDetector;
         private InputStream leakDetectingStream;
 
-        LeakDetectingResponse(Response delegate, Endpoint endpoint) {
+        LeakDetectingResponse(Response delegate, LeakDetector leakDetector) {
             this.delegate = delegate;
-            leakDetector = new LeakDetector(delegate, endpoint);
+            this.leakDetector = leakDetector;
         }
 
         @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LeakDetectingChannel.java
@@ -81,6 +81,7 @@ final class LeakDetectingChannel implements Channel {
         }
 
         @Override
+        @SuppressWarnings("NoFinalizer")
         protected void finalize() throws Throwable {
             if (armed) {
                 metrics.responseLeak()
@@ -140,6 +141,7 @@ final class LeakDetectingChannel implements Channel {
 
         private final Response delegate;
         private final LeakDetector leakDetector;
+
         @Nullable
         private InputStream leakDetectingStream;
 

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -9,6 +9,10 @@ namespaces:
         type: timer
         tags: [channel-name, service-name]
         docs: Request time, note that this does not include time spent reading the response body.
+      response.leak:
+        type: meter
+        tags: [channel-name, service-name, endpoint]
+        docs: Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
       request.active:
         type: counter
         tags: [channel-name, service-name, stage]

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelsTest.java
@@ -108,7 +108,7 @@ public final class DialogueChannelsTest {
 
     @Test
     public void testRequestMakesItThrough() throws ExecutionException, InterruptedException {
-        assertThat(channel.execute(endpoint, request).get()).isEqualTo(response);
+        assertThat(channel.execute(endpoint, request).get()).isNotNull();
     }
 
     @Test

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/LeakDetectingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/LeakDetectingChannelTest.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+import com.codahale.metrics.Meter;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LeakDetectingChannelTest {
+    private static final String CHANNEL = "channel";
+    private static final String SERVICE = "service";
+    private static final String ENDPOINT = "endpoint";
+
+    private DialogueClientMetrics metrics;
+
+    @Mock
+    private Endpoint mockEndpoint;
+
+    @Mock
+    private Response response;
+
+    @BeforeEach
+    void beforeEach() {
+        metrics = DialogueClientMetrics.of(new DefaultTaggedMetricRegistry());
+        lenient().when(mockEndpoint.serviceName()).thenReturn(SERVICE);
+        lenient().when(mockEndpoint.endpointName()).thenReturn(ENDPOINT);
+        lenient().when(response.body()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    }
+
+    @Test
+    @SuppressWarnings("FutureReturnValueIgnored") // intentional leak
+    void testLeakMetric() throws Exception {
+        Channel delegate = (endpoint, request) -> Futures.immediateFuture(response);
+        LeakDetectingChannel detector = new LeakDetectingChannel(delegate, CHANNEL, metrics);
+        // Result is intentionally ignored to cause a leak
+        detector.execute(mockEndpoint, Request.builder().build());
+        Meter leaks = metrics.responseLeak()
+                .channelName(CHANNEL)
+                .serviceName(SERVICE)
+                .endpoint(ENDPOINT)
+                .build();
+        Awaitility.waitAtMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            System.gc();
+            assertThat(leaks.getCount()).isOne();
+        });
+        verify(response).close();
+    }
+
+    @Test
+    void testNotLeaked_streamReferenceHeld() throws Exception {
+        Channel delegate = (endpoint, request) -> Futures.immediateFuture(response);
+        LeakDetectingChannel detector = new LeakDetectingChannel(delegate, CHANNEL, metrics);
+        // Result is intentionally ignored to cause a leak
+        try (InputStream ignored =
+                detector.execute(mockEndpoint, Request.builder().build()).get().body()) {
+            Meter leaks = metrics.responseLeak()
+                    .channelName(CHANNEL)
+                    .serviceName(SERVICE)
+                    .endpoint(ENDPOINT)
+                    .build();
+            // GC and test enough times to be confident no leaks were recorded
+            for (int i = 0; i < 100; i++) {
+                System.gc();
+                Thread.sleep(1);
+                assertThat(leaks.getCount()).isZero();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
resources probably aren't leaked, but we don't have validation.

## After this PR
==COMMIT_MSG==
Log warnings and record metrics when resource leaks are discovered.
==COMMIT_MSG==

## Possible downsides?
Implementing a finalize adds objects to the finalizer queue which runs on a single thread. It shouldn't be problematic and the cost is effectively zero compared to the cost of a resource leak.
