### PR TITLE
Blocking clients wrap checked failures with DialogueException

### DIFF
--- a/changelog/@unreleased/pr-759.v2.yml
+++ b/changelog/@unreleased/pr-759.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Blocking clients wrap checked failures with UnknownRemoteException
+  description: Blocking clients wrap checked failures with a custom internal `DialogueException`.
   links:
   - https://github.com/palantir/dialogue/pull/759

--- a/changelog/@unreleased/pr-759.v2.yml
+++ b/changelog/@unreleased/pr-759.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Blocking clients wrap checked failures with UnknownRemoteException
+  links:
+  - https://github.com/palantir/dialogue/pull/759

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.dialogue.serde;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -31,15 +30,12 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
-import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
@@ -164,25 +160,5 @@ enum DefaultClients implements Clients {
                 .from(original)
                 .putHeaderParams(HttpHeaders.ACCEPT, acceptValue)
                 .build();
-    }
-
-    /** Internal marker type for failure legibility, this type is not meant to be handled directly. */
-    private static final class DialogueException extends RuntimeException implements SafeLoggable {
-
-        private static final String MESSAGE = "Dialogue transport failure";
-
-        private DialogueException(Throwable cause) {
-            super(MESSAGE, cause);
-        }
-
-        @Override
-        public String getLogMessage() {
-            return MESSAGE;
-        }
-
-        @Override
-        public List<Arg<?>> getArgs() {
-            return ImmutableList.of();
-        }
     }
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -17,12 +17,10 @@
 package com.palantir.conjure.java.dialogue.serde;
 
 import com.google.common.net.HttpHeaders;
-import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.dialogue.Channel;
@@ -69,7 +67,6 @@ enum DefaultClients implements Clients {
     }
 
     @Override
-    @SuppressWarnings("ThrowError") // match behavior of Futures.getUnchecked(Future)
     public <T> T block(ListenableFuture<T> future) {
         try {
             return future.get();
@@ -81,7 +78,6 @@ enum DefaultClients implements Clients {
             throw new SafeRuntimeException("Interrupted waiting for future", e);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
-            String message = cause.getMessage();
 
             // TODO(jellis): can consider propagating other relevant exceptions (eg: HttpConnectTimeoutException)
             // see HttpClientImpl#send(HttpRequest req, BodyHandler<T> responseHandler)
@@ -102,9 +98,12 @@ enum DefaultClients implements Clients {
 
             // This matches the behavior in Futures.getUnchecked(Future)
             if (cause instanceof Error) {
-                throw new ExecutionError(cause.getMessage(), (Error) cause);
+                cause.addSuppressed(new SafeRuntimeException("Rethrown by dialogue"));
+                throw (Error) cause;
             }
-            throw new UncheckedExecutionException(message, cause);
+            UnknownRemoteException remoteException = new UnknownRemoteException(-1, "<request failed>");
+            remoteException.initCause(cause);
+            throw remoteException;
         }
     }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.dialogue.serde;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -30,12 +31,15 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
@@ -101,9 +105,7 @@ enum DefaultClients implements Clients {
                 cause.addSuppressed(new SafeRuntimeException("Rethrown by dialogue"));
                 throw (Error) cause;
             }
-            UnknownRemoteException remoteException = new UnknownRemoteException(-1, "<request failed>");
-            remoteException.initCause(cause);
-            throw remoteException;
+            throw new DialogueException(cause);
         }
     }
 
@@ -162,5 +164,25 @@ enum DefaultClients implements Clients {
                 .from(original)
                 .putHeaderParams(HttpHeaders.ACCEPT, acceptValue)
                 .build();
+    }
+
+    /** Internal marker type for failure legibility, this type is not meant to be handled directly. */
+    private static final class DialogueException extends RuntimeException implements SafeLoggable {
+
+        private static final String MESSAGE = "Dialogue transport failure";
+
+        private DialogueException(Throwable cause) {
+            super(MESSAGE, cause);
+        }
+
+        @Override
+        public String getLogMessage() {
+            return MESSAGE;
+        }
+
+        @Override
+        public List<Arg<?>> getArgs() {
+            return ImmutableList.of();
+        }
     }
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.List;
+
+/** Internal marker type for failure legibility, this type is not meant to be handled directly. */
+final class DialogueException extends RuntimeException implements SafeLoggable {
+    private static final String MESSAGE = "Dialogue transport failure";
+
+    DialogueException(Throwable cause) {
+        super(MESSAGE, cause);
+    }
+
+    @Override
+    public String getLogMessage() {
+        return MESSAGE;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return ImmutableList.of();
+    }
+}

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
@@ -21,11 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
@@ -89,8 +87,8 @@ public class DefaultClientsBlockingTest {
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(exception);
 
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
-                .isInstanceOf(UncheckedExecutionException.class)
-                .hasCauseInstanceOf(Exception.class);
+                .isInstanceOf(UnknownRemoteException.class)
+                .hasCause(exception);
     }
 
     @Test
@@ -98,9 +96,7 @@ public class DefaultClientsBlockingTest {
         Error error = new Error();
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(error);
 
-        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
-                .isInstanceOf(ExecutionError.class)
-                .hasCauseInstanceOf(Error.class);
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture)).isSameAs(error);
     }
 
     @Test

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
@@ -87,7 +87,7 @@ public class DefaultClientsBlockingTest {
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(exception);
 
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
-                .isInstanceOf(UnknownRemoteException.class)
+                .satisfies(value -> value.getClass().getSimpleName().contains("DialogueException"))
                 .hasCause(exception);
     }
 

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractSampleServiceClientTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractSampleServiceClientTest.java
@@ -195,7 +195,8 @@ public abstract class AbstractSampleServiceClientTest {
         server.shutdown();
         assertThatThrownBy(() -> blockingClient.objectToObject(HEADER, PATH, QUERY, BODY))
                 .isInstanceOf(RuntimeException.class)
-                .hasCauseInstanceOf(ConnectException.class)
+                .getCause()
+                .isInstanceOf(ConnectException.class)
                 .hasMessageMatching(".*((Connection refused)|(Failed to connect)).*");
     }
 


### PR DESCRIPTION
Throwing an UncheckedExecutionException from `fooService.ping()`
isn't terribly helpful and doesn't make the type of issue
immediately obvious.

## After this PR
==COMMIT_MSG==
Blocking clients wrap checked failures with UnknownRemoteException
==COMMIT_MSG==