### PR TITLE
More logging around Apache client creation & close

### DIFF
--- a/changelog/@unreleased/pr-655.v2.yml
+++ b/changelog/@unreleased/pr-655.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`ApacheHttpClientChannels` prints some debug log lines around creation
+    & close'
+  links:
+  - https://github.com/palantir/dialogue/pull/655

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -28,6 +28,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -171,12 +172,15 @@ public final class ApacheHttpClientChannels {
         @Override
         public void close() throws IOException {
             PoolStats poolStats = pool.getTotalStats();
-            log.debug(
-                    "Closing Apache client",
-                    SafeArg.of("name", name),
-                    SafeArg.of("idle", poolStats.getAvailable()),
-                    SafeArg.of("leased", poolStats.getLeased()),
-                    SafeArg.of("pending", poolStats.getPending()));
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Closing Apache client",
+                        SafeArg.of("name", name),
+                        SafeArg.of("idle", poolStats.getAvailable()),
+                        SafeArg.of("leased", poolStats.getLeased()),
+                        SafeArg.of("pending", poolStats.getPending()),
+                        new SafeRuntimeException("Exception for stacktrace"));
+            }
             client.close();
         }
 

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -161,7 +161,7 @@ public final class ApacheHttpClientChannels {
                 PoolingHttpClientConnectionManager pool,
                 ResponseLeakDetector leakDetector,
                 @Nullable ExecutorService executor) {
-            log.debug("Apache client created", SafeArg.of("name", name));
+            log.info("Apache client created", SafeArg.of("name", name));
             this.name = name;
             this.client = client;
             this.pool = pool;
@@ -172,15 +172,15 @@ public final class ApacheHttpClientChannels {
         @Override
         public void close() throws IOException {
             PoolStats poolStats = pool.getTotalStats();
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Closing Apache client",
-                        SafeArg.of("name", name),
-                        SafeArg.of("idle", poolStats.getAvailable()),
-                        SafeArg.of("leased", poolStats.getLeased()),
-                        SafeArg.of("pending", poolStats.getPending()),
-                        new SafeRuntimeException("Exception for stacktrace"));
-            }
+            SafeRuntimeException stacktrace =
+                    log.isDebugEnabled() ? new SafeRuntimeException("Exception for stacktrace") : null;
+            log.info(
+                    "Closing Apache client",
+                    SafeArg.of("name", name),
+                    SafeArg.of("idle", poolStats.getAvailable()),
+                    SafeArg.of("leased", poolStats.getLeased()),
+                    SafeArg.of("pending", poolStats.getPending()),
+                    stacktrace);
             client.close();
         }
 


### PR DESCRIPTION
## Before this PR

@bwaldrep reported a containerized service is throwing a bunch of these:
(traceid d751285fbb945646)
```
java.lang.IllegalStateException: {throwable0_message}
	at org.apache.http.util.Asserts.check(Asserts.java:34)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.requestConnection(PoolingHttpClientConnectionManager.java:269)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:176)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
	at com.palantir.dialogue.hc4.ApacheHttpClientBlockingChannel.execute(ApacheHttpClientBlockingChannel.java:79)
	at com.palantir.dialogue.blocking.BlockingChannelAdapter$BlockingChannelAdapterChannel$BlockingChannelAdapterTask.run(BlockingChannelAdapter.java:122)
	at com.palantir.tracing.Tracers$TracingAwareRunnable.run(Tracers.java:501)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(Thread.java:834)
```

## After this PR
==COMMIT_MSG==
`ApacheHttpClientChannels` prints some debug log lines around creation & close
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
