### PR TITLE
IOExceptions push back concurrency limits

### DIFF
--- a/changelog/@unreleased/pr-645.v2.yml
+++ b/changelog/@unreleased/pr-645.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: IOExceptions decrease concurrency limits
+  links:
+  - https://github.com/palantir/dialogue/pull/645

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/AimdConcurrencyLimiter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/AimdConcurrencyLimiter.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue.core;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.palantir.dialogue.Response;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntBinaryOperator;
@@ -64,8 +65,12 @@ final class AimdConcurrencyLimiter {
         }
 
         @Override
-        public void onFailure(Throwable _throwable) {
-            ignore();
+        public void onFailure(Throwable throwable) {
+            if (throwable instanceof IOException) {
+                dropped();
+            } else {
+                ignore();
+            }
         }
 
         void ignore() {


### PR DESCRIPTION
## Before this PR
Previously all exceptions were ignored, and the limiters were
only impacted by response codes.

## After this PR
This will resolve issues with handshake storms.
==COMMIT_MSG==
IOExceptions decrease concurrency limits
==COMMIT_MSG==

## Possible downsides?
Might impact us in unexpected ways.
