### PR TITLE
NSSChannel no longer uses Optional#map with a method reference

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -83,7 +83,13 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
-        return delegate.maybeExecute(endpoint, request).map(this::wrapWithCallback);
+        Optional<ListenableFuture<Response>> maybe = delegate.maybeExecute(endpoint, request);
+        if (!maybe.isPresent()) {
+            return Optional.empty();
+        }
+
+        ListenableFuture<Response> wrappedFuture = wrapWithCallback(maybe.get());
+        return Optional.of(wrappedFuture);
     }
 
     private ListenableFuture<Response> wrapWithCallback(ListenableFuture<Response> response) {


### PR DESCRIPTION
## Before this PR

This Optional.map accounted for 2% of a benchmark according to YourKit.

## After this PR
==COMMIT_MSG==
NSSChannel no longer uses Optional#map with a method reference
==COMMIT_MSG==

I kinda want an error-prone annotation like `@PerformanceSensitive` that would enable all kinds of silly lints that we wouldn't normally care about for these #execute methods.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
