### PR TITLE
Eliminate an Optional#map from a PinUntilErrorChannel hot codepath

### DIFF
--- a/changelog/@unreleased/pr-751.v2.yml
+++ b/changelog/@unreleased/pr-751.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: PinUntilError no longer allocates a lambda per request
+  links:
+  - https://github.com/palantir/dialogue/pull/751


### PR DESCRIPTION
## Before this PR

While trying to make the simulations go faster (so I can simulate hours of requests instead of minutes), I noticed this method was burning a little bit of our CPU time.

## After this PR
==COMMIT_MSG==
PinUntilError no longer allocates a lambda per request
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
