### PR TITLE
Apache HttpClient is configured not to normalize URIs

### DIFF
--- a/changelog/@unreleased/pr-668.v2.yml
+++ b/changelog/@unreleased/pr-668.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Apache HttpClient is configured not to normalize URIs
+  links:
+  - https://github.com/palantir/dialogue/pull/668

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -295,6 +295,9 @@ public final class ApacheHttpClientChannels {
                             // Match okhttp, disallow redirects
                             .setRedirectsEnabled(false)
                             .setRelativeRedirectsAllowed(false)
+                            // Don't attempt to replace duplicated slashes with a single slash, otherwise
+                            // empty path parameters cannot be matched by the server.
+                            .setNormalizeUri(false)
                             .build())
                     .setDefaultSocketConfig(socketConfig)
                     .evictIdleConnections(idleConnectionTimeoutMillis, TimeUnit.MILLISECONDS)

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -370,6 +370,29 @@ public abstract class AbstractChannelTest {
     }
 
     @Test
+    public void supports_empty_path_parameter() throws InterruptedException, ExecutionException {
+        endpoint.method = HttpMethod.GET;
+        endpoint.renderPath =
+                (params, url) -> url.pathSegment("a").pathSegment("").pathSegment("b");
+        ListenableFuture<Response> result = channel.execute(endpoint, request);
+        RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getMethod()).isEqualTo("GET");
+        assertThat(recorded.getPath()).isEqualTo("/a//b");
+        assertThat(result.get().code()).isEqualTo(200);
+    }
+
+    @Test
+    public void emptyTrailingPathParameterResultsInTrailingSlash() throws InterruptedException, ExecutionException {
+        endpoint.method = HttpMethod.GET;
+        endpoint.renderPath = (params, url) -> url.pathSegment("foo").pathSegment("");
+        ListenableFuture<Response> result = channel.execute(endpoint, request);
+        RecordedRequest recorded = server.takeRequest();
+        assertThat(recorded.getMethod()).isEqualTo("GET");
+        assertThat(recorded.getPath()).isEqualTo("/foo/");
+        assertThat(result.get().code()).isEqualTo(200);
+    }
+
+    @Test
     @TestTracing(snapshot = true)
     public void requestAreTraced() throws Exception {
         endpoint.method = HttpMethod.POST;


### PR DESCRIPTION
## Before this PR
Previously this resulted in failures to match endpoints when
empty path parameters were applied to non-final path segments.

## After this PR
==COMMIT_MSG==
Apache HttpClient is configured not to normalize URIs
==COMMIT_MSG==

## Possible downsides?
We may be relying on normalization in some way that we aren't aware of.
