### PR TITLE
Dialogue clients do not fail when a Content-Length header is provided

### DIFF
--- a/changelog/@unreleased/pr-748.v2.yml
+++ b/changelog/@unreleased/pr-748.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue clients do not fail when a Content-Lenght header is provided
+  links:
+  - https://github.com/palantir/dialogue/pull/748

--- a/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ApacheHttpClientChannelsTest.java
@@ -29,16 +29,12 @@ import com.palantir.dialogue.AbstractChannelTest;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
-import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestConfigurations;
 import com.palantir.dialogue.TestEndpoint;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.net.UnknownHostException;
 import java.util.Map;
-import java.util.OptionalLong;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
@@ -108,47 +104,6 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
                 .from(request)
                 .body(body)
                 .putHeaderParams(HttpHeaders.CONTENT_LENGTH, Integer.toString(CONTENT.length))
-                .build();
-        channel.execute(endpoint, request);
-        RecordedRequest recordedRequest = server.takeRequest();
-        assertThat(recordedRequest.getMethod()).isEqualTo("POST");
-        assertThat(recordedRequest.getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo(Integer.toString(CONTENT.length));
-        assertThat(recordedRequest.getHeader(HttpHeaders.TRANSFER_ENCODING)).isNull();
-    }
-
-    @Test
-    @SuppressWarnings("FutureReturnValueIgnored")
-    public void supportsContentLengthOnBody() throws InterruptedException {
-        endpoint.method = HttpMethod.POST;
-        request = Request.builder()
-                .from(request)
-                .body(new RequestBody() {
-
-                    @Override
-                    public void writeTo(OutputStream output) throws IOException {
-                        body.writeTo(output);
-                    }
-
-                    @Override
-                    public String contentType() {
-                        return body.contentType();
-                    }
-
-                    @Override
-                    public boolean repeatable() {
-                        return body.repeatable();
-                    }
-
-                    @Override
-                    public OptionalLong length() {
-                        return OptionalLong.of(CONTENT.length);
-                    }
-
-                    @Override
-                    public void close() {
-                        body.close();
-                    }
-                })
                 .build();
         channel.execute(endpoint, request);
         RecordedRequest recordedRequest = server.takeRequest();

--- a/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc4-client/src/test/java/com/palantir/dialogue/hc4/ApacheHttpClientChannelsTest.java
@@ -29,12 +29,16 @@ import com.palantir.dialogue.AbstractChannelTest;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestConfigurations;
 import com.palantir.dialogue.TestEndpoint;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.UnknownHostException;
 import java.util.Map;
+import java.util.OptionalLong;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
@@ -104,6 +108,47 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
                 .from(request)
                 .body(body)
                 .putHeaderParams(HttpHeaders.CONTENT_LENGTH, Integer.toString(CONTENT.length))
+                .build();
+        channel.execute(endpoint, request);
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod()).isEqualTo("POST");
+        assertThat(recordedRequest.getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo(Integer.toString(CONTENT.length));
+        assertThat(recordedRequest.getHeader(HttpHeaders.TRANSFER_ENCODING)).isNull();
+    }
+
+    @Test
+    @SuppressWarnings("FutureReturnValueIgnored")
+    public void supportsContentLengthOnBody() throws InterruptedException {
+        endpoint.method = HttpMethod.POST;
+        request = Request.builder()
+                .from(request)
+                .body(new RequestBody() {
+
+                    @Override
+                    public void writeTo(OutputStream output) throws IOException {
+                        body.writeTo(output);
+                    }
+
+                    @Override
+                    public String contentType() {
+                        return body.contentType();
+                    }
+
+                    @Override
+                    public boolean repeatable() {
+                        return body.repeatable();
+                    }
+
+                    @Override
+                    public OptionalLong length() {
+                        return OptionalLong.of(CONTENT.length);
+                    }
+
+                    @Override
+                    public void close() {
+                        body.close();
+                    }
+                })
                 .build();
         channel.execute(endpoint, request);
         RecordedRequest recordedRequest = server.takeRequest();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueNodeSelectionStrategy.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueNodeSelectionStrategy.java
@@ -55,7 +55,7 @@ enum DialogueNodeSelectionStrategy {
             return BALANCED;
         }
 
-        log.info("Received unknown selection strategy", SafeArg.of("strategy", value));
+        log.info("Received unknown selection strategy {}", SafeArg.of("strategy", value));
         return UNKNOWN;
     }
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
@@ -19,7 +19,6 @@ package com.palantir.dialogue;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.OptionalLong;
 
 public interface RequestBody extends Closeable {
 
@@ -31,13 +30,6 @@ public interface RequestBody extends Closeable {
 
     /** Returns <pre>true</pre> if {@link #writeTo(OutputStream)} may be invoked multiple times. */
     boolean repeatable();
-
-    /** Returns the {@code Content-Length} of the request body, if known. Note that there is no guarantee that
-     * this will result in a {@code Content-Length} request rather than {@code Transfer-Encoding: chunked}.
-     */
-    default OptionalLong length() {
-        return OptionalLong.empty();
-    }
 
     /**
      * Closes this {@link RequestBody} and releases all resources. Calling {@link #close()} should never throw,

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RequestBody.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.OptionalLong;
 
 public interface RequestBody extends Closeable {
 
@@ -30,6 +31,13 @@ public interface RequestBody extends Closeable {
 
     /** Returns <pre>true</pre> if {@link #writeTo(OutputStream)} may be invoked multiple times. */
     boolean repeatable();
+
+    /** Returns the {@code Content-Length} of the request body, if known. Note that there is no guarantee that
+     * this will result in a {@code Content-Length} request rather than {@code Transfer-Encoding: chunked}.
+     */
+    default OptionalLong length() {
+        return OptionalLong.empty();
+    }
 
     /**
      * Closes this {@link RequestBody} and releases all resources. Calling {@link #close()} should never throw,


### PR DESCRIPTION
==COMMIT_MSG==
Dialogue clients do not fail when a Content-Lenght header is provided
==COMMIT_MSG==
