### PR TITLE
Implement naive 308 retry-other handling

### DIFF
--- a/changelog/@unreleased/pr-648.v2.yml
+++ b/changelog/@unreleased/pr-648.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement naive 308 retry-other handling
+  links:
+  - https://github.com/palantir/dialogue/pull/648

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -20,6 +20,10 @@ import com.palantir.dialogue.Response;
 /** Utility functionality for {@link Response} handling. */
 final class Responses {
 
+    private static boolean isRetryOther(Response response) {
+        return response.code() == 308;
+    }
+
     private static boolean isTooManyRequests(Response response) {
         return response.code() == 429;
     }
@@ -29,7 +33,7 @@ final class Responses {
     }
 
     static boolean isQosStatus(Response response) {
-        return isTooManyRequests(response) || isUnavailable(response);
+        return isRetryOther(response) || isTooManyRequests(response) || isUnavailable(response);
     }
 
     static boolean isServerError(Response response) {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -24,11 +24,11 @@ final class Responses {
         return response.code() == 308;
     }
 
-    private static boolean isTooManyRequests(Response response) {
+    static boolean isTooManyRequests(Response response) {
         return response.code() == 429;
     }
 
-    private static boolean isUnavailable(Response response) {
+    static boolean isUnavailable(Response response) {
         return response.code() == 503;
     }
 


### PR DESCRIPTION
Dialogue considers 308 responses the same as other QoS codes in
order to approximate the expected behavior. After enough 308s
we expect calls to land on the right server.
This allows us to avoid adding cruft to node selection strategies
in support of a single use case.

==COMMIT_MSG==
Implement naive 308 retry-other handling
==COMMIT_MSG==

## Possible downsides?
It doesn't use the `Location` header.
