### PR TITLE
Live reloading an extra uri allows QueuedChannel to make progress

### DIFF
--- a/changelog/@unreleased/pr-605.v2.yml
+++ b/changelog/@unreleased/pr-605.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Live reloading an extra uri allows some queued requests to immediately
+    make progress. (Previously they wouldn't be considered until a new request or
+    response was received).
+  links:
+  - https://github.com/palantir/dialogue/pull/605

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -42,6 +42,8 @@ import javax.annotation.Nullable;
  * {@link #maybeExecute} method returns empty.
  */
 final class ConcurrencyLimitedChannel implements LimitedChannel {
+    static final int INITIAL_LIMIT = 20;
+
     @Nullable
     private static final Void NO_CONTEXT = null;
 
@@ -86,7 +88,7 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
     static SimpleLimiter<Void> createLimiter(Ticker nanoTimeClock) {
         AIMDLimit aimdLimit = AIMDLimit.newBuilder()
                 // Explicitly set values to prevent library changes from breaking us
-                .initialLimit(20)
+                .initialLimit(INITIAL_LIMIT)
                 .minLimit(1)
                 .backoffRatio(0.9)
                 // Don't count slow calls as a sign of the server being overloaded

--- a/simulation/src/test/resources/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44767eb097c4d42cf3def98195f1a922d5c2cc049038bd772704d8b50b435de6
-size 125985
+oid sha256:ea23d49ca04a3224660d3a4e67ff1b0df4b7b30d7bff380ef3e601da8fe8fa6d
+size 123159

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -14,7 +14,7 @@
             fast_500s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=76.0%	client_mean=PT0.055333733S 	server_cpu=PT3M27.501499711S	client_received=3750/3750	server_resps=3750	codes={200=2849, 500=901}
                       fast_500s_then_revert[UNLIMITED_ROUND_ROBIN].txt:	success=76.0%	client_mean=PT0.055333733S 	server_cpu=PT3M27.501499711S	client_received=3750/3750	server_resps=3750	codes={200=2849, 500=901}
                live_reloading[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT12.9285176S  	server_cpu=PT2H2M54.3S    	client_received=2500/2500	server_resps=2500	codes={200=2500}
-                   live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=64.0%	client_mean=PT4.2080936S   	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1600, 500=900}
+                   live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=63.7%	client_mean=PT4.210672S    	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1593, 500=907}
                              live_reloading[UNLIMITED_ROUND_ROBIN].txt:	success=55.8%	client_mean=PT2.84916S     	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1394, 500=1106}
           one_big_spike[CONCURRENCY_LIMITER_BLACKLIST_ROUND_ROBIN].txt:	success=79.0%	client_mean=PT1.478050977S 	server_cpu=PT1M59.71393673S	client_received=1000/1000	server_resps=790	codes={200=790, Failed to make a request=210}
                 one_big_spike[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT3.53697893S  	server_cpu=PT2M30S        	client_received=1000/1000	server_resps=1000	codes={200=1000}

--- a/simulation/src/test/resources/txt/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/live_reloading[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=64.0%	client_mean=PT4.2080936S   	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1600, 500=900}
+success=63.7%	client_mean=PT4.210672S    	server_cpu=PT1H58M42.9S   	client_received=2500/2500	server_resps=2500	codes={200=1593, 500=907}


### PR DESCRIPTION
## Before this PR

Say you have n upstreams and their concurrency limiters are all saturated so there are a bunch of queued requests, then you live-reload in an extra uri. At the moment, no requests get sent to this URI until the QueuedChannel's edge transitions are triggered (i.e. either a new request is made or an existing request comes back).

## After this PR
==COMMIT_MSG==
Live reloading an extra uri allows QueuedChannel to immediately make progress
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
