### PR TITLE
[proof of concept] cancelling client-side future aborts work on the server

### DIFF
--- a/dialogue-client-verifier/build.gradle
+++ b/dialogue-client-verifier/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     testImplementation project('verification-server-api')
     testImplementation project(':dialogue-apache-hc4-client')
+    testImplementation project(':dialogue-okhttp-client')
     testImplementation project(':dialogue-serde')
     testImplementation project(':dialogue-example:dialogue-example-dialogue')
     testImplementation 'junit:junit'

--- a/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
+++ b/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
@@ -148,13 +148,14 @@ public class IntegrationTest {
             outputStream.write(" World".getBytes(StandardCharsets.UTF_8));
         };
 
-
         ClientConfiguration clientConf = clientConf(getUri(undertow));
-        Channel okhttpChannel = OkHttpChannels.create(clientConf);
-        Channel rawOkhttp = OkHttpChannel.of(OkHttpChannels.createOkHttpClient(clientConf), new URL(getUri(undertow)));
-        // ApacheHttpClientChannels.create(clientConf(getUri(undertow))),
-        DefaultConjureRuntime runtime = DefaultConjureRuntime.builder().build();
-        SampleServiceAsync sampleServiceAsync = SampleServiceAsync.of(rawOkhttp, runtime);
+
+        Channel channel = OkHttpChannel.of(OkHttpChannels.createOkHttpClient(clientConf), new URL(getUri(undertow)));
+        // Channel channel = OkHttpChannels.create(clientConf);
+        // Channel channel = ApacheHttpClientChannels.create(clientConf(getUri(undertow)));
+
+        SampleServiceAsync sampleServiceAsync =
+                SampleServiceAsync.of(channel, DefaultConjureRuntime.builder().build());
 
         ListenableFuture<Optional<InputStream>> future = sampleServiceAsync.getOptionalBinary();
 

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
@@ -133,7 +133,7 @@ public final class OkHttpChannel implements Channel {
             }
 
             @Override
-            public boolean cancel(boolean mayInterruptIfRunning) {
+            public boolean cancel(boolean _mayInterruptIfRunning) {
                 okCall.cancel();
                 return false;
             }

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannels.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannels.java
@@ -134,12 +134,12 @@ public final class OkHttpChannels {
         // some servers fail to implement this piece of the specification, which can violate our
         // assumptions.
         // This check can be removed once we've migrated to TLSv1.3+
-        // if (!config.enableGcmCipherSuites() || !config.enableHttp2().orElse(DEFAULT_ENABLE_HTTP2)) {
-        //     builder.protocols(ImmutableList.of(Protocol.HTTP_1_1));
-        // }
+        if (!config.enableGcmCipherSuites() || !config.enableHttp2().orElse(DEFAULT_ENABLE_HTTP2)) {
+            builder.protocols(ImmutableList.of(Protocol.HTTP_1_1));
+        }
 
-        // TODO(dfox): get the h2 upgrading working
-        builder.protocols(ImmutableList.of(Protocol.H2_PRIOR_KNOWLEDGE));
+        // // TODO(dfox): get the h2 upgrading working
+        // builder.protocols(ImmutableList.of(Protocol.H2_PRIOR_KNOWLEDGE));
 
         return builder.build();
     }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -79,8 +79,8 @@ enum DefaultClients implements Clients {
                     }
 
                     @Override
-                    public void onFailure(Throwable t) {
-                        settableFuture.setException(t);
+                    public void onFailure(Throwable throwable) {
+                        settableFuture.setException(throwable);
                     }
                 },
                 MoreExecutors.directExecutor());


### PR DESCRIPTION
I literally just wanted to play around with this, not intending to merge anything.

Was a little surprised that this worked with http1.  Also seems like Futures.transform's cancel behaviour isn't what I wanted when it's already returned a Response (but the server is still doing work to put bytes onto the network).
