### PR TITLE
fix #728 308 retry-other responses don't use exponential backoff

### DIFF
--- a/changelog/@unreleased/pr-729.v2.yml
+++ b/changelog/@unreleased/pr-729.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 308 retry-other responses don't use exponential backoff
+  links:
+  - https://github.com/palantir/dialogue/pull/729

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -20,7 +20,7 @@ import com.palantir.dialogue.Response;
 /** Utility functionality for {@link Response} handling. */
 final class Responses {
 
-    private static boolean isRetryOther(Response response) {
+    static boolean isRetryOther(Response response) {
         return response.code() == 308;
     }
 


### PR DESCRIPTION
==COMMIT_MSG==
308 retry-other responses don't use exponential backoff
==COMMIT_MSG==
