### PR TITLE
Escape plus sign in query strings

### DIFF
--- a/changelog/@unreleased/pr-572.v2.yml
+++ b/changelog/@unreleased/pr-572.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Dialogue now precent-encodes the plus sign character in query strings.
+  links:
+  - https://github.com/palantir/dialogue/pull/572

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -221,6 +221,8 @@ public final class BaseUrl {
         private static final CharMatcher IS_HOST = UNRESERVED.or(SUB_DELIMS);
         private static final CharMatcher IS_P_CHAR = UNRESERVED.or(SUB_DELIMS);
         private static final CharMatcher IS_PATH = UNRESERVED.or(SUB_DELIMS).or(CharMatcher.anyOf("/"));
+        // The RFC permits percent-encoding any character. We also percent encode '+' because otherwise most servers
+        // interpret it as an url encoded space.
         private static final CharMatcher IS_QUERY_CHAR =
                 IS_P_CHAR.or(CharMatcher.anyOf("/?")).and(CharMatcher.noneOf("=&+"));
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -222,7 +222,7 @@ public final class BaseUrl {
         private static final CharMatcher IS_P_CHAR = UNRESERVED.or(SUB_DELIMS);
         private static final CharMatcher IS_PATH = UNRESERVED.or(SUB_DELIMS).or(CharMatcher.anyOf("/"));
         private static final CharMatcher IS_QUERY_CHAR =
-                CharMatcher.anyOf("=&").negate().and(IS_P_CHAR.or(CharMatcher.anyOf("?/")));
+                IS_P_CHAR.or(CharMatcher.anyOf("/?")).and(CharMatcher.noneOf("=&+"));
 
         static boolean isHost(String maybeHost) {
             return IS_HOST.matchesAllOf(maybeHost) || isIpv6Host(maybeHost);

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -160,11 +160,11 @@ public final class UrlBuilderTest {
 
     @Test
     public void urlEncoder_encodeQuery_onlyEncodesNonReservedChars() {
-        String nonReserved = "aAzZ09!$'()*+,;?/";
+        String nonReserved = "aAzZ09!$'()*,;/?";
         assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue(nonReserved)).isEqualTo(nonReserved);
         assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("@[]{}ßçö"))
                 .isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("&=")).isEqualTo("%26%3D");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("=&+")).isEqualTo("%3D%26%2B");
     }
 
     @Test

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -168,6 +168,11 @@ public final class UrlBuilderTest {
     }
 
     @Test
+    public void urlEncoder_encodeQuery_encodesPlusSign() {
+        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("+")).isEqualTo("%2B");
+    }
+
+    @Test
     public void newBuilderCopiesAllFields() throws Exception {
         BaseUrl.DefaultUrlBuilder original = BaseUrl.DefaultUrlBuilder.from(new URL("http://foo:42"))
                 .pathSegment("foo")


### PR DESCRIPTION
## Before this PR
The `+` character is not escaped when used in query strings.

## After this PR
The `+` character is escaped when used in query strings.

According to [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.4), `+` is a valid character in a query string and does not need to be escaped. However, the [W3C recommendations for URI addressing](https://www.w3.org/Addressing/URL/4_URI_Recommentations.html) state that `+` is shorthand notation for a space. In practice, nearly all servers interpret `+` as a space and most URL encoding libraries escape `+` in query strings. In order to be compatible with server implementations, we should escape the `+` character in query strings.