### PR TITLE
IdleConnectionEvictor is started

### DIFF
--- a/changelog/@unreleased/pr-740.v2.yml
+++ b/changelog/@unreleased/pr-740.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: IdleConnectionEvictor is started properly
+  links:
+  - https://github.com/palantir/dialogue/pull/740

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -191,6 +191,7 @@ public final class ApacheHttpClientChannels {
                     Thread.currentThread().interrupt();
                 }
             });
+            connectionEvictor.start();
             closer.register(apacheClient);
             closer.register(pool::shutdown);
             closer.register(DialogueClientMetrics.of(taggedMetrics)


### PR DESCRIPTION
Previously it wasn't started, and didn't evict connections. They would be evicted when new connections were requested, with a potential race against servers closing persistent connections, which can burn retries when it occurs.

==COMMIT_MSG==
IdleConnectionEvictor is started properly
==COMMIT_MSG==