### PR TITLE
Eliminate stream, findFirst from BalancedNodeSelectionStrategyChannel

### DIFF
--- a/changelog/@unreleased/pr-752.v2.yml
+++ b/changelog/@unreleased/pr-752.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: BalancedNodeSelectionStrategyChannel is slightly more performant as
+    it uses plain loops instead of Stream and findFirst
+  links:
+  - https://github.com/palantir/dialogue/pull/752

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -92,10 +92,9 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
 
         // TODO(dfox): P2C optimization when we have high number of nodes to save CPU?
         // http://www.eecs.harvard.edu/~michaelm/NEWWORK/postscripts/twosurvey.pdf
-        SortableChannel[] sortedList = sortByScore(preShuffled);
+        SortableChannel[] sortedChannels = sortByScore(preShuffled);
 
-        for (int i = 0; i < sortedList.length; i++) {
-            SortableChannel channel = sortedList[i];
+        for (SortableChannel channel : sortedChannels) {
             Optional<ListenableFuture<Response>> maybe = channel.delegate.maybeExecute(endpoint, request);
             if (maybe.isPresent()) {
                 return maybe;


### PR DESCRIPTION
## Before this PR

Again, I'm trying to make SimulationTests faster so I can reasonably simulate larger volumes of fast requests over longer amounts of time. Turns out, this method showed up in my flamegraphs.

## After this PR
==COMMIT_MSG==
BalancedNodeSelectionStrategyChannel is slightly more performant as it uses plain loops instead of java Streams (which necessitate the use of lambdas)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
