### PR TITLE
Logging around zero uri behaviour

### DIFF
--- a/changelog/@unreleased/pr-606.v2.yml
+++ b/changelog/@unreleased/pr-606.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: DialogueChannel now produces log.info lines when live-reloading transitions
+    to/from a zero-uri state.
+  links:
+  - https://github.com/palantir/dialogue/pull/606

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -45,8 +45,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class DialogueChannel implements Channel {
+    private static final Logger log = LoggerFactory.getLogger(DialogueChannel.class);
+
     private final Map<String, LimitedChannel> limitedChannelByUri = new ConcurrentHashMap<>();
     private final AtomicReference<LimitedChannel> nodeSelectionStrategy = new AtomicReference<>();
 
@@ -92,6 +96,20 @@ public final class DialogueChannel implements Channel {
         // Uris didn't really change so nothing to do
         if (limitedChannelByUri.keySet().equals(uniqueUris)) {
             return;
+        }
+
+        if (!limitedChannelByUri.isEmpty() && uris.isEmpty()) {
+            log.info(
+                    "Updated to zero uris",
+                    SafeArg.of("channelName", channelName),
+                    SafeArg.of("prevNumUris", limitedChannelByUri.size()));
+        }
+        boolean firstTime = nodeSelectionStrategy.get() == null;
+        if (limitedChannelByUri.isEmpty() && !uris.isEmpty() && !firstTime) {
+            log.info(
+                    "Updated from zero uris",
+                    SafeArg.of("channelName", channelName),
+                    SafeArg.of("numUris", uris.size()));
         }
 
         Sets.SetView<String> staleUris = Sets.difference(limitedChannelByUri.keySet(), uniqueUris);


### PR DESCRIPTION
## Before this PR

We haven't really intentionally chosen any behaviour when a DialogueChannel live-reloads to/from a zero uri state. (Currently you can't construct one with zero uris, and reloading into this state throws an IndexOutOfBounds exception).

## After this PR
==COMMIT_MSG==
DialogueChannel now produces log.info lines when live-reloading transitions to/from a zero-uri state.
==COMMIT_MSG==

This doesn't change any of the underlying behaviour, it's just supposed to be an uncontroversial baby-step towards a better world.

## Possible downsides?
- we don't have tests for log.info lines, so this could probably regress silently.
