### PR TITLE
QueuedChannel logging uses correct slf4j substitutions

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -131,7 +131,10 @@ final class QueuedChannel implements Channel {
         int newSize = incrementQueueSize();
 
         if (log.isDebugEnabled()) {
-            log.debug("Request queued {}", SafeArg.of("queueSize", newSize), SafeArg.of("channelName", channelName));
+            log.debug(
+                    "Request queued {} on channel {}",
+                    SafeArg.of("queueSize", newSize),
+                    SafeArg.of("channelName", channelName));
         }
 
         schedule();
@@ -154,7 +157,7 @@ final class QueuedChannel implements Channel {
 
         if (log.isDebugEnabled()) {
             log.debug(
-                    "Scheduled {} requests",
+                    "Scheduled {} requests on channel {}",
                     SafeArg.of("numScheduled", numScheduled),
                     SafeArg.of("channelName", channelName));
         }


### PR DESCRIPTION
==COMMIT_MSG==
QueuedChannel logging uses correct slf4j substitutions
==COMMIT_MSG==