### PR TITLE
Stop publishing alternative channel impls (in prep for 1.0)

### DIFF
--- a/dialogue-httpurlconnection-client/build.gradle
+++ b/dialogue-httpurlconnection-client/build.gradle
@@ -1,6 +1,3 @@
-apply from: "$rootDir/gradle/publish-jar.gradle"
-apply plugin: 'com.palantir.revapi'
-
 dependencies {
     api project(':dialogue-core')
     api project(':dialogue-target')

--- a/dialogue-java-client/build.gradle
+++ b/dialogue-java-client/build.gradle
@@ -1,6 +1,3 @@
-apply from: "$rootDir/gradle/publish-jar.gradle"
-apply plugin: 'com.palantir.revapi'
-
 sourceCompatibility = 11
 
 dependencies {

--- a/dialogue-okhttp-client/build.gradle
+++ b/dialogue-okhttp-client/build.gradle
@@ -1,6 +1,3 @@
-apply from: "$rootDir/gradle/publish-jar.gradle"
-apply plugin: 'com.palantir.revapi'
-
 dependencies {
     compile project(':dialogue-target')
     compile project(':dialogue-core')


### PR DESCRIPTION
## Before this PR

@callumr thought the recommended way of using dialogue was the new java9 HttpClient thing, but we actually discourage this one due to it failing to complete a benchmark (so bugs in the JVM)

## After this PR
==COMMIT_MSG==
`dialogue-apache-hc4-client` is the only published channel implementation, as this is our recommended and supported client.
==COMMIT_MSG==

## Possible downsides?
- when it comes to benchmarking, we may have to copy and paste the other impls.
