### PR TITLE
Provide a tracing operation name to the blocking adapter executor

### DIFF
--- a/changelog/@unreleased/pr-585.v2.yml
+++ b/changelog/@unreleased/pr-585.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide a tracing operation name to the blocking adapter executor
+  links:
+  - https://github.com/palantir/dialogue/pull/585

--- a/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
+++ b/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
@@ -41,8 +41,9 @@ public final class BlockingChannelAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(BlockingChannelAdapter.class);
 
-    private static final Supplier<ExecutorService> blockingExecutor =
-            Suppliers.memoize(() -> Tracers.wrap(Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+    private static final Supplier<ExecutorService> blockingExecutor = Suppliers.memoize(() -> Tracers.wrap(
+            "dialogue-blocking-channel",
+            Executors.newCachedThreadPool(new ThreadFactoryBuilder()
                     .setNameFormat("dialogue-blocking-channel-%d")
                     .setDaemon(true)
                     .build())));


### PR DESCRIPTION
==COMMIT_MSG==
Provide a tracing operation name to the blocking adapter executor
==COMMIT_MSG==