### PR TITLE
Fix deserialization of structured errors after retries are exhausted

### DIFF
--- a/changelog/@unreleased/pr-630.v2.yml
+++ b/changelog/@unreleased/pr-630.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Structured errors are now correctly deserialized when requests exhaust
+    all available retries. (Previously they would always appear as an `UnknownRemoteException`.)
+  links:
+  - https://github.com/palantir/dialogue/pull/630

--- a/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
+++ b/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
@@ -131,7 +131,11 @@ public class IntegrationTest {
         };
 
         assertThatThrownBy(sampleServiceBlocking()::voidToVoid)
-                .isInstanceOf(RemoteException.class);
+                .isInstanceOf(RemoteException.class)
+                .satisfies(throwable -> {
+                    assertThat(((RemoteException) throwable).getError().parameters())
+                            .containsEntry("numCalls", "4");
+                });
 
         assertThat(calls).describedAs("one initial call + 4 retries").hasValue(5);
     }

--- a/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
+++ b/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
@@ -17,6 +17,7 @@
 package com.palantir.verification;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
@@ -27,6 +28,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.client.config.ClientConfigurations;
 import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
@@ -50,6 +52,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPOutputStream;
 import org.junit.After;
 import org.junit.Before;
@@ -110,6 +113,27 @@ public class IntegrationTest {
 
         assertThat(maybeBinary).isPresent();
         assertThat(maybeBinary.get()).hasSameContentAs(asInputStream("Hello, world"));
+    }
+
+    @Test
+    public void deserializes_a_conjure_error_after_exhausting_retries() {
+        AtomicInteger calls = new AtomicInteger(0);
+        undertowHandler = exchange -> {
+            exchange.setStatusCode(429);
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+            exchange.getResponseSender()
+                    .send("{"
+                            + "\"errorCode\":\"FAILED_PRECONDITION\","
+                            + "\"errorName\":\"Default:FailedPrecondition\","
+                            + "\"errorInstanceId\":\"43580df1-e019-473b-bb3d-be6d489f36e5\","
+                            + "\"parameters\":{\"numCalls\":\"" + calls.getAndIncrement() + "\"}"
+                            + "}\n");
+        };
+
+        assertThatThrownBy(sampleServiceBlocking()::voidToVoid)
+                .isInstanceOf(RemoteException.class);
+
+        assertThat(calls).describedAs("one initial call + 4 retries").hasValue(5);
     }
 
     @Test

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -126,7 +126,7 @@ final class RetryingChannel implements Channel {
         return delegate.execute(endpoint, request);
     }
 
-    private boolean isRetryable(Request request) {
+    private static boolean isRetryable(Request request) {
         Optional<RequestBody> maybeBody = request.body();
         return !maybeBody.isPresent() || maybeBody.get().repeatable();
     }
@@ -253,7 +253,8 @@ final class RetryingChannel implements Channel {
             if (!shouldPropagateQos(serverQoS)) {
                 result = Futures.transformAsync(result, this::handleHttpResponse, MoreExecutors.directExecutor());
             }
-            result = Futures.catchingAsync(result, Throwable.class, this::handleThrowable, MoreExecutors.directExecutor());
+            result = Futures.catchingAsync(
+                    result, Throwable.class, this::handleThrowable, MoreExecutors.directExecutor());
             return result;
         }
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -182,8 +182,8 @@ final class RetryingChannel implements Channel {
 
         ListenableFuture<Response> handleHttpResponse(Response response) {
             if (Responses.isQosStatus(response)) {
-                response.close();
                 if (++failures <= maxRetries) {
+                    response.close(); // nobody is going to read this response body
                     Throwable throwableToLog = log.isInfoEnabled()
                             ? new SafeRuntimeException(
                                     "Received retryable response", SafeArg.of("status", response.code()))
@@ -196,6 +196,7 @@ final class RetryingChannel implements Channel {
                             SafeArg.of("retries", maxRetries),
                             SafeArg.of("status", response.code()));
                 }
+                // not closing the final response body because ConjureBodySerde needs to read it to deserialize
                 return Futures.immediateFuture(response);
             }
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -230,6 +230,35 @@ public class RetryingChannelTest {
     }
 
     @Test
+    public void final_exhausted_failure_response_body_is_not_closed() throws Exception {
+        TestResponse response1 = new TestResponse().code(503);
+        TestResponse response2 = new TestResponse().code(503);
+        TestResponse response3 = new TestResponse().code(503);
+
+        when(channel.execute(any(), any()))
+                .thenReturn(Futures.immediateFuture(response1))
+                .thenReturn(Futures.immediateFuture(response2))
+                .thenReturn(Futures.immediateFuture(response3));
+
+        Channel retryer = new RetryingChannel(
+                channel,
+                "my-channel",
+                2,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+        ListenableFuture<Response> response = retryer.execute(TestEndpoint.POST, REQUEST);
+        assertThat(response.get(1, TimeUnit.SECONDS).code()).isEqualTo(503);
+
+        assertThat(response1.isClosed()).isTrue();
+        assertThat(response2.isClosed()).isTrue();
+        assertThat(response3.isClosed())
+                .describedAs("The last response must be left open so we can read the body"
+                        + " and deserialize it into a structured error")
+                .isFalse();
+    }
+
+    @Test
     public void testPropagatesCancel() {
         ListenableFuture<Response> delegateResult = SettableFuture.create();
         when(channel.execute(any(), any())).thenReturn(delegateResult);


### PR DESCRIPTION
## Before this PR

All versions of dialogue contain this bug: when we exhaust retries and pass the final response to the ErrorDecoder, the response body has already been closed so it can't read the json.  This means _every_ structured error comes out as an `UnknownRemoteException`:

```
com.palantir.conjure.java.api.errors.UnknownRemoteException: Error 429. (Failed to parse response body as SerializableError.)
	at com.palantir.conjure.java.dialogue.serde.DefaultClients.newUnknownRemoteException(DefaultClients.java:120)
	at com.palantir.conjure.java.dialogue.serde.DefaultClients.block(DefaultClients.java:94)
	at com.palantir.dialogue.example.SampleServiceBlocking$1.voidToVoid(SampleServiceBlocking.java:35)
	...
Caused by: com.palantir.conjure.java.api.errors.UnknownRemoteException: Error 429. (Failed to parse response body as SerializableError.)
	at com.palantir.conjure.java.dialogue.serde.ErrorDecoder.decode(ErrorDecoder.java:57)
	at com.palantir.conjure.java.dialogue.serde.ConjureBodySerDe$EmptyBodyDeserializer.deserialize(ConjureBodySerDe.java:333)
	at com.palantir.conjure.java.dialogue.serde.ConjureBodySerDe$EmptyBodyDeserializer.deserialize(ConjureBodySerDe.java:320)
	at com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture.doTransform(AbstractTransformFuture.java:242)
	...
Caused by: org.apache.http.ConnectionClosedException: Premature end of Content-Length delimited message body (expected: 164; received: 0)
	at org.apache.http.impl.io.ContentLengthInputStream.read(ContentLengthInputStream.java:178)
	at org.apache.http.conn.EofSensorInputStream.read(EofSensorInputStream.java:135)
	at java.base/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.base/java.io.InputStreamReader.read(InputStreamReader.java:185)
	at java.base/java.io.Reader.read(Reader.java:229)
	at com.google.common.io.CharStreams.copyReaderToBuilder(CharStreams.java:119)
	at com.google.common.io.CharStreams.toStringBuilder(CharStreams.java:177)
	at com.google.common.io.CharStreams.toString(CharStreams.java:163)
	at com.palantir.conjure.java.dialogue.serde.ErrorDecoder.toString(ErrorDecoder.java:77)
	at com.palantir.conjure.java.dialogue.serde.ErrorDecoder.decode(ErrorDecoder.java:55)
```

This is obviously different from c-j-r's behaviour, and means anyone's `catch(RemoteException)` blocks won't get triggered.

## After this PR
==COMMIT_MSG==
Structured errors are now correctly deserialized when requests exhaust all available retries. (Previously they would always appear as an `UnknownRemoteException`.)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
