### PR TITLE
Leak detection is disabled by default

### DIFF
--- a/changelog/@unreleased/pr-696.v2.yml
+++ b/changelog/@unreleased/pr-696.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Leak detection can be enabled at 100% by enabling trace logging, and
+    1% by enabling debug logging.
+  links:
+  - https://github.com/palantir/dialogue/pull/696

--- a/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ResponseLeakDetectorTest.java
+++ b/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ResponseLeakDetectorTest.java
@@ -56,7 +56,7 @@ public class ResponseLeakDetectorTest {
 
     @Test
     public void testLeakMetric() {
-        ResponseLeakDetector detector = new ResponseLeakDetector(CLIENT, metrics, SafeThreadLocalRandom.get(), 1);
+        ResponseLeakDetector detector = new ResponseLeakDetector(CLIENT, metrics, SafeThreadLocalRandom.get(), () -> 1);
         // Result is intentionally ignored to cause a leak
         detector.wrap(response, mockEndpoint);
         Meter leaks = metrics.responseLeak()
@@ -73,7 +73,7 @@ public class ResponseLeakDetectorTest {
 
     @Test
     public void testNotLeaked_streamReferenceHeld() throws Exception {
-        ResponseLeakDetector detector = new ResponseLeakDetector(CLIENT, metrics, SafeThreadLocalRandom.get(), 1);
+        ResponseLeakDetector detector = new ResponseLeakDetector(CLIENT, metrics, SafeThreadLocalRandom.get(), () -> 1);
         // Result is intentionally ignored to cause a leak
         try (InputStream ignored = detector.wrap(response, mockEndpoint).body()) {
             Meter leaks = metrics.responseLeak()


### PR DESCRIPTION
Reduced from 1% overall. It has never detected a leak.
Finalizers can be dangerous due to reliance on a shared queue
resource.
In the worst case when users leak closeable responses there's an
open connection until the reference is garbage collected. This
won't risk saturating our connection pool.

## After this PR
==COMMIT_MSG==
Leak detection can be enabled at 100% by enabling trace logging, and 1% by enabling debug logging.
==COMMIT_MSG==