### PR TITLE
[test-only] speed up simulations

### DIFF
--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/TestResponse.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/TestResponse.java
@@ -19,11 +19,11 @@ package com.palantir.dialogue;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.HttpHeaders;
 
@@ -31,7 +31,7 @@ public final class TestResponse implements Response {
 
     private final CloseRecordingInputStream inputStream;
 
-    private AtomicBoolean closeCalled = new AtomicBoolean(false);
+    private boolean closeCalled = false;
     private int code = 0;
     private ListMultimap<String, String> headers = ImmutableListMultimap.of();
 
@@ -72,7 +72,7 @@ public final class TestResponse implements Response {
     public void close() {
         checkNotClosed();
         try {
-            closeCalled.compareAndSet(false, true);
+            closeCalled = true;
             inputStream.close();
         } catch (IOException e) {
             throw new SafeRuntimeException("Failed to close", e);
@@ -80,13 +80,11 @@ public final class TestResponse implements Response {
     }
 
     public boolean isClosed() {
-        return closeCalled.get();
+        return closeCalled;
     }
 
     private void checkNotClosed() {
-        if (closeCalled.get()) {
-            throw new SafeRuntimeException("Please don't close twice");
-        }
+        Preconditions.checkState(!isClosed(), "Please don't close twice");
     }
 
     @CheckReturnValue

--- a/simulation/build.gradle
+++ b/simulation/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'com.palantir.tracing:tracing'
 
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-core'

--- a/simulation/src/main/java/com/palantir/dialogue/core/MetricNames.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/MetricNames.java
@@ -23,20 +23,27 @@ import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 final class MetricNames {
+
+    private static final MetricName RESPONSE_CLOSE =
+            MetricName.builder().safeName("responseClose").build();
+    private static final MetricName GLOBAL_RESPONSES =
+            MetricName.builder().safeName("globalResponses").build();
+    private static final MetricName GLOBAL_SERVER_TIME =
+            MetricName.builder().safeName("globalServerTime").build();
+
     /** Counter incremented every time a {@code Response} is closed. */
     static Counter responseClose(TaggedMetricRegistry reg) {
-        return reg.counter(MetricName.builder().safeName("responseClose").build());
+        return reg.counter(RESPONSE_CLOSE);
     }
 
     /** Counter for how many responses are issued across all servers. */
     static Counter globalResponses(TaggedMetricRegistry registry) {
-        return registry.counter(MetricName.builder().safeName("globalResponses").build());
+        return registry.counter(GLOBAL_RESPONSES);
     }
 
     /** Counter for how long servers spend processing requests. */
     static Counter globalServerTimeNanos(TaggedMetricRegistry registry) {
-        return registry.counter(
-                MetricName.builder().safeName("globalServerTime").build());
+        return registry.counter(GLOBAL_SERVER_TIME);
     }
 
     static Counter activeRequests(TaggedMetricRegistry reg, String serverName) {

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationMetricsReporter.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationMetricsReporter.java
@@ -135,7 +135,7 @@ final class SimulationMetricsReporter {
                     SafeArg.of("column", column),
                     SafeArg.of("xaxis", xAxis.length),
                     SafeArg.of("length", series.length));
-            chart.addSeries(asString(column), xAxis, series).setToolTips(nullToolTips);
+            chart.addSeries(asString(column) + ".count", xAxis, series).setToolTips(nullToolTips);
         }
 
         if (!simulation.events().getEvents().isEmpty()) {

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationMetricsReporter.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationMetricsReporter.java
@@ -27,6 +27,7 @@ import com.palantir.tritium.metrics.registry.MetricName;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -47,14 +48,14 @@ import org.slf4j.LoggerFactory;
  */
 final class SimulationMetricsReporter {
     private static final Logger log = LoggerFactory.getLogger(SimulationMetricsReporter.class);
+    private static final MetricName X_AXIS =
+            MetricName.builder().safeName("time_sec").build();
 
     private final Simulation simulation;
 
     // each of these is a named column
-    private final LoadingCache<String, List<Double>> measurements =
+    private final LoadingCache<MetricName, List<Double>> measurements =
             Caffeine.newBuilder().build(name -> new ArrayList<>(Collections.nCopies(numMeasurements(), 0d)));
-
-    private static final String X_AXIS = "time_sec";
     private Predicate<MetricName> prefilter = foo -> true;
 
     SimulationMetricsReporter(Simulation simulation) {
@@ -72,10 +73,8 @@ final class SimulationMetricsReporter {
                 return;
             }
 
-            String name = asString(metricName);
-
             if (metric instanceof Counting) { // includes meters too!
-                measurements.get(name + ".count").add((double) ((Counting) metric).getCount());
+                measurements.get(metricName).add((double) ((Counting) metric).getCount());
                 return;
             }
 
@@ -86,7 +85,7 @@ final class SimulationMetricsReporter {
                         "Gauges must produce numbers",
                         SafeArg.of("metric", metricName),
                         SafeArg.of("value", value));
-                measurements.get(name + ".count").add(((Number) value).doubleValue());
+                measurements.get(metricName).add(((Number) value).doubleValue());
                 return;
             }
 
@@ -99,8 +98,11 @@ final class SimulationMetricsReporter {
     }
 
     public XYChart chart(Pattern metricNameRegex) {
-        XYChart chart =
-                new XYChartBuilder().width(800).height(600).xAxisTitle(X_AXIS).build();
+        XYChart chart = new XYChartBuilder()
+                .width(800)
+                .height(600)
+                .xAxisTitle(X_AXIS.safeName())
+                .build();
 
         // if we render too many samples, it just ends up looking like a wall of colour
         int granularity = chart.getWidth() / 3;
@@ -114,17 +116,17 @@ final class SimulationMetricsReporter {
         chart.getStyler().setToolTipsEnabled(true);
         chart.getStyler().setToolTipsAlwaysVisible(true);
 
-        Map<String, List<Double>> map = measurements.asMap();
+        Map<MetricName, List<Double>> map = measurements.asMap();
         double[] xAxis = reduceGranularity(
                 granularity, map.get(X_AXIS).stream().mapToDouble(d -> d).toArray());
-        List<String> columns = map.keySet().stream()
-                .filter(name -> !name.equals(X_AXIS))
-                .filter(metricNameRegex.asPredicate())
-                .sorted()
+        List<MetricName> columns = map.keySet().stream()
+                .filter(metric -> !metric.equals(X_AXIS))
+                .filter(metric -> metricNameRegex.asPredicate().test(asString(metric)))
+                .sorted(Comparator.comparing(metric -> asString(metric)))
                 .collect(Collectors.toList());
         String[] nullToolTips = Collections.nCopies(xAxis.length, null).toArray(new String[] {});
 
-        for (String column : columns) {
+        for (MetricName column : columns) {
             double[] series = reduceGranularity(
                     granularity, map.get(column).stream().mapToDouble(d -> d).toArray());
             Preconditions.checkState(
@@ -133,7 +135,7 @@ final class SimulationMetricsReporter {
                     SafeArg.of("column", column),
                     SafeArg.of("xaxis", xAxis.length),
                     SafeArg.of("length", series.length));
-            chart.addSeries(column, xAxis, series).setToolTips(nullToolTips);
+            chart.addSeries(asString(column), xAxis, series).setToolTips(nullToolTips);
         }
 
         if (!simulation.events().getEvents().isEmpty()) {

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -97,12 +97,16 @@ final class SimulationServer implements Channel {
                     new FutureCallback<Response>() {
                         @Override
                         public void onSuccess(Response result) {
-                            log.debug(
-                                    "time={} server={} status={} id={}",
-                                    Duration.ofNanos(simulation.clock().read()),
-                                    serverName,
-                                    result.code(),
-                                    request != null ? request.headerParams().get(Benchmark.REQUEST_ID_HEADER) : null);
+                            if (log.isDebugEnabled()) {
+                                log.debug(
+                                        "time={} server={} status={} id={}",
+                                        Duration.ofNanos(simulation.clock().read()),
+                                        serverName,
+                                        result.code(),
+                                        request != null
+                                                ? request.headerParams().get(Benchmark.REQUEST_ID_HEADER)
+                                                : null);
+                            }
                         }
 
                         @Override

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationUtils.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationUtils.java
@@ -16,41 +16,12 @@
 
 package com.palantir.dialogue.core;
 
-import com.google.common.collect.ListMultimap;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
-import com.palantir.dialogue.Response;
 import com.palantir.dialogue.UrlBuilder;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.io.InputStream;
 import java.util.Map;
 
 final class SimulationUtils {
-
-    public static Response wrapWithCloseInstrumentation(Response delegate, TaggedMetricRegistry registry) {
-        return new Response() {
-            @Override
-            public InputStream body() {
-                return delegate.body();
-            }
-
-            @Override
-            public int code() {
-                return delegate.code();
-            }
-
-            @Override
-            public ListMultimap<String, String> headers() {
-                return delegate.headers();
-            }
-
-            @Override
-            public void close() {
-                MetricNames.responseClose(registry).inc();
-                delegate.close();
-            }
-        };
-    }
 
     static final String CHANNEL_NAME = "test-channel";
     static final String SERVICE_NAME = "svc";

--- a/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
@@ -24,6 +24,7 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestResponse;
+import com.palantir.tracing.Tracer;
 import java.io.IOException;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -548,7 +549,7 @@ final class SimulationTest {
                     StandardOpenOption.CREATE,
                     StandardOpenOption.TRUNCATE_EXISTING);
 
-            XYChart activeRequests = simulation.metricsReporter().chart(Pattern.compile("activeRequests\\.count$"));
+            XYChart activeRequests = simulation.metricsReporter().chart(Pattern.compile("activeRequests$"));
             activeRequests.setTitle(String.format(
                     "%s success=%s%% client_mean=%.1f ms server_cpu=%s",
                     st, result.successPercentage(), clientMeanMillis, serverCpu));
@@ -562,7 +563,7 @@ final class SimulationTest {
             }
 
             SimulationMetricsReporter.png(
-                    pngPath, activeRequests, simulation.metricsReporter().chart(Pattern.compile("request\\.count$"))
+                    pngPath, activeRequests, simulation.metricsReporter().chart(Pattern.compile("request$"))
                     // simulation.metrics().chart(Pattern.compile("(responseClose|globalResponses)"))
                     );
             log.info("Generated {} ({} ms)", pngPath, sw.elapsed(TimeUnit.MILLISECONDS));
@@ -581,6 +582,8 @@ final class SimulationTest {
                 .metricsReporter()
                 .onlyRecordMetricsFor(m ->
                         m.safeName().endsWith("activeRequests") || m.safeName().endsWith("request"));
+
+        Tracer.setSampler(() -> false);
     }
 
     @AfterAll

--- a/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
@@ -38,6 +38,7 @@ public enum Strategy {
     CONCURRENCY_LIMITER_PIN_UNTIL_ERROR(Strategy::pinUntilError),
     UNLIMITED_ROUND_ROBIN(Strategy::unlimitedRoundRobin);
 
+    private static final ClientConfiguration STUB_CONFIG = stubConfig();
     private final BiFunction<Simulation, Supplier<Map<String, SimulationServer>>, Channel> getChannel;
 
     Strategy(BiFunction<Simulation, Supplier<Map<String, SimulationServer>>, Channel> getChannel) {
@@ -78,7 +79,7 @@ public enum Strategy {
                 .clientConfiguration(applyConfig
                         .apply(ClientConfiguration.builder()
                                 .uris(ImmutableList.copyOf(channelSupplier.get().keySet()))
-                                .from(stubConfig())
+                                .from(STUB_CONFIG)
                                 .taggedMetricRegistry(sim.taggedMetrics()))
                         .build())
                 .channelFactory(uri -> channelSupplier.get().get(uri))


### PR DESCRIPTION
## Before this PR

Surprise surprise, a big chunk of slowness of our simulations was due to metric reporting and the actual benchmark harness. Reducing the amount of thrown exceptions and actually the `asString` method gives us a little speedup.

Turning off trace sampling is a decent speedup too.

## After this PR
==COMMIT_MSG==
SimulationTest is a bit faster (now completes in ~5 seconds)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
