### PR TITLE
Declare PathTemplate is Immutable

### DIFF
--- a/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 
+@Immutable
 public final class PathTemplate {
 
     // TODO(rfink): Add query parameters.
@@ -86,6 +88,7 @@ public final class PathTemplate {
         }
     }
 
+    @Immutable
     public static final class Segment {
         @Nullable
         private final String fixed;


### PR DESCRIPTION
When hand-rolling a dialogue client, I got these annoying warnings:

```
> Task :multipass-oauth2-client:compileJava
/Volumes/git/multipass-grant-types/multipass-oauth2-client/src/main/java/com/palantir/multipass/client/api/MultipassOAuth2Endpoints.java:16: warning: [ImmutableEnumChecker] enums should be immutable: 'token' has field 'pathTemplate' of type 'com.palantir.dialogue.PathTemplate', the declaration of type 'com.palantir.dialogue.PathTemplate' is not annotated with @com.google.errorprone.annotations.Immutable
        private final PathTemplate pathTemplate =
                                   ^
    (see https://errorprone.info/bugpattern/ImmutableEnumChecker)
/Volumes/git/multipass-grant-types/multipass-oauth2-client/src/main/java/com/palantir/multipass/client/api/MultipassOAuth2Endpoints.java:46: warning: [ImmutableEnumChecker] enums should be immutable: 'revokeToken' has field 'pathTemplate' of type 'com.palantir.dialogue.PathTemplate', the declaration of type 'com.palantir.dialogue.PathTemplate' is not annotated with @com.google.errorprone.annotations.Immutable
        private final PathTemplate pathTemplate =
                                   ^
    (see https://errorprone.info/bugpattern/ImmutableEnumChecker)
2 warnings
```