### PR TITLE
DialogueClients produces versioned metrics

### DIFF
--- a/changelog/@unreleased/pr-718.v2.yml
+++ b/changelog/@unreleased/pr-718.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Clients constructed using the `DialogueClients` fluent factories now
+    have metrics tagged with the proper `dialogueVersion`.
+  links:
+  - https://github.com/palantir/dialogue/pull/718

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/AugmentClientConfig.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/AugmentClientConfig.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.client.config.ClientConfigurations;
 import com.palantir.conjure.java.client.config.HostEventsSink;
 import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.dialogue.core.DialogueInternalVersionedTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.security.Provider;
@@ -36,8 +37,13 @@ import org.immutables.value.Value;
 interface AugmentClientConfig {
     @Value.Default
     @SuppressWarnings("deprecation") // ideally users would wire in a registry, but this works out of the box
-    default TaggedMetricRegistry taggedMetrics() {
+    default TaggedMetricRegistry userProvidedTaggedMetrics() {
         return SharedTaggedMetricRegistries.getSingleton();
+    }
+
+    @Value.Derived
+    default TaggedMetricRegistry taggedMetricRegistry() {
+        return DialogueInternalVersionedTaggedMetricRegistry.wrap(userProvidedTaggedMetrics());
     }
 
     Optional<UserAgent> userAgent();
@@ -76,7 +82,7 @@ interface AugmentClientConfig {
         }
 
         builder.userAgent(augment.userAgent());
-        builder.taggedMetricRegistry(augment.taggedMetrics());
+        builder.taggedMetricRegistry(augment.taggedMetricRegistry());
 
         augment.nodeSelectionStrategy().ifPresent(builder::nodeSelectionStrategy);
         augment.clientQoS().ifPresent(builder::clientQoS);

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -61,6 +61,7 @@ public final class DialogueClients {
     }
 
     /** Low-level API. Most users won't need this, but it is necessary to construct feign-shim clients. */
+    @CheckReturnValue
     public interface ReloadingChannelFactory {
         Channel getChannel(String serviceName);
     }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -144,7 +144,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
     @Override
     public DialogueClients.ReloadingFactory withTaggedMetrics(TaggedMetricRegistry metrics) {
-        return new ReloadingClientFactory(params.withTaggedMetrics(metrics), cache);
+        return new ReloadingClientFactory(params.withUserProvidedTaggedMetrics(metrics), cache);
     }
 
     @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
@@ -38,7 +38,7 @@ interface Config {
         return ClientConfiguration.builder()
                 .from(rawConfig())
                 .taggedMetricRegistry(
-                        VersionedTaggedMetricRegistry.create(rawConfig().taggedMetricRegistry()))
+                        DialogueInternalVersionedTaggedMetricRegistry.wrap(rawConfig().taggedMetricRegistry()))
                 .build();
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
@@ -37,8 +37,8 @@ interface Config {
     default ClientConfiguration clientConf() {
         return ClientConfiguration.builder()
                 .from(rawConfig())
-                .taggedMetricRegistry(
-                        DialogueInternalVersionedTaggedMetricRegistry.wrap(rawConfig().taggedMetricRegistry()))
+                .taggedMetricRegistry(DialogueInternalVersionedTaggedMetricRegistry.wrap(
+                        rawConfig().taggedMetricRegistry()))
                 .build();
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueInternalVersionedTaggedMetricRegistry.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueInternalVersionedTaggedMetricRegistry.java
@@ -22,30 +22,34 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-final class VersionedTaggedMetricRegistry implements TaggedMetricRegistry {
+public final class DialogueInternalVersionedTaggedMetricRegistry implements TaggedMetricRegistry {
     private static final String DIALOGUE_VERSION = Optional.ofNullable(
-                    VersionedTaggedMetricRegistry.class.getPackage().getImplementationVersion())
+                    DialogueInternalVersionedTaggedMetricRegistry.class
+                            .getPackage()
+                            .getImplementationVersion())
             .orElse("dev");
 
     private final TaggedMetricRegistry delegate;
 
-    private VersionedTaggedMetricRegistry(TaggedMetricRegistry delegate) {
-        this.delegate = delegate;
+    private DialogueInternalVersionedTaggedMetricRegistry(TaggedMetricRegistry delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "TaggedMetricRegistry");
     }
 
-    static VersionedTaggedMetricRegistry create(TaggedMetricRegistry delegate) {
-        if (delegate instanceof VersionedTaggedMetricRegistry) {
-            return (VersionedTaggedMetricRegistry) delegate;
+    public static DialogueInternalVersionedTaggedMetricRegistry wrap(TaggedMetricRegistry delegate) {
+        if (delegate instanceof DialogueInternalVersionedTaggedMetricRegistry) {
+            return (DialogueInternalVersionedTaggedMetricRegistry) delegate;
         }
-        return new VersionedTaggedMetricRegistry(delegate);
+        return new DialogueInternalVersionedTaggedMetricRegistry(delegate);
     }
 
     private MetricName augment(MetricName name) {
@@ -142,5 +146,22 @@ final class VersionedTaggedMetricRegistry implements TaggedMetricRegistry {
     public boolean removeMetrics(String _safeTagName, String _safeTagValue, TaggedMetricSet _metrics) {
         throw new UnsupportedOperationException(
                 "Removal operations are not implemented as we don't need them in dialogue");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        DialogueInternalVersionedTaggedMetricRegistry that = (DialogueInternalVersionedTaggedMetricRegistry) obj;
+        return delegate.equals(that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate);
     }
 }


### PR DESCRIPTION
## Before this PR

I tried to read out the `dialogue.client.create` metric in my Witchcraft PR and found that the `dialogueVersion` tag was missing on one of the metrics. 

## After this PR
==COMMIT_MSG==
Clients constructed using the `DialogueClients` fluent factories now have metrics tagged with the proper `dialogueVersion`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
