### PR TITLE
RetryingChannel retries IOExceptions rather than all Throwables

### DIFF
--- a/changelog/@unreleased/pr-644.v2.yml
+++ b/changelog/@unreleased/pr-644.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: RetryingChannel retries IOExceptions rather than all Throwables
+  links:
+  - https://github.com/palantir/dialogue/pull/644

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -70,11 +70,6 @@ final class QueuedChannel implements Channel {
     private final Timer queuedTime;
     private final Supplier<ListenableFuture<Response>> limitedResultSupplier;
 
-    QueuedChannel(LimitedChannel channel, String channelName, DialogueClientMetrics metrics) {
-        this(channel, channelName, metrics, 100_000);
-    }
-
-    @VisibleForTesting
     QueuedChannel(LimitedChannel delegate, String channelName, DialogueClientMetrics metrics, int maxQueueSize) {
         this.delegate = new NeverThrowLimitedChannel(delegate);
         this.channelName = channelName;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -40,6 +40,7 @@ import com.palantir.tracing.Tracers;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Optional;
@@ -264,7 +265,9 @@ final class RetryingChannel implements Channel {
                             && socketTimeout.getMessage().contains("connect timed out");
                 }
             }
-            return true;
+            // Only retry IOExceptions. Other failures, particularly RuntimeException and Error are not
+            // meant to be recovered from.
+            return throwable instanceof IOException;
         }
 
         private void logRetry(long backoffNanoseconds, @Nullable Throwable throwable) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -66,8 +66,8 @@ public class QueuedChannelTest {
 
     @BeforeEach
     public void before() {
-        queuedChannel =
-                new QueuedChannel(delegate, "my-channel", DialogueClientMetrics.of(new DefaultTaggedMetricRegistry()));
+        queuedChannel = new QueuedChannel(
+                delegate, "my-channel", DialogueClientMetrics.of(new DefaultTaggedMetricRegistry()), 100_000);
         futureResponse = SettableFuture.create();
         maybeResponse = Optional.of(futureResponse);
 


### PR DESCRIPTION
IOExceptions are thrown by clients when calls fail in unexpected
ways. Other exceptions indicate programming or system errors that
cannot be recovered from.

## Before this PR
Burn retries on requests that cannot succeed.

## After this PR
==COMMIT_MSG==
RetryingChannel retries IOExceptions rather than all Throwables
==COMMIT_MSG==

## Possible downsides?
We may discover other exceptions that we _do_ want to retry that aren't IOExceptions.
