### PR TITLE
RetryingChannel records stacktraces for logs (when debug logging is enabled)

### DIFF
--- a/changelog/@unreleased/pr-568.v2.yml
+++ b/changelog/@unreleased/pr-568.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    RetryingChannel records informational stacktraces when debug logging is enabled. These are not collected
+    during normal operation to avoid the performance impact on calls that don't retry.
+  links:
+  - https://github.com/palantir/dialogue/pull/568


### PR DESCRIPTION
## Before this PR

Motivation here: https://github.com/palantir/dialogue/issues/565

## After this PR
==COMMIT_MSG==
RetryingChannel records informational stacktraces when debug logging enabled.
==COMMIT_MSG==

## Possible downsides?
- recording stacktraces is expensive, so we don't want to do it all the time
- don't have any tests, could regress