### PR TITLE
[test-only] simulation for blue/green upgrades when the new node returns 400s

### DIFF
--- a/simulation/src/test/resources/fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
+++ b/simulation/src/test/resources/fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bab314322ab6c7960e3724b818739cb67f2f5a281ca75d30a35048db959b2c9
+size 177661

--- a/simulation/src/test/resources/fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e09de5f957c91d2d402811f32bb333b2ac65ab705ce7caed5f5f4bb9d196840b
+size 173474

--- a/simulation/src/test/resources/fast_400s_then_revert[UNLIMITED_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/fast_400s_then_revert[UNLIMITED_ROUND_ROBIN].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce07f528bfd625ac07ca1844a317d0faa2326e4ff49bf3f53f84c10a1bf9809e
+size 172612

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -10,6 +10,9 @@
              drastic_slowdown[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT1.965733249S 	server_cpu=PT41M8.192999979S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                  drastic_slowdown[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.275952999S 	server_cpu=PT18M23.81199998S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                            drastic_slowdown[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.275952999S 	server_cpu=PT18M23.81199998S	client_received=4000/4000	server_resps=4000	codes={200=4000}
+        fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=82.2%	client_mean=PT0.102233333S 	server_cpu=PT10M13.4S     	client_received=6000/6000	server_resps=6000	codes={200=4934, 400=1066}
+            fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=71.0%	client_mean=PT0.091S       	server_cpu=PT9M6S         	client_received=6000/6000	server_resps=6000	codes={200=4260, 400=1740}
+                      fast_400s_then_revert[UNLIMITED_ROUND_ROBIN].txt:	success=71.0%	client_mean=PT0.091S       	server_cpu=PT9M6S         	client_received=6000/6000	server_resps=6000	codes={200=4260, 400=1740}
         fast_503s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.120012009S 	server_cpu=PT1H30M0.00000004S	client_received=45000/45000	server_resps=45004	codes={200=45000}
             fast_503s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.120105435S 	server_cpu=PT1H30M0.0000004S	client_received=45000/45000	server_resps=45040	codes={200=45000}
                       fast_503s_then_revert[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.120105435S 	server_cpu=PT1H30M0.0000004S	client_received=45000/45000	server_resps=45040	codes={200=45000}
@@ -81,6 +84,21 @@ slowdown_and_error_thresholds[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=
 ## `drastic_slowdown[UNLIMITED_ROUND_ROBIN]`
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/drastic_slowdown[UNLIMITED_ROUND_ROBIN].png" /></td><td><image width=400 src="drastic_slowdown[UNLIMITED_ROUND_ROBIN].png" /></td></tr></table>
+
+
+## `fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## `fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].png" /></td><td><image width=400 src="fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].png" /></td></tr></table>
+
+
+## `fast_400s_then_revert[UNLIMITED_ROUND_ROBIN]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/fast_400s_then_revert[UNLIMITED_ROUND_ROBIN].png" /></td><td><image width=400 src="fast_400s_then_revert[UNLIMITED_ROUND_ROBIN].png" /></td></tr></table>
 
 
 ## `fast_503s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR]`

--- a/simulation/src/test/resources/txt/fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
+++ b/simulation/src/test/resources/txt/fast_400s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
@@ -1,0 +1,1 @@
+success=82.2%	client_mean=PT0.102233333S 	server_cpu=PT10M13.4S     	client_received=6000/6000	server_resps=6000	codes={200=4934, 400=1066}

--- a/simulation/src/test/resources/txt/fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/fast_400s_then_revert[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
@@ -1,0 +1,1 @@
+success=71.0%	client_mean=PT0.091S       	server_cpu=PT9M6S         	client_received=6000/6000	server_resps=6000	codes={200=4260, 400=1740}

--- a/simulation/src/test/resources/txt/fast_400s_then_revert[UNLIMITED_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/fast_400s_then_revert[UNLIMITED_ROUND_ROBIN].txt
@@ -1,0 +1,1 @@
+success=71.0%	client_mean=PT0.091S       	server_cpu=PT9M6S         	client_received=6000/6000	server_resps=6000	codes={200=4260, 400=1740}


### PR DESCRIPTION
## Before this PR

@tpetracca reported in #dev-rpc that there have been some P0s recently (PDS-118387, PDS-118388, PDS-118389) where a new node started erroneously returning 4xx responses (e.g. 400 or even 401/403), when the old node continued to serve 200s.

## After this PR
==COMMIT_MSG==
simulation for blue/green upgrades when the new node returns 400s
==COMMIT_MSG==

Interestingly it seems pin_until_error currently performs the best in this scenario.

# [GRAPHS](https://github.com/palantir/dialogue/blob/dfox/more-simulations/simulation/src/test/resources/report.md#fast_400s_then_revertconcurrency_limiter_pin_until_error)

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
