### PR TITLE
POC for sticky sessioning

### DIFF
--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
@@ -23,6 +23,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.dialogue.blocking.BlockingChannel;
 import com.palantir.dialogue.core.BaseUrl;
 import com.palantir.logsafe.Preconditions;
@@ -129,6 +130,11 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             } catch (IOException | RuntimeException e) {
                 log.warn("Failed to close response", e);
             }
+        }
+
+        @Override
+        public <T> Optional<T> getTag(TagKey<T> tagKey) {
+            return Optional.empty();
         }
 
         @Override

--- a/dialogue-blocking-channels/src/test/java/com/palantir/dialogue/blocking/BlockingChannelAdapterTest.java
+++ b/dialogue-blocking-channels/src/test/java/com/palantir/dialogue/blocking/BlockingChannelAdapterTest.java
@@ -26,12 +26,14 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.dialogue.UrlBuilder;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import org.awaitility.Awaitility;
@@ -57,6 +59,11 @@ public class BlockingChannelAdapterTest {
 
         @Override
         public void close() {}
+
+        @Override
+        public <T> Optional<T> getTag(TagKey<T> tagKey) {
+            return Optional.empty();
+        }
     };
 
     private static final Endpoint stubEndpoint = new Endpoint() {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -25,6 +25,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.BufferedInputStream;
@@ -138,6 +139,11 @@ final class ContentDecodingChannel implements Channel {
             } finally {
                 delegate.close();
             }
+        }
+
+        @Override
+        public <T> Optional<T> getTag(TagKey<T> tagKey) {
+            return delegate.getTag(tagKey);
         }
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorChannel.java
@@ -147,7 +147,7 @@ final class PinUntilErrorChannel implements LimitedChannel {
                         OptionalInt next = incrementHostIfNecessary(currentIndex);
                         instrumentation.receivedThrowable(currentIndex, channel, throwable, next);
                     }
-                }));
+                })).map(future -> StickySessioning.addExecutedOnTag(future, channel));
     }
 
     /**

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RandomSelectionChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RandomSelectionChannel.java
@@ -54,8 +54,8 @@ final class RandomSelectionChannel implements LimitedChannel {
             LimitedChannel channel = delegates.get(toIndex(visitedChannels, host));
             Optional<ListenableFuture<Response>> maybeCall = channel.maybeExecute(endpoint, request);
             if (maybeCall.isPresent()) {
-                return maybeCall;
-            }
+                return maybeCall.map(future -> StickySessioning.addExecutedOnTag(future, channel));
+        }
             if (visitedChannels == null) {
                 visitedChannels = new BitSet(elements);
             }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickySessioning.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickySessioning.java
@@ -1,0 +1,120 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.collect.ListMultimap;
+import com.google.common.util.concurrent.FluentFuture;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
+import java.io.InputStream;
+import java.util.Optional;
+
+public final class StickySessioning {
+    private static final TagKey<LimitedChannel> EXECUTED_ON = new TagKey<>(LimitedChannel.class);
+
+    private StickySessioning() {}
+
+    static LimitedChannel wrapWithRecordedChoiceSelection(LimitedChannel delegate) {
+        return new RecordedChoiceChannel(delegate);
+    }
+
+    static ListenableFuture<Response> addExecutedOnTag(
+            ListenableFuture<Response> responseFuture,
+            LimitedChannel channel) {
+        return Futures.transform(responseFuture,
+                response -> new Response() {
+                    @Override
+                    public InputStream body() {
+                        return response.body();
+                    }
+
+                    @Override
+                    public int code() {
+                        return response.code();
+                    }
+
+                    @Override
+                    public ListMultimap<String, String> headers() {
+                        return response.headers();
+                    }
+
+                    @Override
+                    public void close() {
+                        response.close();
+                    }
+
+                    @Override
+                    public <T> Optional<T> getTag(TagKey<T> tagKey) {
+                        if (tagKey == EXECUTED_ON) {
+                            T ret = (T) channel;
+                            return Optional.of(ret);
+                        }
+                        return response.getTag(tagKey);
+                    }
+                }, MoreExecutors.directExecutor());
+    }
+
+    private static final class RecordedChoiceChannel implements LimitedChannel {
+        private final LimitedChannel delegate;
+
+        private RecordedChoiceChannel(LimitedChannel delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Optional<ListenableFuture<Response>> maybeExecute(
+                Endpoint endpoint, Request request) {
+            return request.getTag(EXECUTED_ON).orElse(delegate).maybeExecute(endpoint, request);
+        }
+    }
+
+    private static final class StickySessionChannel implements Channel {
+        private final Channel delegate;
+
+        private FluentFuture<LimitedChannel> stuckChannel;
+
+        private StickySessionChannel(Channel delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public synchronized ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+            if (stuckChannel != null) {
+                return executeOnStuckChannel(endpoint, request);
+            }
+            ListenableFuture<Response> response = delegate.execute(endpoint, request);
+            stuckChannel = FluentFuture.from(response)
+                    .transform(r -> r.getTag(EXECUTED_ON)
+                                    .orElseThrow(() -> new IllegalStateException("No channel used was tagged")),
+                            MoreExecutors.directExecutor());
+            return response;
+        }
+
+        private ListenableFuture<Response> executeOnStuckChannel(Endpoint endpoint, Request request) {
+            return stuckChannel.transformAsync(channel -> delegate.execute(endpoint, Request.builder()
+                    .from(request)
+                    .putTags(EXECUTED_ON, channel)
+                    .build()), MoreExecutors.directExecutor());
+        }
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentDecodingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentDecodingChannelTest.java
@@ -29,12 +29,14 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.dialogue.UrlBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Optional;
 import java.util.zip.GZIPOutputStream;
 import org.assertj.core.data.MapEntry;
 import org.immutables.value.Value;
@@ -184,6 +186,13 @@ public final class ContentDecodingChannelTest {
 
         @Override
         default void close() {}
+
+        Map<TagKey<?>, Object> tags();
+
+        @Override
+        default <T> Optional<T> getTag(TagKey<T> tag) {
+            return Optional.ofNullable(tag.cast(tags().get(tag)));
+        }
 
         class Builder extends ImmutableStubResponse.Builder {}
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -36,6 +36,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.dialogue.UrlBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -43,6 +44,7 @@ import java.io.OutputStream;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -368,6 +370,11 @@ public class RetryingChannelTest {
 
         @Override
         public void close() {}
+
+        @Override
+        public <T> Optional<T> getTag(TagKey<T> tagKey) {
+            return Optional.empty();
+        }
     }
 
     private static final class TestEndpoint implements Endpoint {

--- a/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionBlockingChannel.java
+++ b/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionBlockingChannel.java
@@ -25,6 +25,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.dialogue.blocking.BlockingChannel;
 import com.palantir.dialogue.core.BaseUrl;
 import com.palantir.logsafe.Preconditions;
@@ -151,6 +152,11 @@ final class HttpUrlConnectionBlockingChannel implements BlockingChannel {
             } catch (IOException e) {
                 log.warn("Failed to close response", e);
             }
+        }
+
+        @Override
+        public <T> Optional<T> getTag(TagKey<T> tagKey) {
+            return Optional.empty();
         }
 
         @Override

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -31,6 +31,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,6 +118,11 @@ public final class HttpChannel implements Channel {
                 } catch (IOException e) {
                     log.warn("Failed to close response", e);
                 }
+            }
+
+            @Override
+            public <T> Optional<T> getTag(TagKey<T> tagKey) {
+                return Optional.empty();
             }
         };
     }

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import java.io.InputStream;
+import java.util.Optional;
 
 public final class OkHttpResponse implements Response {
 
@@ -56,5 +57,10 @@ public final class OkHttpResponse implements Response {
     @Override
     public void close() {
         delegate.close();
+    }
+
+    @Override
+    public <T> Optional<T> getTag(TagKey<T> tagKey) {
+        return Optional.empty();
     }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -31,6 +31,7 @@ import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
@@ -260,6 +261,11 @@ public class ConjureBodySerDeTest {
 
         @Override
         public void close() {}
+
+        @Override
+        public <T> Optional<T> getTag(TagKey<T> tagKey) {
+            return Optional.empty();
+        }
 
         public void contentType(String contentType) {
             this.headers = ImmutableListMultimap.of(HttpHeaders.CONTENT_TYPE, contentType);

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoderTest.java
@@ -33,11 +33,13 @@ import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import javax.annotation.CheckForNull;
 import javax.ws.rs.core.HttpHeaders;
 import org.junit.Test;
@@ -190,6 +192,11 @@ public final class ErrorDecoderTest {
 
             @Override
             public void close() {}
+
+            @Override
+            public <T> Optional<T> getTag(TagKey<T> tagKey) {
+                return Optional.empty();
+            }
         };
     }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -35,12 +35,14 @@ public final class Request {
     private final ImmutableListMultimap<String, String> queryParams;
     private final ImmutableMap<String, String> pathParams;
     private final Optional<RequestBody> body;
+    private final Map<TagKey<?>, Object> tags;
 
     private Request(Builder builder) {
         body = builder.body;
         headerParams = Multimaps.unmodifiableListMultimap(builder.headerParams);
         queryParams = builder.queryParams.build();
         pathParams = builder.pathParams.build();
+        tags = builder.tags.build();
     }
 
     /**
@@ -74,6 +76,10 @@ public final class Request {
         return body;
     }
 
+    public <T> Optional<T> getTag(TagKey<T> tagKey) {
+        return Optional.ofNullable(tags.get(tagKey)).map(tagKey::cast);
+    }
+
     @Override
     public String toString() {
         return "Request{"
@@ -86,6 +92,8 @@ public final class Request {
                 + pathParams
                 + ", body="
                 + body
+                + ", tags="
+                + tags
                 + '}';
     }
 
@@ -119,6 +127,7 @@ public final class Request {
                 .build();
         private ImmutableListMultimap.Builder<String, String> queryParams = ImmutableListMultimap.builder();
         private ImmutableMap.Builder<String, String> pathParams = ImmutableMap.builder();
+        private ImmutableMap.Builder<TagKey<?>, Object> tags = ImmutableMap.builder();
         private Optional<RequestBody> body = Optional.empty();
 
         private Builder() {}
@@ -217,6 +226,22 @@ public final class Request {
         @SuppressWarnings("unchecked")
         public Request.Builder body(Optional<? extends RequestBody> value) {
             body = (Optional<RequestBody>) value;
+            return this;
+        }
+
+        public <T> Request.Builder putTags(TagKey<T> tagKey, T tagValue) {
+            tags.put(tagKey, tagValue);
+            return this;
+        }
+
+        public Request.Builder tags(Map<TagKey<?>, Object> entries) {
+            tags = ImmutableMap.builder();
+            tags.putAll(entries);
+            return this;
+        }
+
+        public Request.Builder putAllTags(Map<TagKey<?>, Object> entries) {
+            tags.putAll(entries);
             return this;
         }
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -46,4 +46,6 @@ public interface Response extends Closeable {
      */
     @Override
     void close();
+
+    <T> Optional<T> getTag(TagKey<T> tagKey);
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/TagKey.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/TagKey.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+public final class TagKey<T>  {
+    private final Class<T> valueClass;
+
+    public TagKey(Class<T> valueClass) {
+        this.valueClass = valueClass;
+    }
+
+    public T cast(Object object) {
+        return valueClass.cast(object);
+    }
+}

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationUtils.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationUtils.java
@@ -22,12 +22,14 @@ import com.google.common.collect.MultimapBuilder;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TagKey;
 import com.palantir.dialogue.UrlBuilder;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +62,11 @@ final class SimulationUtils {
 
             @Override
             public void close() {}
+
+            @Override
+            public <T> Optional<T> getTag(TagKey<T> tagKey) {
+                return Optional.empty();
+            }
         };
     }
 
@@ -93,6 +100,11 @@ final class SimulationUtils {
                             timesClosed,
                             new SafeRuntimeException("for stacktrace"));
                 }
+            }
+
+            @Override
+            public <T> Optional<T> getTag(TagKey<T> tagKey) {
+                return Optional.empty();
             }
         };
     }


### PR DESCRIPTION
Will discuss internally, but we have a lot of garbage at present related
to handling load balancing - we need a 'session' of requests to an
underlying channel.

Wondered if this might be cleaner?

Adds a 'tag' concept to requests and responses, where channels can add
and remove data as relevant (although the present implementation of
'getTag()'.

Then, uses the tag concept to implement a limited channel which can be
used to implement sticky sessioning.