### PR TITLE
maxQueueSize 1k -> 100k

### DIFF
--- a/changelog/@unreleased/pr-628.v2.yml
+++ b/changelog/@unreleased/pr-628.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: The QueuedChannel can now absorb a spike of 100k requests when concurrency
+    limiters are preventing requests from getting out the door (previously it could
+    only absorb 1k).
+  links:
+  - https://github.com/palantir/dialogue/pull/628

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -71,7 +71,7 @@ final class QueuedChannel implements Channel {
     private final Supplier<ListenableFuture<Response>> limitedResultSupplier;
 
     QueuedChannel(LimitedChannel channel, String channelName, DialogueClientMetrics metrics) {
-        this(channel, channelName, metrics, 1_000);
+        this(channel, channelName, metrics, 100_000);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Before this PR

When trying to replace c-j-r with dialogue in @jkozlowski's data storage product, `testPartitionedRangeScan` passes with c-j-r but fails with dialogue because it kicks off a big burst of requests but the queue fills up and 4 retries get exhausted before any capacity becomes available.

https://internal-circle/gh/foundry/a-client-java/14856

## After this PR
==COMMIT_MSG==
The QueuedChannel can now absorb a spike of 100k requests when concurrency limiters are preventing requests from getting out the door (previously it could only absorb 1k).
==COMMIT_MSG==

_I tried this locally and it enabled the above tests to pass._

## Possible downsides?
- this isn't a long term solution, because as soon as a bigger burst of traffic comes along we'll hit the same degenerate case where the queue just refuses requests.
