### PR TITLE
dialogue.pinuntilerror tagged by channel-name

### DIFF
--- a/changelog/@unreleased/pr-560.v2.yml
+++ b/changelog/@unreleased/pr-560.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Metrics for the PinUntilErrorChannel are now tagged by channel-name
+  links:
+  - https://github.com/palantir/dialogue/pull/560

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -108,7 +108,11 @@ public final class DialogueChannel implements Channel {
         newUris.forEach(uri -> limitedChannelByUri.put(uri, createLimitedChannel(uri, allUris.indexOf(uri))));
 
         nodeSelectionStrategy.getAndUpdate(previous -> getUpdatedNodeSelectionStrategy(
-                previous, clientConfiguration, ImmutableList.copyOf(limitedChannelByUri.values()), random));
+                previous,
+                clientConfiguration,
+                ImmutableList.copyOf(limitedChannelByUri.values()),
+                random,
+                channelName));
     }
 
     private LimitedChannel createLimitedChannel(String uri, int uriIndex) {
@@ -135,7 +139,8 @@ public final class DialogueChannel implements Channel {
             @Nullable LimitedChannel previousNodeSelectionStrategy,
             ClientConfiguration config,
             List<LimitedChannel> channels,
-            Random random) {
+            Random random,
+            String channelName) {
         if (channels.size() == 1) {
             // no fancy node selection heuristic can save us if our one node goes down
             return channels.get(0);
@@ -154,9 +159,11 @@ public final class DialogueChannel implements Channel {
                             config.nodeSelectionStrategy(),
                             channels,
                             pinuntilerrorMetrics,
-                            random);
+                            random,
+                            channelName);
                 }
-                return PinUntilErrorChannel.of(config.nodeSelectionStrategy(), channels, pinuntilerrorMetrics, random);
+                return PinUntilErrorChannel.of(
+                        config.nodeSelectionStrategy(), channels, pinuntilerrorMetrics, random, channelName);
             case ROUND_ROBIN:
                 // No need to preserve previous state with round robin
                 return new RandomSelectionChannel(channels, random);

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -54,13 +54,13 @@ namespaces:
     metrics:
       success:
         type: meter
-        tags: [hostIndex]
+        tags: [channel-name, hostIndex]
         docs: Meter of the requests that were successfully, tagged by the index of the inner channel. (Note if there are >10 nodes this metric will not be recorded).
       nextNode:
         type: meter
-        tags: [reason]
+        tags: [channel-name, reason]
         docs: Marked every time we switch to a new node, includes the reason why we switched (limited, responseCode, throwable).
-        # TODO(dfox): can we plumb the serviceName in here e.g. GatekeeperService?
       reshuffle:
+        tags: [channel-name]
         type: meter
         docs: Marked every time we reshuffle all the nodes.

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
@@ -60,6 +60,7 @@ public class PinUntilErrorChannelTest {
     private PinUntilErrorChannel pinUntilErrorWithoutReshuffle;
     private PinUntilErrorChannel pinUntilError;
     private DialoguePinuntilerrorMetrics metrics = DialoguePinuntilerrorMetrics.of(new DefaultTaggedMetricRegistry());
+    private String channelName = "channelName";
     private Random pseudo = new Random(12893712L);
 
     @BeforeEach
@@ -68,10 +69,10 @@ public class PinUntilErrorChannelTest {
 
         PinUntilErrorChannel.ConstantNodeList constantList = new PinUntilErrorChannel.ConstantNodeList(channels);
         PinUntilErrorChannel.ReshufflingNodeList shufflingList =
-                PinUntilErrorChannel.ReshufflingNodeList.of(channels, pseudo, clock, metrics);
+                PinUntilErrorChannel.ReshufflingNodeList.of(channels, pseudo, clock, metrics, channelName);
 
-        pinUntilErrorWithoutReshuffle = new PinUntilErrorChannel(constantList, 1, metrics);
-        pinUntilError = new PinUntilErrorChannel(shufflingList, 1, metrics);
+        pinUntilErrorWithoutReshuffle = new PinUntilErrorChannel(constantList, 1, metrics, channelName);
+        pinUntilError = new PinUntilErrorChannel(shufflingList, 1, metrics, channelName);
     }
 
     @Test
@@ -173,7 +174,8 @@ public class PinUntilErrorChannelTest {
     @Test
     void handles_reconstruction_from_stale_state() {
         PinUntilErrorChannel.from(
-                null, NodeSelectionStrategy.PIN_UNTIL_ERROR, ImmutableList.of(channel1, channel2), metrics, pseudo);
+                null, NodeSelectionStrategy.PIN_UNTIL_ERROR, ImmutableList.of(channel1, channel2), metrics, pseudo,
+                channelName);
     }
 
     private static int getCode(PinUntilErrorChannel channel) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorChannelTest.java
@@ -174,7 +174,11 @@ public class PinUntilErrorChannelTest {
     @Test
     void handles_reconstruction_from_stale_state() {
         PinUntilErrorChannel.from(
-                null, NodeSelectionStrategy.PIN_UNTIL_ERROR, ImmutableList.of(channel1, channel2), metrics, pseudo,
+                null,
+                NodeSelectionStrategy.PIN_UNTIL_ERROR,
+                ImmutableList.of(channel1, channel2),
+                metrics,
+                pseudo,
                 channelName);
     }
 


### PR DESCRIPTION
## Before this PR

As soon as one server had multiple dialogue clients, our graphs in DD become pretty useless.

## After this PR
==COMMIT_MSG==
Metrics for the PinUntilErrorChannel are now tagged by channel-name
==COMMIT_MSG==

## Possible downsides?
- more metrics = more $
