### PR TITLE
Update JacksonEmptyContainerLoader to use Type, not Class

### DIFF
--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.java.dialogue.serde;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -132,7 +131,7 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
     private Optional<Object> jacksonDeserializeFromNull(Type type) {
         try {
             return Optional.ofNullable(mapper.readerFor(mapper.getTypeFactory().constructType(type))
-                    .readValue(NullNode.instance));
+                    .readValue(mapper.nullNode()));
         } catch (IOException e) {
             return Optional.empty();
         }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
@@ -18,10 +18,10 @@ package com.palantir.conjure.java.dialogue.serde;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -50,39 +50,40 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getEmptyInstance(TypeMarker<T> token) {
-        Class<?> clazz = getClass(token.getType());
-        return (T) constructEmptyInstance(clazz, token, 10)
+        return (T) constructEmptyInstance(token.getType(), token, 10)
                 .orElseThrow(() -> new SafeIllegalStateException(
                         "Unable to construct empty container type", SafeArg.of("type", token)));
     }
 
-    private Optional<Object> constructEmptyInstance(Class<?> clazz, TypeMarker<?> token, int maxRecursion) {
+    private Optional<Object> constructEmptyInstance(Type type, TypeMarker<?> originalType, int maxRecursion) {
 
         // handle Map, List, Set
-        Optional<Object> collection = coerceCollections(clazz);
+        Optional<Object> collection = coerceCollections(type);
         if (collection.isPresent()) {
             return collection;
         }
 
         // this is our preferred way to construct instances
-        Optional<Object> jacksonInstance = jacksonDeserializeFromNull(clazz);
+        Optional<Object> jacksonInstance = jacksonDeserializeFromNull(type);
         if (jacksonInstance.isPresent()) {
             return jacksonInstance;
         }
 
         // fallback to manual reflection to handle aliases of optionals (and aliases of aliases of optionals)
-        Optional<Method> jsonCreator = getJsonCreatorStaticMethod(clazz);
+        Optional<Method> jsonCreator = getJsonCreatorStaticMethod(type);
         if (jsonCreator.isPresent()) {
             Method method = jsonCreator.get();
-            Class<?> parameterType = method.getParameters()[0].getType();
-            Optional<Object> parameter = constructEmptyInstance(parameterType, token, decrement(maxRecursion, token));
+            Type parameterType = method.getParameters()[0].getParameterizedType();
+            // Class<?> parameterType = method.getParameters()[0].getType();
+            Optional<Object> parameter =
+                    constructEmptyInstance(parameterType, originalType, decrement(maxRecursion, originalType));
 
             if (parameter.isPresent()) {
                 return invokeStaticFactoryMethod(method, parameter.get());
             } else {
                 log.debug(
                         "Found a @JsonCreator, but couldn't construct the parameter",
-                        SafeArg.of("type", token),
+                        SafeArg.of("type", type),
                         SafeArg.of("parameter", parameter));
                 return Optional.empty();
             }
@@ -90,7 +91,7 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
 
         log.debug(
                 "Jackson couldn't instantiate an empty instance and also couldn't find a usable @JsonCreator",
-                SafeArg.of("type", token));
+                SafeArg.of("type", type));
         return Optional.empty();
     }
 
@@ -100,6 +101,20 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
                 "Unable to construct an empty instance as @JsonCreator requires too much recursion",
                 SafeArg.of("type", originalType));
         return maxRecursion - 1;
+    }
+
+    private static Optional<Object> coerceCollections(Type type) {
+        if (type instanceof Class) {
+            return coerceCollections((Class<?>) type);
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type raw = parameterizedType.getRawType();
+            if (raw instanceof Class) {
+                return coerceCollections((Class<?>) raw);
+            }
+        }
+        return Optional.empty();
     }
 
     private static Optional<Object> coerceCollections(Class<?> clazz) {
@@ -114,21 +129,26 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
         }
     }
 
-    private Optional<Object> jacksonDeserializeFromNull(Class<?> clazz) {
+    private Optional<Object> jacksonDeserializeFromNull(Type type) {
         try {
-            return Optional.ofNullable(mapper.readValue("null", clazz));
+            return Optional.ofNullable(mapper.readerFor(mapper.getTypeFactory().constructType(type))
+                    .readValue(NullNode.instance));
         } catch (IOException e) {
             return Optional.empty();
         }
     }
 
     // doesn't attempt to handle multiple @JsonCreator methods on one class
-    private static Optional<Method> getJsonCreatorStaticMethod(@Nonnull Class<?> clazz) {
-        return Arrays.stream(clazz.getMethods())
-                .filter(method -> Modifier.isStatic(method.getModifiers())
-                        && method.getParameterCount() == 1
-                        && method.getAnnotation(JsonCreator.class) != null)
-                .findFirst();
+    private static Optional<Method> getJsonCreatorStaticMethod(@Nonnull Type type) {
+        if (type instanceof Class) {
+            Class<?> clazz = (Class<?>) type;
+            return Arrays.stream(clazz.getMethods())
+                    .filter(method -> Modifier.isStatic(method.getModifiers())
+                            && method.getParameterCount() == 1
+                            && method.getAnnotation(JsonCreator.class) != null)
+                    .findFirst();
+        }
+        return Optional.empty();
     }
 
     private static Optional<Object> invokeStaticFactoryMethod(Method method, Object parameter) {
@@ -137,17 +157,6 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
         } catch (IllegalAccessException | InvocationTargetException e) {
             log.debug("Reflection instantiation failed", e);
             return Optional.empty();
-        }
-    }
-
-    private static Class<?> getClass(Type type) {
-        if (type instanceof Class) {
-            return (Class<?>) type;
-        } else if (type instanceof ParameterizedType) {
-            ParameterizedType parameterized = (ParameterizedType) type;
-            return getClass(parameterized.getRawType());
-        } else {
-            throw new SafeIllegalArgumentException("Unable to getClass", SafeArg.of("type", type));
         }
     }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -36,6 +36,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -267,6 +268,22 @@ public class ConjureBodySerDeTest {
 
         assertThatExceptionOfType(RemoteException.class)
                 .isThrownBy(() -> serializers.emptyBodyDeserializer().deserialize(response));
+    }
+
+    @Test
+    public void testEmptyResponse_list() {
+        BodySerDe serde = DefaultConjureRuntime.builder().build().bodySerDe();
+        List<String> result =
+                serde.deserializer(new TypeMarker<List<String>>() {}).deserialize(new TestResponse().code(204));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void testEmptyResponse_list_raw() {
+        BodySerDe serde = DefaultConjureRuntime.builder().build().bodySerDe();
+        List result = serde.deserializer(new TypeMarker<List>() {}).deserialize(new TestResponse().code(204));
+        assertThat(result).isEmpty();
     }
 
     /** Deserializes requests as the configured content type. */


### PR DESCRIPTION
This way we can avoid losing context.

==COMMIT_MSG==
Update JacksonEmptyContainerLoader to use Type, not Class
==COMMIT_MSG==
