### PR TITLE
PinUntilError stable hostindex metrics

### DIFF
--- a/changelog/@unreleased/pr-689.v2.yml
+++ b/changelog/@unreleased/pr-689.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'Per-host metrics for the PinUntilError node selection strategy (`dialogue.pinuntilerror.success`)
+    were misleading after each 10 minute reshuffle. '
+  links:
+  - https://github.com/palantir/dialogue/pull/689

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
@@ -49,10 +49,10 @@ import org.mockito.quality.Strictness;
 public class PinUntilErrorNodeSelectionStrategyChannelTest {
 
     @Mock
-    private LimitedChannel channel1;
+    private PinUntilErrorNodeSelectionStrategyChannel.PinChannel channel1;
 
     @Mock
-    private LimitedChannel channel2;
+    private PinUntilErrorNodeSelectionStrategyChannel.PinChannel channel2;
 
     @Mock
     private Ticker clock;
@@ -65,7 +65,8 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
 
     @BeforeEach
     public void before() {
-        ImmutableList<LimitedChannel> channels = ImmutableList.of(channel1, channel2);
+        ImmutableList<PinUntilErrorNodeSelectionStrategyChannel.PinChannel> channels =
+                ImmutableList.of(channel1, channel2);
 
         PinUntilErrorNodeSelectionStrategyChannel.ConstantNodeList constantList =
                 new PinUntilErrorNodeSelectionStrategyChannel.ConstantNodeList(channels);


### PR DESCRIPTION
## Before this PR

Graphs look wrong for atlas -> timelock api calls because only one of these hosts is the leader so there should be no other calls to non leader hosts.

![image](https://user-images.githubusercontent.com/3473798/80601676-0675df80-8a26-11ea-96c8-5868af8f46ce.png)

## After this PR
==COMMIT_MSG==
The `dialogue.pinuntilerror.success` metric had a `hostIndex` tag which was pretty useless because it was the index into the _shuffled_ list of nodes.  Now, this index is preserved from the _original_ list of nodes, so we should expect to see a square wave style pattern as nodes are reshuffled every 10 minutes.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
