### PR TITLE
Fill out the README a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ public ListenableFuture<Thing> getThing(
 
 ## Blocking or async
 
-Of the two generated interfaces `FooServiceBlocking` and `FooServiceAync`, the blocking version is usually appropriate for 80% of use-cases, and results in much simpler control flow and error-handling. The async version returns Guava [`ListenableFutures`](https://github.com/google/guava/wiki/ListenableFutureExplained) so is a lot more fiddly to use. `Futures.addCallback` and `FluentFuture` are your friend here.
+Of the two generated interfaces `FooServiceBlocking` and `FooServiceAync`, the blocking version is usually appropriate for 98% of use-cases, and results in much simpler control flow and error-handling. The async version returns Guava [`ListenableFutures`](https://github.com/google/guava/wiki/ListenableFutureExplained) so is a lot more fiddly to use. `Futures.addCallback` and `FluentFuture` are your friend here.
 
 
 ## Design

--- a/README.md
+++ b/README.md
@@ -1,7 +1,60 @@
 # Dialogue
 
-Dialogue is an experimental client-side framework for HTTP-based RPC. The API is influenced by gRPC's Java library.
-Dialogue was designed as a codegen target for [Conjure](https://palantir.github.io/conjure).
+_Dialogue is a client-side library for HTTP-based RPC, designed to work well with [Conjure](https://palantir.github.io/conjure)-defined APIs._
+
+## conjure-java generated client bindings
+
+Dialogue works best with generated client bindings, i.e. for a given Conjure-defined `FooService`, the [conjure-java](https://github.com/palantir/conjure-java) code generator can produce two java interfaces: `FooServiceBlocking` and `FooServiceAsync`. Generating these at compile-time means that making a request involves zero reflection - all serializers and deserializers are already set up in advance, so that zero efficiency compromises are made. A sample `getThing` endpoint with some path params, query params and a request body looks like this:
+
+```java
+@Override
+public ListenableFuture<Thing> getThing(
+        AuthHeader authHeader, String pathParam, List<ResourceIdentifier> queryKey, MyRequest body) {
+    Request.Builder _request = Request.builder();
+    _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+    _request.putPathParams("path", plainSerDe.serializeString(pathParam));
+    for (ResourceIdentifier queryKeyElement : queryKey) {
+        _request.putQueryParams("queryKey", plainSerDe.serializeRid(queryKeyElement));
+    }
+    _request.body(myRequestSerializer.serialize(body));
+    return runtime.clients()
+            .call(channel, DialogueSampleEndpoints.getThing, _request.build(), thingDeserializer);
+}
+```
+
+
+### Building a client
+
+**Short-answer**: setting up clients should probably be encapsulated by your server framework to ensure connection pools are reused properly. For example in Witchcraft:
+
+```groovy
+FooServiceBlocking fooService = witchcraft.conjureClients().client(FooServiceBlocking.class, "foo-service").get();
+
+// then you can make network calls by just calling a method
+List<Item> items = fooService.getItems();
+```
+
+**Long answer**
+
+Dialogue is built around the `Channel` abstraction, with many different implementations that often add a little bit of behaviour and then delegate to another inner Channel.
+
+```java
+public interface Channel {
+    ListenableFuture<Response> execute(Endpoint endpoint, Request request);
+}
+```
+
+For example, the [UserAgentChannel](https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentChannel.java) just augments the request with a `user-agent` header and then calls a delegate.
+
+
+## Blocking or async?
+
+Of the two generated interfaces `FooServiceBlocking` and `FooServiceAync`, the blocking version is usually appropriate for 80% of use-cases, and results in much simpler control flow and error-handling. The async version returns Guava [`ListenableFutures`](https://github.com/google/guava/wiki/ListenableFutureExplained) so is a lot more fiddly to use. `Futures.addCallback` and `FluentFuture` are your friend here.
+
+
+## Design and motivation
+
+The API is influenced by gRPC's Java library.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ _Dialogue is a client-side library for HTTP-based RPC, designed to work well wit
 - **Client-side node selection**: by making load balancing decisions in the client, Dialogue avoids the necessity for an L7 proxy (and its associated latency penalty).
 - **Queue**: in the case where all nodes are limited (e.g. during a spike in traffic), requests are added to a FIFO queue and processed as soon as the one of the ConcurrencyLimiters has capacity;
 - **Retries**: requests are retried a constant number of times.
-- **Live reloading**: uris can be added or removed without losing the state of the ConcurrencyLimiters or node selection.
+- **Live reloading**: uris can be added or removed without losing ConcurrencyLimiter or node selection states.
+- **Streaming**: requests and responses are streamed without buffering the entire body into memory.
 
 ## Observability
 
@@ -105,9 +106,14 @@ For example, the [UserAgentChannel](https://github.com/palantir/dialogue/blob/de
 
 _This API is influenced by gRPC's [Java library](https://github.com/grpc/grpc-java), which has a similar [Channel](https://github.com/grpc/grpc-java/blob/master/api/src/main/java/io/grpc/Channel.java) concept._
 
+
 ## Alternative HTTP clients
 
 Dialogue is not coupled to a single HTTP client library - this repo contains implementations based on [OkHttp](https://square.github.io/okhttp/), Java's [HttpURLConnection](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html), the new Java11 [HttpClient](https://openjdk.java.net/groups/net/httpclient/intro.html) as well as the aforementioned [Apache HttpClient](https://hc.apache.org/httpcomponents-client-ga/).  We endorse the Apache client because as it performed best in our benchmarks and affords granular control over connection pools.
+
+## History
+
+Dialogue is the product of years of learning from operating thousands of Java servers across hundreds of deployments. [Previous incarnations](https://github.com/palantir/conjure-java-runtime) relied on Feign, Retrofit2 and OkHttp.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Dialogue is a client-side library for HTTP-based RPC, designed to work well wit
 - **ConcurrencyLimiters**: additive increase multiplicative decrease (AIMD) concurrency limiters ensure bursty traffic doesn't overload upstream servers.
 - **Client-side node selection**: by making load balancing decisions in the client, Dialogue avoids the necessity for an L7 proxy (and its associated latency penalty).
 - **Queue**: in the case where all nodes are limited (e.g. during a spike in traffic), requests are added to a FIFO queue and processed as soon as the one of the ConcurrencyLimiters has capacity.
-- **Retries**: requests are retried a constant number of times, unless they were streamed.
+- **Retries**: requests are retried a constant number of times, if possible.
 - **Live reloading**: uris can be added or removed without losing ConcurrencyLimiter or node selection states.
 - **Content decoding**: JSON, [SMILE](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/smile) and [CBOR](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/cbor) are supported by default, with user-defined encodings also supported.
 - **Streaming**: requests and responses are streamed without buffering the entire body into memory.


### PR DESCRIPTION
## Before this PR

We had a pretty minimal README, with no usage info, version information, license or description of features.

## After this PR
==COMMIT_MSG==
README mentions some key features, usage and interaction with conjure.
==COMMIT_MSG==

Sentences are always contentious, I'm sure there's plenty that can be improved here. Just wanted to get _something_ in so that when people receive excavator PRs to adopt dialogue they aren't too confused.

## Possible downsides?

