### PR TITLE
Promote smile encoding to be preferred over json response encoding

### DIFF
--- a/changelog/@unreleased/pr-594.v2.yml
+++ b/changelog/@unreleased/pr-594.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Promote smile encoding to be preferred over json response encoding
+  links:
+  - https://github.com/palantir/dialogue/pull/594

--- a/changelog/@unreleased/pr-594.v2.yml
+++ b/changelog/@unreleased/pr-594.v2.yml
@@ -1,5 +1,9 @@
 type: improvement
 improvement:
-  description: Promote smile encoding to be preferred over json response encoding
+  description: Promote smile encoding to be preferred over json response encoding for more efficient and compat serialization.
+  While our existing infrastructure applies gzip content-compression to responses, the smile format removes the need for
+  CPU-expensive gzip compression in many cases, and allows the compressor to focus on the dynamic data (patterns in the values)
+  in responses that still exceed the compression threshold.
+  In practice we've seen SMILE encoding offer 50% increases in end-to-end performance when large structured objects are involved.
   links:
   - https://github.com/palantir/dialogue/pull/594

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
@@ -31,8 +31,8 @@ import java.util.List;
 public final class DefaultConjureRuntime implements ConjureRuntime {
 
     static final ImmutableList<WeightedEncoding> DEFAULT_ENCODINGS = ImmutableList.of(
-            WeightedEncoding.of(Encodings.json(), 1),
-            WeightedEncoding.of(Encodings.smile(), .9),
+            WeightedEncoding.of(Encodings.json(), .9),
+            WeightedEncoding.of(Encodings.smile(), 1),
             WeightedEncoding.of(Encodings.cbor(), .7));
 
     private final BodySerDe bodySerDe;


### PR DESCRIPTION
Note that this change intentionally does not promote CBOR, which
may be supported on other non-java platforms. This allows us to
minimally take advantage of binary encoding without risking changes
in nonstandard consumers yet.

## After this PR
==COMMIT_MSG==
Promote smile encoding to be preferred over json response encoding
==COMMIT_MSG==

## Possible downsides?
It's new and different!
