### PR TITLE
Some helpful toStrings for debugging

### DIFF
--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/BinaryEncoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/BinaryEncoding.java
@@ -44,9 +44,9 @@ enum BinaryEncoding implements Encoding {
     @SuppressWarnings("unchecked")
     public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
         if (MARKER.equals(type)) {
-            return input -> (T) input;
+            return (Deserializer<T>) InputStreamDeserializer.INSTANCE;
         } else if (OPTIONAL_MARKER.equals(type)) {
-            return input -> (T) Optional.of(input);
+            return (Deserializer<T>) OptionalInputStreamDeserializer.INSTANCE;
         }
         throw new SafeIllegalStateException(
                 "BinaryEncoding only supports InputStream and Optional<InputStream>", SafeArg.of("requested", type));
@@ -60,5 +60,38 @@ enum BinaryEncoding implements Encoding {
     @Override
     public boolean supportsContentType(String contentType) {
         return Encodings.matchesContentType(CONTENT_TYPE, contentType);
+    }
+
+    @Override
+    public String toString() {
+        return "BinaryEncoding{" + CONTENT_TYPE + '}';
+    }
+
+    enum OptionalInputStreamDeserializer implements Deserializer<Object> {
+        INSTANCE;
+
+        @Override
+        public Object deserialize(InputStream input) {
+            return Optional.of(input);
+        }
+
+        @Override
+        public String toString() {
+            return "OptionalInputStreamDeserializer{}";
+        }
+    }
+
+    enum InputStreamDeserializer implements Deserializer<Object> {
+        INSTANCE;
+
+        @Override
+        public Object deserialize(InputStream input) {
+            return input;
+        }
+
+        @Override
+        public String toString() {
+            return "InputStreamDeserializer{}";
+        }
     }
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -247,7 +247,10 @@ final class ConjureBodySerDe implements BodySerDe {
                     return container;
                 }
             }
-            throw new SafeRuntimeException("Unsupported Content-Type", SafeArg.of("Content-Type", contentType));
+            throw new SafeRuntimeException(
+                    "Unsupported Content-Type",
+                    SafeArg.of("received", contentType.get()),
+                    SafeArg.of("supportedEncodings", encodings));
         }
     }
 
@@ -259,6 +262,11 @@ final class ConjureBodySerDe implements BodySerDe {
         EncodingDeserializerContainer(Encoding encoding, TypeMarker<T> token) {
             this.encoding = encoding;
             this.deserializer = encoding.deserializer(token);
+        }
+
+        @Override
+        public String toString() {
+            return "EncodingDeserializerContainer{encoding=" + encoding + ", deserializer=" + deserializer + '}';
         }
     }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -287,5 +287,10 @@ final class ConjureBodySerDe implements BodySerDe {
         public Optional<String> accepts() {
             return Optional.empty();
         }
+
+        @Override
+        public String toString() {
+            return "EmptyBodyDeserializer{}";
+        }
     }
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encoding.java
@@ -42,7 +42,7 @@ public interface Encoding {
      */
     <T> Deserializer<T> deserializer(TypeMarker<T> type);
 
-    /** Returns the value used in response <pre>Content-Type</pre> header. */
+    /** Returns the value used in request <pre>Content-Type</pre> headers. */
     String getContentType();
 
     /**

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encodings.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encodings.java
@@ -77,6 +77,11 @@ public final class Encodings {
                 }
             };
         }
+
+        @Override
+        public final String toString() {
+            return "AbstractJacksonEncoding{" + getContentType() + '}';
+        }
     }
 
     /** Returns a serializer for the Conjure JSON wire format. */


### PR DESCRIPTION
## Before this PR

I noticed a few classes don't have nice toStrings, which makes it a bit trickier when hooked up to a debugger because you have to expand a bunch of classes.

## After this PR
==COMMIT_MSG==
More encoding-related classes now have helpful toString implementations
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
