### PR TITLE
Refactor optional deserialization to avoid memoization

### DIFF
--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -215,7 +215,7 @@ final class ConjureBodySerDe implements BodySerDe {
                     .collect(ImmutableList.toImmutableList());
             this.errorDecoder = errorDecoder;
             this.token = token;
-            this.emptyInstance = empty.getEmptyInstanceIfOptional(token);
+            this.emptyInstance = empty.tryGetEmptyInstance(token);
             // Encodings are applied to the accept header in the order of preference based on the provided list.
             this.acceptValue =
                     Optional.of(encodings.stream().map(Encoding::getContentType).collect(Collectors.joining(", ")));

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.dialogue.serde;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.dialogue.BinaryRequestBody;
@@ -38,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.HttpHeaders;
 import org.slf4j.Logger;
@@ -204,7 +202,8 @@ final class ConjureBodySerDe implements BodySerDe {
         private final ImmutableList<EncodingDeserializerContainer<T>> encodings;
         private final ErrorDecoder errorDecoder;
         private final Optional<String> acceptValue;
-        private final Supplier<T> emptyInstance;
+        private final Optional<T> emptyInstance;
+        private final TypeMarker<T> token;
 
         EncodingDeserializerRegistry(
                 List<Encoding> encodings,
@@ -215,7 +214,8 @@ final class ConjureBodySerDe implements BodySerDe {
                     .map(encoding -> new EncodingDeserializerContainer<>(encoding, token))
                     .collect(ImmutableList.toImmutableList());
             this.errorDecoder = errorDecoder;
-            this.emptyInstance = Suppliers.memoize(() -> empty.getEmptyInstance(token)); // TODO(dfox): save exception?
+            this.token = token;
+            this.emptyInstance = empty.getEmptyInstanceIfOptional(token);
             // Encodings are applied to the accept header in the order of preference based on the provided list.
             this.acceptValue =
                     Optional.of(encodings.stream().map(Encoding::getContentType).collect(Collectors.joining(", ")));
@@ -231,7 +231,11 @@ final class ConjureBodySerDe implements BodySerDe {
                     // TODO(dfox): what if we get a 204 for a non-optional type???
                     // TODO(dfox): support http200 & body=null
                     // TODO(dfox): what if we were expecting an empty list but got {}?
-                    return emptyInstance.get();
+                    if (emptyInstance.isPresent()) {
+                        return emptyInstance.get();
+                    }
+                    throw new SafeRuntimeException(
+                            "Unable to deserialize non-optional response type from 204", SafeArg.of("type", token));
                 }
 
                 Optional<String> contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/EmptyContainerDeserializer.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/EmptyContainerDeserializer.java
@@ -21,6 +21,9 @@ import java.util.Optional;
 
 interface EmptyContainerDeserializer {
 
-    /** Throws if constructing an empty instance is not possible. */
-    <T> Optional<T> getEmptyInstanceIfOptional(TypeMarker<T> typeMarker);
+    /**
+     * Constructs an empty instance if the type {@code T} supports empty values, otherwise returns
+     * {@link Optional#empty()}.
+     */
+    <T> Optional<T> tryGetEmptyInstance(TypeMarker<T> typeMarker);
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/EmptyContainerDeserializer.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/EmptyContainerDeserializer.java
@@ -17,9 +17,10 @@
 package com.palantir.conjure.java.dialogue.serde;
 
 import com.palantir.dialogue.TypeMarker;
+import java.util.Optional;
 
 interface EmptyContainerDeserializer {
 
     /** Throws if constructing an empty instance is not possible. */
-    <T> T getEmptyInstance(TypeMarker<T> typeMarker);
+    <T> Optional<T> getEmptyInstanceIfOptional(TypeMarker<T> typeMarker);
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
@@ -47,7 +47,7 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Optional<T> getEmptyInstanceIfOptional(TypeMarker<T> token) {
+    public <T> Optional<T> tryGetEmptyInstance(TypeMarker<T> token) {
         return (Optional<T>) constructEmptyInstance(token.getType(), token, 10);
     }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -48,10 +47,8 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T getEmptyInstance(TypeMarker<T> token) {
-        return (T) constructEmptyInstance(token.getType(), token, 10)
-                .orElseThrow(() -> new SafeIllegalStateException(
-                        "Unable to construct empty container type", SafeArg.of("type", token)));
+    public <T> Optional<T> getEmptyInstanceIfOptional(TypeMarker<T> token) {
+        return (Optional<T>) constructEmptyInstance(token.getType(), token, 10);
     }
 
     private Optional<Object> constructEmptyInstance(Type type, TypeMarker<?> originalType, int maxRecursion) {

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoaderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoaderTest.java
@@ -64,25 +64,25 @@ public class JacksonEmptyContainerLoaderTest {
 
     @Test
     public void http_204_turns_empty_body_into_alias_of_OptionalEmpty() {
-        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<Alias1>() {}))
+        assertThat(emptyContainerDecoder.tryGetEmptyInstance(new TypeMarker<Alias1>() {}))
                 .hasValue(Alias1.of(Optional.empty()));
     }
 
     @Test
     public void http_204_turns_empty_body_into_alias_of_OptionalInt() {
-        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<Alias2>() {}))
+        assertThat(emptyContainerDecoder.tryGetEmptyInstance(new TypeMarker<Alias2>() {}))
                 .hasValue(Alias2.of(OptionalInt.empty()));
     }
 
     @Test
     public void http_204_turns_empty_body_into_alias_of_OptionalDouble() {
-        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<Alias3>() {}))
+        assertThat(emptyContainerDecoder.tryGetEmptyInstance(new TypeMarker<Alias3>() {}))
                 .hasValue(Alias3.of(OptionalDouble.empty()));
     }
 
     @Test
     public void http_204_can_handle_alias_of_alias_of_optional_string() {
-        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<AliasAlias1>() {}))
+        assertThat(emptyContainerDecoder.tryGetEmptyInstance(new TypeMarker<AliasAlias1>() {}))
                 .hasValue(AliasAlias1.of(Alias1.of(Optional.empty())));
     }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoaderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoaderTest.java
@@ -64,25 +64,25 @@ public class JacksonEmptyContainerLoaderTest {
 
     @Test
     public void http_204_turns_empty_body_into_alias_of_OptionalEmpty() {
-        assertThat(emptyContainerDecoder.getEmptyInstance(new TypeMarker<Alias1>() {}))
-                .isEqualTo(Alias1.of(Optional.empty()));
+        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<Alias1>() {}))
+                .hasValue(Alias1.of(Optional.empty()));
     }
 
     @Test
     public void http_204_turns_empty_body_into_alias_of_OptionalInt() {
-        assertThat(emptyContainerDecoder.getEmptyInstance(new TypeMarker<Alias2>() {}))
-                .isEqualTo(Alias2.of(OptionalInt.empty()));
+        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<Alias2>() {}))
+                .hasValue(Alias2.of(OptionalInt.empty()));
     }
 
     @Test
     public void http_204_turns_empty_body_into_alias_of_OptionalDouble() {
-        assertThat(emptyContainerDecoder.getEmptyInstance(new TypeMarker<Alias3>() {}))
-                .isEqualTo(Alias3.of(OptionalDouble.empty()));
+        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<Alias3>() {}))
+                .hasValue(Alias3.of(OptionalDouble.empty()));
     }
 
     @Test
     public void http_204_can_handle_alias_of_alias_of_optional_string() {
-        assertThat(emptyContainerDecoder.getEmptyInstance(new TypeMarker<AliasAlias1>() {}))
-                .isEqualTo(AliasAlias1.of(Alias1.of(Optional.empty())));
+        assertThat(emptyContainerDecoder.getEmptyInstanceIfOptional(new TypeMarker<AliasAlias1>() {}))
+                .hasValue(AliasAlias1.of(Alias1.of(Optional.empty())));
     }
 }


### PR DESCRIPTION
While I think it may be helpful to memoize encoding bits, it's
odd that we memoize only some pieces.

==COMMIT_MSG==
Refactor optional deserialization to avoid memoization
==COMMIT_MSG==