### PR TITLE
--continue on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             echo "$TAGS_TO_DELETE" | while read -r TAG; do git tag -d "$TAG" 1>/dev/null; done
       - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'build-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --parallel --stacktrace --max-workers=4 build publishToMavenLocal
+      - run: ./gradlew --parallel --stacktrace --max-workers=4 --continue build publishToMavenLocal
       - deploy:
           command: |
             if [[ "${CIRCLE_BRANCH:-x}" == "develop" ]] || [[ "${CIRCLE_TAG:-x}" != "x" ]]; then


### PR DESCRIPTION
## Before this PR
If CI has multiple problems, you'll only get the first one reported in a build.


## After this PR
==COMMIT_MSG==
CircleCI run ./gradlew build --continue to ensure all failures appear in at once.
==COMMIT_MSG==

> When executed with --continue, Gradle will execute every task to be executed where all of the dependencies for that task completed without failure, instead of stopping as soon as the first failure is encountered. Each of the encountered failures will be reported at the end of the build.

https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continue_build_on_failure

## Possible downsides?
This may result in slower red builds, but given that our builds are so fast anyway I think this is OK.
