### PR TITLE
Rename `dialogue.client.response` metric to `client.response`

### DIFF
--- a/changelog/@unreleased/pr-662-pt2.v2.yml
+++ b/changelog/@unreleased/pr-662-pt2.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement `client.response.error` metrics matching those reported by CJR.
+  links:
+  - https://github.com/palantir/dialogue/pull/662

--- a/changelog/@unreleased/pr-662.v2.yml
+++ b/changelog/@unreleased/pr-662.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: Rename `dialogue.client.response` metric to `client.response` to match
-    CJR and avoid unnecessary churn on dashboards and alerts.
+  description: Rename `dialogue.client.response` and `dialogue.client.deprecations` metric to `client.response` and
+    `client.deprecations` respectively to match CJR and avoid unnecessary churn on dashboards and alerts.
   links:
   - https://github.com/palantir/dialogue/pull/662

--- a/changelog/@unreleased/pr-662.v2.yml
+++ b/changelog/@unreleased/pr-662.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: Rename `dialogue.client.response` and `dialogue.client.deprecations` metric to `client.response` and
+  description: Rename `dialogue.client.response` and `dialogue.client.deprecations` metrics to `client.response` and
     `client.deprecations` respectively to match CJR and avoid unnecessary churn on dashboards and alerts.
   links:
   - https://github.com/palantir/dialogue/pull/662

--- a/changelog/@unreleased/pr-662.v2.yml
+++ b/changelog/@unreleased/pr-662.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Rename `dialogue.client.response` metric to `client.response` to match
+    CJR and avoid unnecessary churn on dashboards and alerts.
+  links:
+  - https://github.com/palantir/dialogue/pull/662

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
@@ -41,11 +41,11 @@ final class DeprecationWarningChannel implements Channel {
     private static final Object SENTINEL = new Object();
 
     private final Channel delegate;
-    private final DialogueClientMetrics metrics;
+    private final ClientMetrics metrics;
     private final Cache<String, Object> loggingRateLimiter =
             Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(1)).build();
 
-    DeprecationWarningChannel(Channel delegate, DialogueClientMetrics metrics) {
+    DeprecationWarningChannel(Channel delegate, ClientMetrics metrics) {
         this.delegate = delegate;
         this.metrics = metrics;
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -79,7 +79,14 @@ public final class DialogueChannel implements Channel {
         this.queuedChannel = new QueuedChannel(
                 new SupplierChannel(nodeSelectionStrategy::get), channelName, dialogueClientMetrics, maxQueueSize);
         updateUris(clientConfiguration.uris());
-        this.delegate = wrap(queuedChannel, channelName, clientConfiguration, scheduler, random, dialogueClientMetrics);
+        this.delegate = wrap(
+                queuedChannel,
+                channelName,
+                clientConfiguration,
+                scheduler,
+                random,
+                clientMetrics,
+                dialogueClientMetrics);
     }
 
     @Override
@@ -230,7 +237,8 @@ public final class DialogueChannel implements Channel {
             ClientConfiguration conf,
             Supplier<ScheduledExecutorService> scheduler,
             Random random,
-            DialogueClientMetrics clientMetrics) {
+            ClientMetrics clientMetrics,
+            DialogueClientMetrics dialogueClientMetrics) {
         Channel channel = queuedChannel;
         channel = new TracedChannel(channel, "Dialogue-request-attempt");
         channel = retryingChannel(channel, channelName, conf, scheduler, random);
@@ -239,7 +247,7 @@ public final class DialogueChannel implements Channel {
         channel = new ContentDecodingChannel(channel);
         channel = new NeverThrowChannel(channel);
         channel = new DialogueTracedRequestChannel(channel);
-        channel = new ActiveRequestInstrumentationChannel(channel, channelName, "processing", clientMetrics);
+        channel = new ActiveRequestInstrumentationChannel(channel, channelName, "processing", dialogueClientMetrics);
 
         return channel;
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -58,7 +58,8 @@ public final class DialogueChannel implements Channel {
     private final ClientConfiguration clientConfiguration;
     private final ChannelFactory channelFactory;
     private final Channel delegate;
-    private final DialogueClientMetrics clientMetrics;
+    private final ClientMetrics clientMetrics;
+    private final DialogueClientMetrics dialogueClientMetrics;
     private final Random random;
 
     // TODO(forozco): you really want a refreshable of uri separate from the client config
@@ -72,12 +73,13 @@ public final class DialogueChannel implements Channel {
         this.channelName = channelName;
         this.clientConfiguration = clientConfiguration;
         this.channelFactory = channelFactory;
-        clientMetrics = DialogueClientMetrics.of(clientConfiguration.taggedMetricRegistry());
+        clientMetrics = ClientMetrics.of(clientConfiguration.taggedMetricRegistry());
+        dialogueClientMetrics = DialogueClientMetrics.of(clientConfiguration.taggedMetricRegistry());
         this.random = random;
         this.queuedChannel = new QueuedChannel(
-                new SupplierChannel(nodeSelectionStrategy::get), channelName, clientMetrics, maxQueueSize);
+                new SupplierChannel(nodeSelectionStrategy::get), channelName, dialogueClientMetrics, maxQueueSize);
         updateUris(clientConfiguration.uris());
-        this.delegate = wrap(queuedChannel, channelName, clientConfiguration, scheduler, random, clientMetrics);
+        this.delegate = wrap(queuedChannel, channelName, clientConfiguration, scheduler, random, dialogueClientMetrics);
     }
 
     @Override
@@ -131,7 +133,7 @@ public final class DialogueChannel implements Channel {
         Channel channel = channelFactory.create(uri);
         // Instrument inner-most channel with instrumentation channels so that we measure only the over-the-wire-time
         channel = new InstrumentedChannel(channel, channelName, clientMetrics);
-        channel = new ActiveRequestInstrumentationChannel(channel, channelName, "running", clientMetrics);
+        channel = new ActiveRequestInstrumentationChannel(channel, channelName, "running", dialogueClientMetrics);
         // TracedChannel must wrap TracedRequestChannel to ensure requests have tracing headers.
         channel = new TraceEnrichingChannel(channel);
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/InstrumentedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/InstrumentedChannel.java
@@ -31,9 +31,9 @@ import com.palantir.dialogue.Response;
 final class InstrumentedChannel implements Channel {
     private final Channel delegate;
     private final String channelName;
-    private final DialogueClientMetrics metrics;
+    private final ClientMetrics metrics;
 
-    InstrumentedChannel(Channel delegate, String channelName, DialogueClientMetrics metrics) {
+    InstrumentedChannel(Channel delegate, String channelName, ClientMetrics metrics) {
         this.delegate = delegate;
         this.channelName = channelName;
         this.metrics = metrics;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/InstrumentedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/InstrumentedChannel.java
@@ -17,12 +17,13 @@
 package com.palantir.dialogue.core;
 
 import com.codahale.metrics.Timer;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import java.io.IOException;
 
 /**
  * A channel that observes metrics about the processed requests and responses.
@@ -47,8 +48,25 @@ final class InstrumentedChannel implements Channel {
                 .build()
                 .time();
         ListenableFuture<Response> response = delegate.execute(endpoint, request);
-        response.addListener(context::stop, MoreExecutors.directExecutor());
-        return response;
+        return DialogueFutures.addDirectCallback(response, new FutureCallback<Response>() {
+            @Override
+            public void onSuccess(Response _result) {
+                context.stop();
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                context.stop();
+                if (throwable instanceof IOException) {
+                    metrics.responseError()
+                            .channelName(channelName)
+                            .serviceName(endpoint.serviceName())
+                            .reason("IOException")
+                            .build()
+                            .mark();
+                }
+            }
+        });
     }
 
     @Override

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -10,6 +10,10 @@ namespaces:
         type: timer
         tags: [channel-name, service-name]
         docs: Request time, note that this does not include time spent reading the response body.
+      response.error:
+        type: meter
+        tags: [channel-name, service-name, reason]
+        docs: Rate of errors received by reason and service-name. Currently only errors with reason `IOException` are reported.
       deprecations:
         type: meter
         tags: [service-name]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -10,6 +10,10 @@ namespaces:
         type: timer
         tags: [channel-name, service-name]
         docs: Request time, note that this does not include time spent reading the response body.
+      deprecations:
+        type: meter
+        tags: [service-name]
+        docs: Rate of deprecated endpoints being invoked.
   dialogue.client:
     docs: Dialogue client response metrics.
     metrics:
@@ -36,10 +40,6 @@ namespaces:
         type: timer
         tags: [channel-name]
         docs: Time spent waiting in the queue before execution.
-      deprecations:
-        type: meter
-        tags: [service-name]
-        docs: Rate of deprecated endpoints being invoked.
       limited:
         type: meter
         tags: [channel-name, reason]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -2,13 +2,17 @@ options:
   javaPackage: com.palantir.dialogue.core
   javaVisibility: packagePrivate
 namespaces:
-  dialogue.client:
-    docs: Dialogue client response metrics.
+  client:
+    docs: General client metrics produced by dialogue. These metrics are meant to be applicable to all conjure clients
+          without being implementation-specific.
     metrics:
       response:
         type: timer
         tags: [channel-name, service-name]
         docs: Request time, note that this does not include time spent reading the response body.
+  dialogue.client:
+    docs: Dialogue client response metrics.
+    metrics:
       response.leak:
         type: meter
         tags: [client-name, service-name, endpoint]

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
@@ -57,7 +57,7 @@ public final class InstrumentedChannelTest {
         when(endpoint.serviceName()).thenReturn("my-service");
 
         MetricName name = MetricName.builder()
-                .safeName("dialogue.client.response")
+                .safeName("client.response")
                 .putSafeTags("channel-name", "my-channel")
                 .putSafeTags("service-name", endpoint.serviceName())
                 .build();

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
@@ -49,7 +49,7 @@ public final class InstrumentedChannelTest {
     @BeforeEach
     public void before() {
         registry = new DefaultTaggedMetricRegistry();
-        channel = new InstrumentedChannel(delegate, "my-channel", DialogueClientMetrics.of(registry));
+        channel = new InstrumentedChannel(delegate, "my-channel", ClientMetrics.of(registry));
     }
 
     @Test

--- a/simulation/src/main/java/com/palantir/dialogue/core/Benchmark.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/Benchmark.java
@@ -168,7 +168,7 @@ public final class Benchmark {
 
     @SuppressWarnings({"FutureReturnValueIgnored", "CheckReturnValue"})
     public ListenableFuture<BenchmarkResult> schedule() {
-        DialogueClientMetrics clientMetrics = DialogueClientMetrics.of(simulation.taggedMetrics());
+        ClientMetrics clientMetrics = ClientMetrics.of(simulation.taggedMetrics());
 
         Channel[] channels = Arrays.stream(clients)
                 .map(c -> new InstrumentedChannel(c, SimulationUtils.CHANNEL_NAME, clientMetrics))


### PR DESCRIPTION
This matches the metric reported by CJR to avoid unnecessary churn
on dashboards and alerts.

## After this PR
==COMMIT_MSG==
Rename `dialogue.client.response` metric to `client.response` to match CJR and avoid unnecessary churn on dashboards and alerts.
==COMMIT_MSG==

## Possible downsides?
breaks dialogue boards.