### PR TITLE
[test-only] Fix pin until error reshuffling in simulations

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -150,12 +150,19 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
                                     channels,
                                     pinuntilerrorMetrics,
                                     random,
+                                    tick,
                                     channelName))
                             .build();
                 }
                 return channelBuilder
                         .channel(PinUntilErrorNodeSelectionStrategyChannel.of(
-                                Optional.empty(), updatedStrategy, channels, pinuntilerrorMetrics, random, channelName))
+                                Optional.empty(),
+                                updatedStrategy,
+                                channels,
+                                pinuntilerrorMetrics,
+                                random,
+                                tick,
+                                channelName))
                         .build();
             case BALANCED:
                 // When people ask for 'ROUND_ROBIN', they usually just want something to load balance better.

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
@@ -89,6 +89,7 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
             List<LimitedChannel> channels,
             DialoguePinuntilerrorMetrics metrics,
             Random random,
+            Ticker ticker,
             String channelName) {
         // We preserve the 'stableIndex' so that calls can be attributed to one host even across reshuffles
         List<PinChannel> pinChannels = IntStream.range(0, channels.size())
@@ -111,7 +112,7 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
                 .orElse(0);
 
         if (strategy == DialogueNodeSelectionStrategy.PIN_UNTIL_ERROR) {
-            NodeList shuffling = ReshufflingNodeList.of(initialShuffle, random, System::nanoTime, metrics, channelName);
+            NodeList shuffling = ReshufflingNodeList.of(initialShuffle, random, ticker, metrics, channelName);
             return new PinUntilErrorNodeSelectionStrategyChannel(shuffling, initialPin, metrics, channelName);
         } else if (strategy == DialogueNodeSelectionStrategy.PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE) {
             NodeList constant = new ConstantNodeList(initialShuffle);

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
@@ -201,6 +201,7 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
                 ImmutableList.of(channel1, channel2),
                 metrics,
                 pseudo,
+                Ticker.systemTicker(),
                 channelName);
     }
 

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -25,7 +25,7 @@
 one_endpoint_dies_on_each_server[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=64.4%	client_mean=PT8.3962496S   	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1609, 500=891}
  one_endpoint_dies_on_each_server[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=65.4%	client_mean=PT4.168064S    	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1634, 500=866}
            one_endpoint_dies_on_each_server[UNLIMITED_ROUND_ROBIN].txt:	success=64.7%	client_mean=PT0.6S         	server_cpu=PT25M          	client_received=2500/2500	server_resps=2500	codes={200=1618, 500=882}
-       simplest_possible_case[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.799924242S 	server_cpu=PT2H55M59S     	client_received=13200/13200	server_resps=13200	codes={200=13200}
+       simplest_possible_case[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.837469696S 	server_cpu=PT3H4M14.6S    	client_received=13200/13200	server_resps=13200	codes={200=13200}
            simplest_possible_case[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.785727272S 	server_cpu=PT2H52M51.6S   	client_received=13200/13200	server_resps=13200	codes={200=13200}
                      simplest_possible_case[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.785727272S 	server_cpu=PT2H52M51.6S   	client_received=13200/13200	server_resps=13200	codes={200=13200}
         slow_503s_then_revert[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.137373406S 	server_cpu=PT6M39.633333312S	client_received=3000/3000	server_resps=3077	codes={200=3000}

--- a/simulation/src/test/resources/simplest_possible_case[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
+++ b/simulation/src/test/resources/simplest_possible_case[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78ffed6724c8cd8309972a0ce67cf189e14dc9f2f5deddeed49f1e189378c2f3
-size 318303
+oid sha256:28ff6257585d899f5a8c8b87aa7b5dc3865b0587cb1192ea3f23c947a901359e
+size 240730

--- a/simulation/src/test/resources/txt/simplest_possible_case[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
+++ b/simulation/src/test/resources/txt/simplest_possible_case[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.799924242S 	server_cpu=PT2H55M59S     	client_received=13200/13200	server_resps=13200	codes={200=13200}
+success=100.0%	client_mean=PT0.837469696S 	server_cpu=PT3H4M14.6S    	client_received=13200/13200	server_resps=13200	codes={200=13200}


### PR DESCRIPTION
## Before this PR

I'm tinkering with some longer simulations (like ~30 mins) and expected to see PIN_UNTIL_ERROR reshuffling, but didn't. This is because we plumbed System::nanoTime directly into the channel, so my simulation clock didn't get a chance.

## After this PR
==COMMIT_MSG==
PIN_UNTIL_ERROR strategy's reshuffling behaviour now appears in simulations
==COMMIT_MSG==
![image](https://user-images.githubusercontent.com/3473798/81980901-5f00cb80-9627-11ea-9aca-0e794ed7f3bd.png)



## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
