### PR TITLE
Provide an AuthHeader plain serializer

### DIFF
--- a/changelog/@unreleased/pr-600.v2.yml
+++ b/changelog/@unreleased/pr-600.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide an AuthHeader plain serializer
+  links:
+  - https://github.com/palantir/dialogue/pull/600

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjurePlainSerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjurePlainSerDe.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.dialogue.serde;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.dialogue.PlainSerDe;
 import com.palantir.ri.ResourceIdentifier;
+import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -26,6 +27,11 @@ import java.util.UUID;
 /** Package private internal API. */
 enum ConjurePlainSerDe implements PlainSerDe {
     INSTANCE;
+
+    @Override
+    public String serializeAuthHeader(AuthHeader in) {
+        return in.toString();
+    }
 
     @Override
     public String serializeBearerToken(BearerToken in) {

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/PlainSerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/PlainSerDeTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.dialogue.PlainSerDe;
 import com.palantir.ri.ResourceIdentifier;
+import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -31,6 +32,13 @@ import org.junit.jupiter.api.Test;
 public final class PlainSerDeTest {
 
     private static final PlainSerDe PLAIN = ConjurePlainSerDe.INSTANCE;
+
+    @Test
+    public void testSerializeAuthHeader() {
+        AuthHeader in = AuthHeader.of(BearerToken.valueOf("token"));
+        String out = "Bearer token";
+        assertThat(PLAIN.serializeAuthHeader(in)).isEqualTo(out);
+    }
 
     @Test
     public void testSerializeBearerToken() {

--- a/dialogue-target/src/main/java/com/palantir/dialogue/PlainSerDe.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/PlainSerDe.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue;
 
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.ri.ResourceIdentifier;
+import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -29,6 +30,8 @@ import java.util.UUID;
  * These utilities are used to serialize HTTP path, query, and header parameter values.
  */
 public interface PlainSerDe {
+
+    String serializeAuthHeader(AuthHeader in);
 
     String serializeBearerToken(BearerToken in);
 


### PR DESCRIPTION
This will allow us to update codegen to seralize auth headers
with the 'Bearer' prefix.

## After this PR
==COMMIT_MSG==
Provide an AuthHeader plain serializer
==COMMIT_MSG==
