### PR TITLE
Reduce allocation in InstrumentedChannel

### DIFF
--- a/changelog/@unreleased/pr-733.v2.yml
+++ b/changelog/@unreleased/pr-733.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`InstrumentedChannel` now allocates fewer objects per RPC call.'
+  links:
+  - https://github.com/palantir/dialogue/pull/733

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -75,7 +75,7 @@ public final class DialogueChannel implements Channel {
         Channel channel = cf.channelFactory().create(uri);
         // Instrument inner-most channel with instrumentation channels so that we measure only the over-the-wire-time
         channel = new InstrumentedChannel(
-                channel, cf.channelName(), cf.clientConf().taggedMetricRegistry());
+                channel, cf.channelName(), cf.clientConf().taggedMetricRegistry(), cf.ticker());
         channel = HostMetricsChannel.create(channel, cf, uri);
         channel = new ActiveRequestInstrumentationChannel(
                 channel, cf.channelName(), "running", cf.clientConf().taggedMetricRegistry());

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/InstrumentedChannelTest.java
@@ -18,10 +18,12 @@ package com.palantir.dialogue.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
+import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
@@ -50,7 +52,7 @@ public final class InstrumentedChannelTest {
     @BeforeEach
     public void before() {
         registry = new DefaultTaggedMetricRegistry();
-        channel = new InstrumentedChannel(delegate, "my-channel", registry);
+        channel = new InstrumentedChannel(delegate, "my-channel", registry, mock(Ticker.class));
     }
 
     @Test

--- a/simulation/src/main/java/com/palantir/dialogue/core/Benchmark.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/Benchmark.java
@@ -170,7 +170,8 @@ public final class Benchmark {
     public ListenableFuture<BenchmarkResult> schedule() {
 
         Channel[] channels = Arrays.stream(clients)
-                .map(c -> new InstrumentedChannel(c, SimulationUtils.CHANNEL_NAME, simulation.taggedMetrics()))
+                .map(c -> new InstrumentedChannel(
+                        c, SimulationUtils.CHANNEL_NAME, simulation.taggedMetrics(), simulation.clock()))
                 .toArray(Channel[]::new);
 
         long[] requestsStarted = {0};


### PR DESCRIPTION
## Before this PR

SimulationTest is slow for many reasons. One of my hypothesis is that we actually allocate quite a lot of objects in order to process 45k events.

## After this PR
==COMMIT_MSG==
InstrumentedChannel no longer uses metric-schema's staged builders to access a Timer on every request, instead it does a lookup in a caffeine cache.
==COMMIT_MSG==

This achieved a 20% throughput increase, from 9k -> 11k req/sec

```diff
-com.palantir.dialogue.core.Benchmark - Fired off all requests (4864 ms, 9251req/sec)
+com.palantir.dialogue.core.Benchmark - Fired off all requests (4055 ms, 11097req/sec)
```

![image](https://user-images.githubusercontent.com/3473798/81635544-57fc7200-9409-11ea-9f68-2f00d97753f5.png)



## Possible downsides?
- This isn't JMH precise, so maybe the difference is actually bigger/smaller than my crappy Stopwatch log lines show
