### PR TITLE
Fix a thread leak from unclosed httpclients

### DIFF
--- a/changelog/@unreleased/pr-714.v2.yml
+++ b/changelog/@unreleased/pr-714.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix a thread leak from unclosed httpclients
+  links:
+  - https://github.com/palantir/dialogue/pull/714

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -190,7 +190,21 @@ public final class ApacheHttpClientChannels {
             // Terminate all idle connections, note that this does not in fact close the client
             // itself. Eventually the client will be garbage collected and resources will be released.
             // This allows pending requests to execute without causing application level failures.
+            // Closing the client itself is deferred until this object is garbage collected.
             pool.closeIdleConnections(0, TimeUnit.NANOSECONDS);
+        }
+
+        @Override
+        @SuppressWarnings("NoFinalizer")
+        protected void finalize() throws Throwable {
+            try {
+                // The client object must eventually be closed to avoid leaking threads, in particular
+                // the idle connection eviction thread from IdleConnectionEvictor, though there may
+                // be additional closeable resources.
+                client.close();
+            } finally {
+                super.finalize();
+            }
         }
 
         @Override


### PR DESCRIPTION
The CloseableClient object closes delegate clients
when it is garbage collected, instead of leaking.

The wrapper object is only released once it's no longer used
because it's referenced via the channelFactory object and
the cache, so as long as a service is making requests the
dialogue channel is pinned, and keeps the client around.

Longer term we may wish to implement reference counting
to avoid finalizers and release resources as soon as the last
request completes.

## After this PR
==COMMIT_MSG==
Fix a thread leak from unclosed httpclients
==COMMIT_MSG==

## Possible downsides?
finalizer isn't ideal.
