### PR TITLE
Helpful toString implementations for debugging

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -163,3 +163,13 @@ acceptedBreaks:
       old: "method void com.palantir.dialogue.core.DialogueChannel.Builder::<init>()"
       new: "method void com.palantir.dialogue.core.DialogueChannel.Builder::<init>()"
       justification: "Never intended to be public, no known users"
+  "1.32.0":
+    com.palantir.dialogue:dialogue-core:
+    - code: "java.class.visibilityReduced"
+      old: "class com.palantir.dialogue.core.DialogueTracedRequestChannel"
+      new: "class com.palantir.dialogue.core.DialogueTracedRequestChannel"
+      justification: "Never intended to be public, no known users"
+    - code: "java.method.visibilityReduced"
+      old: "method void com.palantir.dialogue.core.DialogueTracedRequestChannel::<init>(com.palantir.dialogue.Channel)"
+      new: "method void com.palantir.dialogue.core.DialogueTracedRequestChannel::<init>(com.palantir.dialogue.Channel)"
+      justification: "Never intended to be public, no known users"

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ActiveRequestInstrumentationChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ActiveRequestInstrumentationChannel.java
@@ -58,6 +58,6 @@ final class ActiveRequestInstrumentationChannel implements Channel {
 
     @Override
     public String toString() {
-        return "ActiveRequestInstrumentationChannel{" + "delegate=" + delegate + ", stage=" + stage + '}';
+        return "ActiveRequestInstrumentationChannel{stage=" + stage + ", delegate=" + delegate + '}';
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToLimitedChannelAdapter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToLimitedChannelAdapter.java
@@ -39,6 +39,6 @@ final class ChannelToLimitedChannelAdapter implements LimitedChannel {
 
     @Override
     public String toString() {
-        return "ChannelToLimitedChannelAdapter{delegate=" + delegate + '}';
+        return "ChannelToLimitedChannelAdapter{" + delegate + '}';
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -89,6 +89,11 @@ final class ContentDecodingChannel implements Channel {
         return input;
     }
 
+    @Override
+    public String toString() {
+        return "ContentDecodingChannel{" + delegate + '}';
+    }
+
     private static final class ContentDecodingResponse implements Response {
 
         private final Response delegate;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
@@ -89,4 +89,9 @@ final class DeprecationWarningChannel implements Channel {
         }
         return false;
     }
+
+    @Override
+    public String toString() {
+        return "DeprecationWarningChannel{" + delegate + '}';
+    }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -155,6 +155,12 @@ public final class DialogueChannel implements Channel {
         return new Builder();
     }
 
+    @Override
+    public String toString() {
+        return "DialogueChannel@" + Integer.toHexString(System.identityHashCode(this)) + "{channelName="
+                + cf.channelName() + ", delegate=" + delegate + '}';
+    }
+
     public static final class Builder {
         private final ImmutableConfig.Builder builder = ImmutableConfig.builder();
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueTracedRequestChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueTracedRequestChannel.java
@@ -23,10 +23,10 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.tracing.Tracers;
 
-public final class DialogueTracedRequestChannel implements Channel {
+final class DialogueTracedRequestChannel implements Channel {
     private final Channel delegate;
 
-    public DialogueTracedRequestChannel(Channel delegate) {
+    DialogueTracedRequestChannel(Channel delegate) {
         this.delegate = delegate;
     }
 
@@ -34,5 +34,10 @@ public final class DialogueTracedRequestChannel implements Channel {
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
         String operationName = "Dialogue: request " + endpoint.serviceName() + "#" + endpoint.endpointName();
         return Tracers.wrapListenableFuture(operationName, () -> delegate.execute(endpoint, request));
+    }
+
+    @Override
+    public String toString() {
+        return "DialogueTracedRequestChannel{" + delegate + '}';
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -179,6 +179,11 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
         return Optional.empty();
     }
 
+    @Override
+    public String toString() {
+        return "NodeSelectionStrategyChannel{" + nodeSelectionStrategy + '}';
+    }
+
     @Value.Immutable
     interface NodeSelectionChannel {
         DialogueNodeSelectionStrategy strategy();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -238,11 +238,10 @@ final class QueuedChannel implements Channel {
 
     @Override
     public String toString() {
-        return "QueuedChannel{" +
-                "queueSizeEstimate=" + queueSizeEstimate +
-                ", maxQueueSize=" + maxQueueSize +
-                ", delegate=" + delegate +
-                '}';
+        return "QueuedChannel{queueSizeEstimate="
+                + queueSizeEstimate + ", maxQueueSize="
+                + maxQueueSize + ", delegate="
+                + delegate + '}';
     }
 
     /**

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -236,6 +236,15 @@ final class QueuedChannel implements Channel {
         }
     }
 
+    @Override
+    public String toString() {
+        return "QueuedChannel{" +
+                "queueSizeEstimate=" + queueSizeEstimate +
+                ", maxQueueSize=" + maxQueueSize +
+                ", delegate=" + delegate +
+                '}';
+    }
+
     /**
      * Forward the success or failure of the call to the SettableFuture that was previously returned to the caller.
      * This also schedules the next set of requests to be run.

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -192,6 +192,11 @@ final class RetryingChannel implements Channel {
         return !maybeBody.isPresent() || maybeBody.get().repeatable();
     }
 
+    @Override
+    public String toString() {
+        return "RetryingChannel{maxRetries=" + maxRetries + ", serverQoS=" + serverQoS + " delegate=" + delegate + '}';
+    }
+
     private final class RetryingCallback {
         private final Endpoint endpoint;
         private final Request request;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/TracedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/TracedChannel.java
@@ -39,6 +39,6 @@ final class TracedChannel implements Channel {
 
     @Override
     public String toString() {
-        return "TracedChannel{delegate=" + delegate + ", operationName='" + operationName + "\'}";
+        return "TracedChannel{operationName=" + operationName + ", delegate=" + delegate + '}';
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentChannel.java
@@ -60,4 +60,9 @@ final class UserAgentChannel implements Channel {
         String maybeDialogueVersion = Channel.class.getPackage().getImplementationVersion();
         return UserAgent.Agent.of("dialogue", maybeDialogueVersion != null ? maybeDialogueVersion : "0.0.0");
     }
+
+    @Override
+    public String toString() {
+        return "UserAgentChannel{baseAgent=" + UserAgents.format(baseAgent) + ", delegate=" + delegate + '}';
+    }
 }


### PR DESCRIPTION
## Before this PR

When debugging stuff in IntelliJ, there's a nice helpful toString by the side of any variables in scope, e.g.

![image](https://user-images.githubusercontent.com/3473798/80846599-a8ebb980-8c04-11ea-801b-76471d796b7b.png)

Unfortunately, most of our channels just give you a standard system identity hashcode thing.

## After this PR
==COMMIT_MSG==
Many internal Dialogue channels now have helpful toString implementations to aid debugging
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
