### PR TITLE
BinaryRequestBody: fix confusing variable names/comments

### DIFF
--- a/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
@@ -26,7 +26,7 @@ import java.io.OutputStream;
 /** Streamed binary response data with Content-Type <code>application/octet-stream</code>. */
 public interface BinaryRequestBody extends Closeable {
 
-    /** Invoked to write data to the request stream. Called exactly once. */
+    /** Invoked to write data to the request stream. */
     void write(OutputStream requestBody) throws IOException;
 
     /** This method may be overridden to return resources. */

--- a/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-/** Streamed binary response data with Content-Type <code>application/octet-stream</code>. */
+/** Streamed binary request data with Content-Type <code>application/octet-stream</code>. */
 public interface BinaryRequestBody extends Closeable {
 
     /** Invoked to write data to the request stream. */

--- a/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
@@ -23,15 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-/**
- * Streamed binary response data with Content-Type <code>application/octet-stream</code>.
- */
+/** Streamed binary response data with Content-Type <code>application/octet-stream</code>. */
 public interface BinaryRequestBody extends Closeable {
 
-    /**
-     * Invoked to write data to the response stream. Called exactly once.
-     */
-    void write(OutputStream responseBody) throws IOException;
+    /** Invoked to write data to the request stream. Called exactly once. */
+    void write(OutputStream requestBody) throws IOException;
 
     /** This method may be overridden to return resources. */
     @Override
@@ -45,10 +41,10 @@ public interface BinaryRequestBody extends Closeable {
             private boolean invoked;
 
             @Override
-            public void write(OutputStream responseBody) throws IOException {
+            public void write(OutputStream requestBody) throws IOException {
                 Preconditions.checkState(!invoked, "Write has already been called");
                 invoked = true;
-                ByteStreams.copy(inputStream, responseBody);
+                ByteStreams.copy(inputStream, requestBody);
             }
 
             @Override


### PR DESCRIPTION
## Before this PR

I was implementing BinaryRequestBody and got confused by the argument name & javadoc.

## After this PR
==COMMIT_MSG==
BinaryRequestBody javadoc mentions 'request' not 'response'.
==COMMIT_MSG==

## Possible downsides?

