### PR TITLE
Instrument the BlockingChannelAdapter ThreadFactory

### DIFF
--- a/changelog/@unreleased/pr-643.v2.yml
+++ b/changelog/@unreleased/pr-643.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Instrument the BlockingChannelAdapter ThreadFactory
+  links:
+  - https://github.com/palantir/dialogue/pull/643

--- a/dialogue-blocking-channels/build.gradle
+++ b/dialogue-blocking-channels/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     api project(':dialogue-target')
     api 'com.google.guava:guava'
     implementation 'com.palantir.tracing:tracing'
+    implementation 'com.palantir.tritium:tritium-metrics'
 
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testCompile 'org.assertj:assertj-core'

--- a/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
+++ b/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
@@ -28,6 +28,8 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.tracing.Tracers;
+import com.palantir.tritium.metrics.MetricRegistries;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -41,12 +43,16 @@ public final class BlockingChannelAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(BlockingChannelAdapter.class);
 
+    @SuppressWarnings("deprecation") // No reasonable way to pass a tagged registry to this singleton
     private static final Supplier<ExecutorService> blockingExecutor = Suppliers.memoize(() -> Tracers.wrap(
             "dialogue-blocking-channel",
-            Executors.newCachedThreadPool(new ThreadFactoryBuilder()
-                    .setNameFormat("dialogue-blocking-channel-%d")
-                    .setDaemon(true)
-                    .build())));
+            Executors.newCachedThreadPool(MetricRegistries.instrument(
+                    SharedTaggedMetricRegistries.getSingleton(),
+                    new ThreadFactoryBuilder()
+                            .setNameFormat("dialogue-blocking-channel-%d")
+                            .setDaemon(true)
+                            .build(),
+                    "dialogue-blocking-channel"))));
 
     public static Channel of(BlockingChannel blockingChannel) {
         return of(blockingChannel, blockingExecutor.get());


### PR DESCRIPTION
## Before this PR
No idea how many threads were available or rate of creation and termination.

## After this PR
==COMMIT_MSG==
Instrument the BlockingChannelAdapter ThreadFactory
==COMMIT_MSG==

## Possible downsides?
metric $. compute is more expensive.
