### PR TITLE
Only count IOExceptions toward failures in the balanced strategy

### DIFF
--- a/changelog/@unreleased/pr-678.v2.yml
+++ b/changelog/@unreleased/pr-678.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Only count IOExceptions toward failures in the balanced strategy
+  links:
+  - https://github.com/palantir/dialogue/pull/678


### PR DESCRIPTION
Missed this in review:
==COMMIT_MSG==
Only count IOExceptions toward failures in the balanced strategy
==COMMIT_MSG==
