### PR TITLE
Delete low-signal `dialogue.concurrencylimiter.utilization` metric

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -57,15 +57,6 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
         weakGauge(
                 taggedMetrics,
                 MetricName.builder()
-                        .safeName("dialogue.concurrencylimiter.utilization")
-                        .putSafeTags("channel-name", channelName)
-                        .putSafeTags("hostIndex", Integer.toString(uriIndex))
-                        .build(),
-                this,
-                ConcurrencyLimitedChannel::getUtilization);
-        weakGauge(
-                taggedMetrics,
-                MetricName.builder()
                         .safeName("dialogue.concurrencylimiter.max")
                         .putSafeTags("channel-name", channelName)
                         .putSafeTags("hostIndex", Integer.toString(uriIndex))
@@ -99,12 +90,6 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
     @Override
     public String toString() {
         return "ConcurrencyLimitedChannel{" + delegate + '}';
-    }
-
-    private double getUtilization() {
-        double inflight = limiter.getInflight();
-        double limit = limiter.getLimit();
-        return inflight / limit; // minLimit is 1 so we should never get NaN from this
     }
 
     private int getMax() {

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -44,10 +44,6 @@ namespaces:
   dialogue.concurrencylimiter:
     docs: Instrumentation for the ConcurrencyLimitedChannel
     metrics:
-      utilization:
-        type: gauge
-        tags: [channel-name, hostIndex]
-        docs: The proportion of the available concurrency which is currently being used, i.e. if there are 20 permits and only one inflight call, this will be 0.05.
       max:
         type: gauge
         tags: [channel-name, hostIndex]

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -133,10 +133,9 @@ public class ConcurrencyLimitedChannelTest {
 
     @Test
     void testGauges() {
-        when(mockLimiter.getInflight()).thenReturn(5);
-        when(mockLimiter.getLimit()).thenReturn(20);
+        when(mockLimiter.getLimit()).thenReturn(21);
 
-        assertThat(getMax()).isEqualTo(20);
+        assertThat(getMax()).isEqualTo(21);
     }
 
     private void mockResponseCode(int code) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -137,7 +137,6 @@ public class ConcurrencyLimitedChannelTest {
         when(mockLimiter.getLimit()).thenReturn(20);
 
         assertThat(getMax()).isEqualTo(20);
-        assertThat(getUtilization()).isEqualTo(0.25d);
     }
 
     private void mockResponseCode(int code) {
@@ -151,16 +150,6 @@ public class ConcurrencyLimitedChannelTest {
 
     private void mockLimitUnavailable() {
         when(mockLimiter.acquire()).thenReturn(Optional.empty());
-    }
-
-    private Number getUtilization() {
-        Gauge<Object> gauge = metrics.gauge(MetricName.builder()
-                        .safeName("dialogue.concurrencylimiter.utilization")
-                        .putSafeTags("channel-name", "channel")
-                        .putSafeTags("hostIndex", "0")
-                        .build())
-                .get();
-        return (Number) gauge.getValue();
     }
 
     private Number getMax() {


### PR DESCRIPTION
## Before this PR

This gauge is pretty much useless because it's only sampled every 30 seconds, and the interesting stuff is very rare and might happen in between samples.

![image](https://user-images.githubusercontent.com/3473798/79367413-c7379100-7f45-11ea-8a82-6c6116633c52.png)

## After this PR
==COMMIT_MSG==
Delete low-signal `dialogue.concurrencylimiter.utilization` metric
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
