### PR TITLE
DialogueChannel behaves when initialized or live-reloaded with zero uris

### DIFF
--- a/changelog/@unreleased/pr-602.v2.yml
+++ b/changelog/@unreleased/pr-602.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: A DialogueChannel can now be constructed with zero uris (or live-reloaded
+    to zero uris).  In this state, all requests are just queued up and drained when
+    uris become available.
+  links:
+  - https://github.com/palantir/dialogue/pull/602

--- a/dialogue-core/build.gradle
+++ b/dialogue-core/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile 'com.palantir.safethreadlocalrandom:safe-thread-local-random'
     implementation 'com.palantir.tritium:tritium-metrics'
 
+    testImplementation project(':dialogue-client-test-lib')
     testImplementation 'com.palantir.tracing:tracing-test-utils'
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -48,7 +48,9 @@ import javax.annotation.Nullable;
 
 public final class DialogueChannel implements Channel {
     private final Map<String, LimitedChannel> limitedChannelByUri = new ConcurrentHashMap<>();
-    private final AtomicReference<LimitedChannel> nodeSelectionStrategy = new AtomicReference<>();
+    private final AtomicReference<LimitedChannel> nodeSelectionStrategy =
+            new AtomicReference<>(ZeroUriChannel.INSTANCE);
+    private final QueuedChannel queuedChannel; // just so we can process the queue when uris reload
 
     private final String channelName;
     private final ClientConfiguration clientConfiguration;
@@ -69,17 +71,14 @@ public final class DialogueChannel implements Channel {
         this.channelName = channelName;
         this.clientConfiguration = clientConfiguration;
         this.channelFactory = channelFactory;
-        clientMetrics = DialogueClientMetrics.of(clientConfiguration.taggedMetricRegistry());
+        this.clientMetrics = DialogueClientMetrics.of(clientConfiguration.taggedMetricRegistry());
         this.clock = clock;
         this.random = random;
+        this.queuedChannel =
+                new QueuedChannel(new SupplierChannel(nodeSelectionStrategy::get), channelName, clientMetrics);
+
         updateUris(clientConfiguration.uris());
-        this.delegate = wrap(
-                channelName,
-                new SupplierChannel(nodeSelectionStrategy::get),
-                clientConfiguration,
-                scheduler,
-                random,
-                clientMetrics);
+        this.delegate = wrap(queuedChannel, channelName, clientConfiguration, scheduler, random, clientMetrics);
     }
 
     @Override
@@ -110,6 +109,9 @@ public final class DialogueChannel implements Channel {
                 ImmutableList.copyOf(limitedChannelByUri.values()),
                 random,
                 channelName));
+
+        // some stuck requests might be able to make progress now
+        queuedChannel.schedule();
     }
 
     private LimitedChannel createLimitedChannel(String uri, int uriIndex) {
@@ -132,11 +134,15 @@ public final class DialogueChannel implements Channel {
     }
 
     private static LimitedChannel getUpdatedNodeSelectionStrategy(
-            @Nullable LimitedChannel previousNodeSelectionStrategy,
+            LimitedChannel previousNodeSelectionStrategy,
             ClientConfiguration config,
             List<LimitedChannel> channels,
             Random random,
             String channelName) {
+        if (channels.isEmpty()) {
+            return ZeroUriChannel.INSTANCE;
+        }
+
         if (channels.size() == 1) {
             // no fancy node selection heuristic can save us if our one node goes down
             return channels.get(0);
@@ -210,13 +216,13 @@ public final class DialogueChannel implements Channel {
     }
 
     private static Channel wrap(
+            QueuedChannel queuedChannel,
             String channelName,
-            LimitedChannel delegate,
             ClientConfiguration conf,
             Supplier<ScheduledExecutorService> scheduler,
             Random random,
             DialogueClientMetrics clientMetrics) {
-        Channel channel = new LimitedChannelToChannelAdapter(new QueuedChannel(delegate, channelName, clientMetrics));
+        Channel channel = new LimitedChannelToChannelAdapter(queuedChannel);
         channel = new TracedChannel(channel, "Dialogue-request-attempt");
         channel = retryingChannel(channel, channelName, conf, scheduler, random);
         channel = new UserAgentChannel(channel, conf.userAgent().get());
@@ -294,7 +300,6 @@ public final class DialogueChannel implements Channel {
         }
 
         private void preconditions(ClientConfiguration conf) {
-            Preconditions.checkArgument(!conf.uris().isEmpty(), "channels must not be empty");
             Preconditions.checkArgument(conf.userAgent().isPresent(), "config.userAgent() must be specified");
             Preconditions.checkArgument(
                     conf.retryOnSocketException() == ClientConfiguration.RetryOnSocketException.ENABLED,

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -45,8 +45,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class DialogueChannel implements Channel {
+    private static final Logger log = LoggerFactory.getLogger(DialogueChannel.class);
+
     private final Map<String, LimitedChannel> limitedChannelByUri = new ConcurrentHashMap<>();
     private final AtomicReference<LimitedChannel> nodeSelectionStrategy =
             new AtomicReference<>(ZeroUriChannel.INSTANCE);
@@ -140,6 +144,7 @@ public final class DialogueChannel implements Channel {
             Random random,
             String channelName) {
         if (channels.isEmpty()) {
+            log.info("Zero URIs available, all requests will be queued", SafeArg.of("channelName", channelName));
             return ZeroUriChannel.INSTANCE;
         }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ZeroUriChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ZeroUriChannel.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import java.util.Optional;
+
+/** When we literally have zero URIs, no request can get out the door. */
+enum ZeroUriChannel implements LimitedChannel {
+    INSTANCE;
+
+    @Override
+    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint _endpoint, Request _request) {
+        return Optional.empty();
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelsTest.java
@@ -63,7 +63,7 @@ public final class DialogueChannelsTest {
     public static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of("foo", "1.0.0"));
     private static final SslConfiguration SSL_CONFIG = SslConfiguration.of(
             Paths.get("src/test/resources/trustStore.jks"), Paths.get("src/test/resources/keyStore.jks"), "keystore");
-    private static final ClientConfiguration stubConfig = ClientConfiguration.builder()
+    private final ClientConfiguration stubConfig = ClientConfiguration.builder()
             .from(ClientConfigurations.of(ServiceConfiguration.builder()
                     .addUris("http://localhost")
                     .security(SSL_CONFIG)
@@ -235,7 +235,7 @@ public final class DialogueChannelsTest {
         }
     }
 
-    private static long queuedRequestsCounter() {
+    private long queuedRequestsCounter() {
         Map<MetricName, Metric> metrics = Maps.filterKeys(
                 stubConfig.taggedMetricRegistry().getMetrics(),
                 name -> Objects.equals(name.safeName(), "dialogue.client.requests.queued"));

--- a/simulation/src/test/resources/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44767eb097c4d42cf3def98195f1a922d5c2cc049038bd772704d8b50b435de6
-size 125985
+oid sha256:ea23d49ca04a3224660d3a4e67ff1b0df4b7b30d7bff380ef3e601da8fe8fa6d
+size 123159

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -14,7 +14,7 @@
             fast_500s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=76.0%	client_mean=PT0.055333733S 	server_cpu=PT3M27.501499711S	client_received=3750/3750	server_resps=3750	codes={200=2849, 500=901}
                       fast_500s_then_revert[UNLIMITED_ROUND_ROBIN].txt:	success=76.0%	client_mean=PT0.055333733S 	server_cpu=PT3M27.501499711S	client_received=3750/3750	server_resps=3750	codes={200=2849, 500=901}
                live_reloading[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT12.9285176S  	server_cpu=PT2H2M54.3S    	client_received=2500/2500	server_resps=2500	codes={200=2500}
-                   live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=64.0%	client_mean=PT4.2080936S   	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1600, 500=900}
+                   live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=63.7%	client_mean=PT4.210672S    	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1593, 500=907}
                              live_reloading[UNLIMITED_ROUND_ROBIN].txt:	success=55.8%	client_mean=PT2.84916S     	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1394, 500=1106}
           one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].txt:	success=79.0%	client_mean=PT1.478050977S 	server_cpu=PT1M59.71393673S	client_received=1000/1000	server_resps=790	codes={200=790, Failed to make a request=210}
                 one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT3.53697893S  	server_cpu=PT2M30S        	client_received=1000/1000	server_resps=1000	codes={200=1000}

--- a/simulation/src/test/resources/txt/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=64.0%	client_mean=PT4.2080936S   	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1600, 500=900}
+success=63.7%	client_mean=PT4.210672S    	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1593, 500=907}


### PR DESCRIPTION
## Before this PR

Saw a strange DataDog graph, one hypothesis is that it's somehow caused by having zero uris. Wanted to capture the expected behaviour, and in writing the test I think it's all a bit broken.

## After this PR
==COMMIT_MSG==
A DialogueChannel can now be constructed with zero uris (or live-reloaded to zero uris).  In this state, all requests are just queued up and drained when uris become available.
==COMMIT_MSG==

I'm not sure this ever really happens in practise, but given that it's an edge case which _could_ happen (especially when there's eventual consistency in our service discovery), I figured we might as well make it behave sensibly.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
