### PR TITLE
ApacheHttpClientBlockingChannel uses the client via CloseableClient

### DIFF
--- a/changelog/@unreleased/pr-744.v2.yml
+++ b/changelog/@unreleased/pr-744.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ApacheHttpClientBlockingChannel uses the client via CloseableClient
+  links:
+  - https://github.com/palantir/dialogue/pull/744

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
@@ -39,7 +39,6 @@ import org.apache.http.HeaderIterator;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,12 +46,12 @@ import org.slf4j.LoggerFactory;
 final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private static final Logger log = LoggerFactory.getLogger(ApacheHttpClientBlockingChannel.class);
 
-    private final CloseableHttpClient client;
+    private final ApacheHttpClientChannels.CloseableClient client;
     private final BaseUrl baseUrl;
     private final ResponseLeakDetector responseLeakDetector;
 
     ApacheHttpClientBlockingChannel(
-            CloseableHttpClient client, URL baseUrl, ResponseLeakDetector responseLeakDetector) {
+            ApacheHttpClientChannels.CloseableClient client, URL baseUrl, ResponseLeakDetector responseLeakDetector) {
         this.client = client;
         this.baseUrl = BaseUrl.of(baseUrl);
         this.responseLeakDetector = responseLeakDetector;
@@ -76,7 +75,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             RequestBody body = request.body().get();
             builder.setEntity(new RequestBodyEntity(body));
         }
-        CloseableHttpResponse httpClientResponse = client.execute(builder.build());
+        CloseableHttpResponse httpClientResponse = client.apacheClient().execute(builder.build());
         // Defensively ensure that resources are closed if failures occur within this block,
         // for example HttpClientResponse allocation may throw an OutOfMemoryError.
         boolean close = true;

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -103,8 +103,7 @@ public final class ApacheHttpClientChannels {
     }
 
     public static Channel createSingleUri(String uri, CloseableClient client) {
-        BlockingChannel blockingChannel =
-                new ApacheHttpClientBlockingChannel(client.apacheClient, url(uri), client.leakDetector);
+        BlockingChannel blockingChannel = new ApacheHttpClientBlockingChannel(client, url(uri), client.leakDetector);
         return client.executor == null
                 ? BlockingChannelAdapter.of(blockingChannel)
                 : BlockingChannelAdapter.of(blockingChannel, client.executor);
@@ -231,6 +230,10 @@ public final class ApacheHttpClientChannels {
                     .build();
             createMeter.mark();
             return newInstance;
+        }
+
+        CloseableHttpClient apacheClient() {
+            return apacheClient;
         }
 
         @Override


### PR DESCRIPTION
This make the code a bit easier to follow, and retains the client
wrapper as long as the apache channel is used to prevent premature
finalization closing the client.

## After this PR
==COMMIT_MSG==
ApacheHttpClientBlockingChannel uses the client via CloseableClient
==COMMIT_MSG==
