### PR TITLE
Expose convenience method to create a named apache channel

### DIFF
--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/CloseableChannel.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/CloseableChannel.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc4;
+
+import com.palantir.dialogue.Channel;
+import java.io.Closeable;
+
+public interface CloseableChannel extends Channel, Closeable {}


### PR DESCRIPTION
## Before this PR
@JiahuiJiang had noted that it was a bit annoying to create a simple channel because of all the boilerplate around it.

## After this PR
==COMMIT_MSG==
Expose utility for creating a closeable channel
==COMMIT_MSG==

## Possible downsides?
More API, probably only want people to use this in cases where WC is not around.
