### PR TITLE
Validate ciphers against the provided socket factory

### DIFF
--- a/changelog/@unreleased/pr-556.v2.yml
+++ b/changelog/@unreleased/pr-556.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Validate ciphers against the provided socket factory, this adds support
+    for Conscrypt.
+  links:
+  - https://github.com/palantir/dialogue/pull/556

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -119,8 +119,8 @@ public final class ApacheHttpClientChannels {
                 MetricRegistries.instrument(conf.taggedMetricRegistry(), rawSocketFactory, clientName),
                 new String[] {"TLSv1.2"},
                 conf.enableGcmCipherSuites()
-                        ? jvmSupportedCipherSuites(CipherSuites.allCipherSuites(), rawSocketFactory)
-                        : jvmSupportedCipherSuites(CipherSuites.fastCipherSuites(), rawSocketFactory),
+                        ? supportedCipherSuites(CipherSuites.allCipherSuites(), rawSocketFactory)
+                        : supportedCipherSuites(CipherSuites.fastCipherSuites(), rawSocketFactory),
                 new DefaultHostnameVerifier());
 
         PoolingHttpClientConnectionManager connectionManager =
@@ -231,7 +231,7 @@ public final class ApacheHttpClientChannels {
      * Otherwise {@code SSLSocketImpl#setEnabledCipherSuites} throws and IllegalArgumentException complaining about an
      * "Unsupported ciphersuite" at client construction time!
      */
-    private static String[] jvmSupportedCipherSuites(String[] cipherSuites, SSLSocketFactory socketFactory) {
+    private static String[] supportedCipherSuites(String[] cipherSuites, SSLSocketFactory socketFactory) {
         Set<String> jvmSupported = supportedCipherSuites(socketFactory);
         List<String> enabled = new ArrayList<>();
         List<String> unsupported = new ArrayList<>();


### PR DESCRIPTION
Previously we only checked against the JVM default context which
isn't representative of all inputs.

==COMMIT_MSG==
Validate ciphers against the provided socket factory, this adds support for Conscrypt.
==COMMIT_MSG==

Downsides:
We don't have real tests for this, TODO to add tests to this repository which use TLS.