### PR TITLE
Minor logging tweaks

### DIFF
--- a/changelog/@unreleased/pr-737.v2.yml
+++ b/changelog/@unreleased/pr-737.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: RetryingChannel no longer logs stacktraces at info, as these are primarily
+    useful for dialogue maintainers not users. Dialling up logging to debug will still
+    cause call-site stacktraces to be recorded, although this comes with a performance
+    cost.
+  links:
+  - https://github.com/palantir/dialogue/pull/737

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/AimdConcurrencyLimiter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/AimdConcurrencyLimiter.java
@@ -112,7 +112,7 @@ final class AimdConcurrencyLimiter {
             inFlight.decrementAndGet();
             int newLimit = limit.accumulateAndGet(inFlightSnapshot, LimitUpdater.DROPPED);
             if (log.isDebugEnabled()) {
-                log.debug("DOWN {}", SafeArg.of("newLimit", newLimit));
+                log.debug("Decreasing limit {}", SafeArg.of("newLimit", newLimit));
             }
         }
 
@@ -124,7 +124,7 @@ final class AimdConcurrencyLimiter {
             inFlight.decrementAndGet();
             int newLimit = limit.accumulateAndGet(inFlightSnapshot, LimitUpdater.SUCCESS);
             if (log.isDebugEnabled()) {
-                log.debug("UP {}", SafeArg.of("newLimit", newLimit));
+                log.debug("Increasing limit {}", SafeArg.of("newLimit", newLimit));
             }
         }
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -113,7 +113,7 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
     private void logPermitAcquired() {
         if (log.isDebugEnabled()) {
             log.debug(
-                    "Sending. {}/{}",
+                    "Sending {}/{}",
                     SafeArg.of("inflight", limiter.getInflight()),
                     SafeArg.of("max", limiter.getLimit()));
         }
@@ -121,7 +121,7 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
 
     private void logPermitRefused() {
         if (log.isDebugEnabled()) {
-            log.debug("Limited. {}", SafeArg.of("max", limiter.getLimit()));
+            log.debug("Limited {}", SafeArg.of("max", limiter.getLimit()));
         }
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -131,7 +131,7 @@ final class QueuedChannel implements Channel {
         int newSize = incrementQueueSize();
 
         if (log.isDebugEnabled()) {
-            log.debug("Request queued. {}", SafeArg.of("queueSize", newSize), SafeArg.of("channelName", channelName));
+            log.debug("Request queued {}", SafeArg.of("queueSize", newSize), SafeArg.of("channelName", channelName));
         }
 
         schedule();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -128,7 +128,11 @@ final class QueuedChannel implements Channel {
             // Should never happen, ConcurrentLinkedDeque has no maximum size
             return Optional.empty();
         }
-        incrementQueueSize();
+        int newSize = incrementQueueSize();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Request queued. {}", SafeArg.of("queueSize", newSize), SafeArg.of("channelName", channelName));
+        }
 
         schedule();
 
@@ -149,13 +153,16 @@ final class QueuedChannel implements Channel {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("Scheduled {} requests", SafeArg.of("numScheduled", numScheduled));
+            log.debug(
+                    "Scheduled {} requests",
+                    SafeArg.of("numScheduled", numScheduled),
+                    SafeArg.of("channelName", channelName));
         }
     }
 
-    private void incrementQueueSize() {
-        queueSizeEstimate.incrementAndGet();
+    private int incrementQueueSize() {
         queueSizeCounter.inc();
+        return queueSizeEstimate.incrementAndGet();
     }
 
     private void decrementQueueSize() {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -223,10 +223,64 @@ final class RetryingChannel implements Channel {
             return result;
         }
 
+        private ListenableFuture<Response> wrap(ListenableFuture<Response> input) {
+            ListenableFuture<Response> result = input;
+            result = Futures.transformAsync(result, this::handleHttpResponse, MoreExecutors.directExecutor());
+            result = Futures.catchingAsync(
+                    result, Throwable.class, this::handleThrowable, MoreExecutors.directExecutor());
+            return result;
+        }
+
+        ListenableFuture<Response> handleHttpResponse(Response response) {
+            if (isRetryableQosStatus(response)) {
+                return incrementFailuresAndMaybeRetry(response, qosThrowable, retryDueToQosResponse);
+            }
+
+            if (response.code() == 500 && safeToRetry(endpoint.httpMethod())) {
+                return incrementFailuresAndMaybeRetry(response, serverErrorThrowable, retryDueToServerError);
+            }
+
+            return Futures.immediateFuture(response);
+        }
+
+        ListenableFuture<Response> handleThrowable(Throwable clientSideThrowable) {
+            if (++failures <= maxRetries) {
+                if (shouldAttemptToRetry(clientSideThrowable)) {
+                    callsiteStacktrace.ifPresent(clientSideThrowable::addSuppressed);
+                    Meter retryReason = retryDueToThrowable.apply(clientSideThrowable);
+                    long backoffNanoseconds = getBackoffNanoseconds();
+                    infoLogRetry(backoffNanoseconds, clientSideThrowable);
+                    return scheduleRetry(retryReason, backoffNanoseconds);
+                } else if (log.isDebugEnabled()) {
+                    callsiteStacktrace.ifPresent(clientSideThrowable::addSuppressed);
+                    log.debug(
+                            "Not attempting to retry failure",
+                            SafeArg.of("channelName", channelName),
+                            SafeArg.of("serviceName", endpoint.serviceName()),
+                            SafeArg.of("endpoint", endpoint.endpointName()),
+                            clientSideThrowable);
+                }
+            }
+            return Futures.immediateFailedFuture(clientSideThrowable);
+        }
+
+        private ListenableFuture<Response> incrementFailuresAndMaybeRetry(
+                Response response, BiFunction<Endpoint, Response, Throwable> failureSupplier, Meter meter) {
+            if (++failures <= maxRetries) {
+                response.close();
+                Throwable throwableToLog = log.isTraceEnabled() ? failureSupplier.apply(endpoint, response) : null;
+                long backoffNanos = Responses.isRetryOther(response) ? 0 : getBackoffNanoseconds();
+                infoLogRetry(backoffNanos, throwableToLog);
+                return scheduleRetry(meter, backoffNanos);
+            }
+            infoLogRetriesExhausted(response);
+            // not closing response because ConjureBodySerde will need to deserialize it
+            return Futures.immediateFuture(response);
+        }
+
         @SuppressWarnings("FutureReturnValueIgnored") // error-prone bug
-        ListenableFuture<Response> scheduleRetry(Meter meter, BackoffBehavior backoffBehavior) {
+        ListenableFuture<Response> scheduleRetry(Meter meter, long backoffNanoseconds) {
             meter.mark();
-            long backoffNanoseconds = backoffBehavior.apply(getBackoffNanoseconds());
             if (backoffNanoseconds <= 0) {
                 return wrap(delegate.execute(endpoint, request));
             }
@@ -249,18 +303,6 @@ final class RetryingChannel implements Channel {
             return Math.round(backoffSlotSize.toNanos() * jitter.getAsDouble() * upperBound);
         }
 
-        ListenableFuture<Response> handleHttpResponse(Response response) {
-            if (isRetryableQosStatus(response)) {
-                return incrementFailuresAndMaybeRetry(response, qosThrowable, retryDueToQosResponse);
-            }
-
-            if (response.code() == 500 && safeToRetry(endpoint.httpMethod())) {
-                return incrementFailuresAndMaybeRetry(response, serverErrorThrowable, retryDueToServerError);
-            }
-
-            return Futures.immediateFuture(response);
-        }
-
         private boolean isRetryableQosStatus(Response response) {
             switch (serverQoS) {
                 case AUTOMATIC_RETRY:
@@ -272,50 +314,6 @@ final class RetryingChannel implements Channel {
             }
             throw new SafeIllegalStateException(
                     "Encountered unknown propagate QoS configuration", SafeArg.of("serverQoS", serverQoS));
-        }
-
-        private ListenableFuture<Response> incrementFailuresAndMaybeRetry(
-                Response response, BiFunction<Endpoint, Response, Throwable> failureSupplier, Meter meter) {
-            if (++failures <= maxRetries) {
-                response.close();
-                Throwable throwableToLog = log.isTraceEnabled() ? failureSupplier.apply(endpoint, response) : null;
-                infoLogRetry(throwableToLog);
-                return scheduleRetry(
-                        meter, Responses.isRetryOther(response) ? BackoffBehavior.DISABLED : BackoffBehavior.DEFAULT);
-            }
-            if (log.isInfoEnabled()) {
-                SafeRuntimeException stacktrace = callsiteStacktrace.orElse(null);
-                log.info(
-                        "Exhausted {} retries, returning a retryable response with status {}",
-                        SafeArg.of("retries", maxRetries),
-                        SafeArg.of("status", response.code()),
-                        SafeArg.of("channelName", channelName),
-                        SafeArg.of("serviceName", endpoint.serviceName()),
-                        SafeArg.of("endpoint", endpoint.endpointName()),
-                        stacktrace);
-            }
-            // not closing response because ConjureBodySerde will need to deserialize it
-            return Futures.immediateFuture(response);
-        }
-
-        ListenableFuture<Response> handleThrowable(Throwable clientSideThrowable) {
-            if (++failures <= maxRetries) {
-                if (shouldAttemptToRetry(clientSideThrowable)) {
-                    callsiteStacktrace.ifPresent(clientSideThrowable::addSuppressed);
-                    Meter retryReason = retryDueToThrowable.apply(clientSideThrowable);
-                    infoLogRetry(clientSideThrowable);
-                    return scheduleRetry(retryReason, BackoffBehavior.DEFAULT);
-                } else if (log.isDebugEnabled()) {
-                    callsiteStacktrace.ifPresent(clientSideThrowable::addSuppressed);
-                    log.debug(
-                            "Not attempting to retry failure",
-                            SafeArg.of("channelName", channelName),
-                            SafeArg.of("serviceName", endpoint.serviceName()),
-                            SafeArg.of("endpoint", endpoint.endpointName()),
-                            clientSideThrowable);
-                }
-            }
-            return Futures.immediateFailedFuture(clientSideThrowable);
         }
 
         private boolean shouldAttemptToRetry(Throwable throwable) {
@@ -333,25 +331,32 @@ final class RetryingChannel implements Channel {
             return throwable instanceof IOException;
         }
 
-        private void infoLogRetry(@Nullable Throwable throwable) {
+        private void infoLogRetriesExhausted(Response response) {
+            if (log.isInfoEnabled()) {
+                SafeRuntimeException stacktrace = callsiteStacktrace.orElse(null);
+                log.info(
+                        "Exhausted {} retries, returning last received response with status {}",
+                        SafeArg.of("retries", maxRetries),
+                        SafeArg.of("status", response.code()),
+                        SafeArg.of("channelName", channelName),
+                        SafeArg.of("serviceName", endpoint.serviceName()),
+                        SafeArg.of("endpoint", endpoint.endpointName()),
+                        stacktrace);
+            }
+        }
+
+        private void infoLogRetry(long backoffNanoseconds, @Nullable Throwable throwable) {
             if (log.isInfoEnabled()) {
                 log.info(
-                        "Retrying call after failure",
+                        "Retrying call after failure {}/{}",
                         SafeArg.of("failures", failures),
                         SafeArg.of("maxRetries", maxRetries),
+                        SafeArg.of("backoffMillis", TimeUnit.NANOSECONDS.toMillis(backoffNanoseconds)),
                         SafeArg.of("channelName", channelName),
                         SafeArg.of("serviceName", endpoint.serviceName()),
                         SafeArg.of("endpoint", endpoint.endpointName()),
                         throwable);
             }
-        }
-
-        private ListenableFuture<Response> wrap(ListenableFuture<Response> input) {
-            ListenableFuture<Response> result = input;
-            result = Futures.transformAsync(result, this::handleHttpResponse, MoreExecutors.directExecutor());
-            result = Futures.catchingAsync(
-                    result, Throwable.class, this::handleThrowable, MoreExecutors.directExecutor());
-            return result;
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/palantir/dialogue/issues/736

## Before this PR

Iterating on the IntegrationTest to figure out what's going on with our ConcurrencyLimiters is pretty hard right now, as there are either too many or not enough logs.

(Also I still find RetryingChannel hard to read/refactor - see my [abandoned attempt](https://github.com/palantir/dialogue/pull/730))

## After this PR
==COMMIT_MSG==
RetryingChannel no longer logs stacktraces at info, as these are primarily useful for dialogue maintainers not users. Dialling up logging to debug will still cause call-site stacktraces to be recorded, although this comes with a performance cost.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
