### PR TITLE
Support HTTP PATCH

### DIFF
--- a/changelog/@unreleased/pr-563.v2.yml
+++ b/changelog/@unreleased/pr-563.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue supports the PATCH method.
+  links:
+  - https://github.com/palantir/dialogue/pull/563

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
@@ -86,6 +86,9 @@ public final class OkHttpChannel implements Channel {
                 okRequest = okRequest.delete(
                         request.body().isPresent() ? toOkHttpBody(request.body().get()) : null);
                 break;
+            case PATCH:
+                okRequest = okRequest.patch(toOkHttpBody(request.body()));
+                break;
         }
 
         // Fill headers

--- a/dialogue-target/src/main/java/com/palantir/dialogue/HttpMethod.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/HttpMethod.java
@@ -21,5 +21,6 @@ public enum HttpMethod {
     GET,
     POST,
     PUT,
-    DELETE
+    DELETE,
+    PATCH
 }


### PR DESCRIPTION
## Before this PR

Conjure already specifies a restrictive list of HTTP Methods (GET, PUT, POST, DELETE). Dialogue currently enforces exactly the same list.

However, this has the unfortunate side-effect of meaning the dialogue feign shim cannot be used for a bunch of use-cases that c-j-r was handling just fine, e.g. talking to github apis:

```
Caused by: java.lang.IllegalArgumentException: No enum constant com.palantir.dialogue.HttpMethod.PATCH
	at java.base/java.lang.Enum.valueOf(Enum.java:240)
	at com.palantir.dialogue.HttpMethod.valueOf(HttpMethod.java:20)
	at com.palantir.conjure.java.client.jaxrs.DialogueFeignClient$FeignRequestEndpoint.<init>(DialogueFeignClient.java:323)
	at com.palantir.conjure.java.client.jaxrs.DialogueFeignClient.execute(DialogueFeignClient.java:100)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:97)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:76)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
	at com.sun.proxy.$Proxy80.updateRef(Unknown Source)
	at com.palantir.tritium.proxy.InstrumentedGithubReferenceService$3.updateRef(Unknown Source)
	at com.palantir.autorelease.Releaser.moveChangelogs(Releaser.java:256)
	at com.palantir.autorelease.Releaser.frontendRelease(Releaser.java:219)
	at com.palantir.autorelease.frontend.ReleaseResource$2.visitDefault(ReleaseResource.java:280)
	at com.palantir.autorelease.frontend.ReleaseResource$2.visitDefault(ReleaseResource.java:272)
	at com.palantir.autorelease.api.RepositoryType.accept(RepositoryType.java:80)
	at com.palantir.autorelease.frontend.ReleaseResource.release(ReleaseResource.java:272)
	... 61 more
```

Given that we have no control over github's API, it seems sad to end up in the state where some clients are just stuck on c-j-r forever.

## After this PR
==COMMIT_MSG==
Dialogue supports the PATCH method.
==COMMIT_MSG==

## Possible downsides?
- this is a bit of a weird HTTP method and one we don't really want people to use internally. My hope is that the existing conjure restrictions will keep things that way.
