### PR TITLE
Apache client idle and validation timeouts scale with socket timeouts

### DIFF
--- a/changelog/@unreleased/pr-608.v2.yml
+++ b/changelog/@unreleased/pr-608.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Apache client idle and validation timeouts scale with socket timeouts
+  links:
+  - https://github.com/palantir/dialogue/pull/608


### PR DESCRIPTION
When read and write timeouts from ClientConfiguration are low,
connections cannot be kept alive idle beyond the timeout duration.

This change introduces scaling from the idle connection timeout to
the inactivity validation timeout, requiring validation after 40%
of the idle timeout has passed. This doesn't make a difference in
most cases, slightly modifying the default inactivity validation time
from 25 seconds to 22 seconds.

## After this PR
==COMMIT_MSG==
Apache client idle and validation timeouts scale with socket timeouts
==COMMIT_MSG==
