### PR TITLE
Dialogue should not propagate retry-other

### DIFF
--- a/changelog/@unreleased/pr-726.v2.yml
+++ b/changelog/@unreleased/pr-726.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Dialogue does not propagate retry-other
+  links:
+  - https://github.com/palantir/dialogue/pull/726

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
@@ -66,7 +66,9 @@ enum ErrorDecoder {
                 if (location.isPresent()) {
                     String locationHeader = location.get();
                     try {
-                        return toRemoteException(code, QosException.retryOther(new URL(locationHeader)));
+                        UnknownRemoteException remoteException = new UnknownRemoteException(code, "");
+                        remoteException.initCause(QosException.retryOther(new URL(locationHeader)));
+                        return remoteException;
                     } catch (MalformedURLException e) {
                         log.error(
                                 "Failed to parse location header for QosException.RetryOther",
@@ -114,11 +116,5 @@ enum ErrorDecoder {
         try (Reader reader = new InputStreamReader(body, StandardCharsets.UTF_8)) {
             return CharStreams.toString(reader);
         }
-    }
-
-    private static UnknownRemoteException toRemoteException(int code, QosException qos) {
-        UnknownRemoteException remoteException = new UnknownRemoteException(code, "");
-        remoteException.initCause(qos);
-        return remoteException;
     }
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
@@ -66,7 +66,7 @@ enum ErrorDecoder {
                 if (location.isPresent()) {
                     String locationHeader = location.get();
                     try {
-                        return QosException.retryOther(new URL(locationHeader));
+                        return toRemoteException(code, QosException.retryOther(new URL(locationHeader)));
                     } catch (MalformedURLException e) {
                         log.error(
                                 "Failed to parse location header for QosException.RetryOther",
@@ -114,5 +114,11 @@ enum ErrorDecoder {
         try (Reader reader = new InputStreamReader(body, StandardCharsets.UTF_8)) {
             return CharStreams.toString(reader);
         }
+    }
+
+    private static UnknownRemoteException toRemoteException(int code, QosException qos) {
+        UnknownRemoteException remoteException = new UnknownRemoteException(code, "");
+        remoteException.initCause(qos);
+        return remoteException;
     }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoderTest.java
@@ -160,10 +160,13 @@ public final class ErrorDecoderTest {
         assertThat(decoder.isError(response)).isTrue();
 
         RuntimeException result = decoder.decode(response);
-        assertThat(result).isInstanceOfSatisfying(QosException.RetryOther.class, exception -> assertThat(
-                        exception.getRedirectTo())
-                .asString()
-                .isEqualTo(expectedLocation));
+        assertThat(result)
+                .isInstanceOf(UnknownRemoteException.class)
+                .getRootCause()
+                .isInstanceOfSatisfying(
+                        QosException.RetryOther.class,
+                        exception ->
+                                assertThat(exception.getRedirectTo()).asString().isEqualTo(expectedLocation));
     }
 
     @Test


### PR DESCRIPTION
Currently dialogue rethrows qos exceptions, which doesn't quite match CJR: CJR only rethrows throttle and unavailable when `ServerQos.PROPAGATE_429_and_503_TO_CALLER` is set.
The dialogue runtime isn't at all aware of the client configuration at the moment, so we can't emulate that precisely.
This change brings dialogue closer to CJR, but isn't meant to bring the two exactly together.
There's an argument to be made that when a 503 or 429 is returned for all retries, it _should_ be propagated in order to apply backpressure across the entire system.

==COMMIT_MSG==
Dialogue does not propagate retry-other
==COMMIT_MSG==