### PR TITLE
Idle connections are checked and timed out more frequently

### DIFF
--- a/changelog/@unreleased/pr-727.v2.yml
+++ b/changelog/@unreleased/pr-727.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Idle connections are checked and timed out more frequently
+  links:
+  - https://github.com/palantir/dialogue/pull/727

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -187,7 +187,7 @@ public final class ApacheHttpClientChannels {
                 connectionEvictor.shutdown();
                 try {
                     connectionEvictor.awaitTermination(1L, TimeUnit.SECONDS);
-                } catch (final InterruptedException interrupted) {
+                } catch (InterruptedException interrupted) {
                     Thread.currentThread().interrupt();
                 }
             });

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -404,8 +404,6 @@ public final class ApacheHttpClientChannels {
                             // empty path parameters cannot be matched by the server.
                             .setNormalizeUri(false)
                             .build())
-                    .setDefaultSocketConfig(socketConfig)
-                    .evictIdleConnections(idleConnectionTimeoutMillis, TimeUnit.MILLISECONDS)
                     // Connection pool lifecycle must be managed separately. This allows us to configure a more
                     // precise IdleConnectionEvictor.
                     .setConnectionManagerShared(true)
@@ -418,7 +416,6 @@ public final class ApacheHttpClientChannels {
                     .disableCookieManagement()
                     // Dialogue handles content-compression with ContentDecodingChannel
                     .disableContentCompression()
-                    .setSSLSocketFactory(sslSocketFactory)
                     .setDefaultCredentialsProvider(NullCredentialsProvider.INSTANCE)
                     .setTargetAuthenticationStrategy(NullAuthenticationStrategy.INSTANCE)
                     .setProxyAuthenticationStrategy(NullAuthenticationStrategy.INSTANCE)


### PR DESCRIPTION
Previously the idle timeout and check interval were the same,
resulting in the potential for connections to live twice as long
as we expected. While this isn't a big problem, it introduces a
potential race when the server closes an idle connection as the
client attempts to check it out from the pool. The liveness check
can succeed while the subsequent request occurs after the
server-side has closed.

## After this PR
==COMMIT_MSG==
Idle connections are checked and timed out more frequently
==COMMIT_MSG==

## Possible downsides?
More state to manage ourselves
