### PR TITLE
Tracing around dialogue encodings

### DIFF
--- a/changelog/@unreleased/pr-781.v2.yml
+++ b/changelog/@unreleased/pr-781.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Tracing around dialogue encodings describing serde and I/O time per
+    request, matching data produced by conjure-undertow on the server
+  links:
+  - https://github.com/palantir/dialogue/pull/781

--- a/dialogue-serde/build.gradle
+++ b/dialogue-serde/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api 'com.palantir.tokens:auth-tokens'
     implementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
     implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'com.palantir.tracing:tracing'
     implementation 'org.slf4j:slf4j-api'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-core'

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -85,7 +85,8 @@ final class ConjureBodySerDe implements BodySerDe {
     private static List<WeightedEncoding> decorateEncodings(List<WeightedEncoding> input) {
         return input.stream()
                 .map(weightedEncoding -> WeightedEncoding.of(
-                        new LazilyInitializedEncoding(weightedEncoding.encoding()), weightedEncoding.weight()))
+                        new LazilyInitializedEncoding(new TracedEncoding(weightedEncoding.encoding())),
+                        weightedEncoding.weight()))
                 .collect(ImmutableList.toImmutableList());
     }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/LazilyInitializedEncoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/LazilyInitializedEncoding.java
@@ -61,7 +61,7 @@ final class LazilyInitializedEncoding implements Encoding {
 
     @Override
     public String toString() {
-        return "LazilyInitializedEncoding{delegate=" + delegate + '}';
+        return "LazilyInitializedEncoding{" + delegate + '}';
     }
 
     private static final class LazilyInitializedSerializer<T> implements Serializer<T> {
@@ -76,6 +76,11 @@ final class LazilyInitializedEncoding implements Encoding {
         public void serialize(T value, OutputStream output) {
             delegate.get().serialize(value, output);
         }
+
+        @Override
+        public String toString() {
+            return "LazilyInitializedSerializer{" + delegate + '}';
+        }
     }
 
     private static final class LazilyInitializedDeserializer<T> implements Deserializer<T> {
@@ -89,6 +94,11 @@ final class LazilyInitializedEncoding implements Encoding {
         @Override
         public T deserialize(InputStream input) {
             return delegate.get().deserialize(input);
+        }
+
+        @Override
+        public String toString() {
+            return "LazilyInitializedDeserializer{" + delegate + '}';
         }
     }
 }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/TracedEncoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/TracedEncoding.java
@@ -1,0 +1,112 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.tracing.CloseableTracer;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+
+/**
+ * Wrapper around an {@link Encoding} which adds tracing spans around serialization and deserialization operations
+ * including I/O.
+ */
+final class TracedEncoding implements Encoding {
+
+    private final Encoding delegate;
+
+    TracedEncoding(Encoding delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "Encoding is required");
+    }
+
+    @Override
+    public <T> Serializer<T> serializer(TypeMarker<T> type) {
+        String operation = "Dialogue: serialize " + toString(type) + " to " + getContentType();
+        return new TracedSerializer<>(delegate.serializer(type), operation);
+    }
+
+    @Override
+    public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
+        String operation = "Dialogue: deserialize " + toString(type) + " from " + getContentType();
+        return new TracedDeserializer<>(delegate.deserializer(type), operation);
+    }
+
+    @Override
+    public String getContentType() {
+        return delegate.getContentType();
+    }
+
+    @Override
+    public boolean supportsContentType(String contentType) {
+        return delegate.supportsContentType(contentType);
+    }
+
+    @Override
+    public String toString() {
+        return "TracedEncoding{delegate=" + delegate + '}';
+    }
+
+    /**
+     * Builds a human readable type string. Class types use the classes simple name, however complex types do not have
+     * this optimization because it is more complex than it's worth for now.
+     */
+    static String toString(TypeMarker<?> typeMarker) {
+        Type type = typeMarker.getType();
+        if (type instanceof Class) {
+            return ((Class<?>) type).getSimpleName();
+        }
+        return type.toString();
+    }
+
+    private static final class TracedSerializer<T> implements Serializer<T> {
+
+        private final Serializer<T> delegate;
+        private final String operation;
+
+        TracedSerializer(Serializer<T> delegate, String operation) {
+            this.delegate = delegate;
+            this.operation = operation;
+        }
+
+        @Override
+        public void serialize(T value, OutputStream output) {
+            try (CloseableTracer ignored = CloseableTracer.startSpan(operation)) {
+                delegate.serialize(value, output);
+            }
+        }
+    }
+
+    private static final class TracedDeserializer<T> implements Deserializer<T> {
+
+        private final Deserializer<T> delegate;
+        private final String operation;
+
+        TracedDeserializer(Deserializer<T> delegate, String operation) {
+            this.delegate = delegate;
+            this.operation = operation;
+        }
+
+        @Override
+        public T deserialize(InputStream input) {
+            try (CloseableTracer ignored = CloseableTracer.startSpan(operation)) {
+                return delegate.deserialize(input);
+            }
+        }
+    }
+}

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/TracedEncoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/TracedEncoding.java
@@ -59,7 +59,7 @@ final class TracedEncoding implements Encoding {
 
     @Override
     public String toString() {
-        return "TracedEncoding{delegate=" + delegate + '}';
+        return "TracedEncoding{" + delegate + '}';
     }
 
     /**
@@ -90,6 +90,11 @@ final class TracedEncoding implements Encoding {
                 delegate.serialize(value, output);
             }
         }
+
+        @Override
+        public String toString() {
+            return "TracedSerializer{delegate=" + delegate + ", operation='" + operation + "'}";
+        }
     }
 
     private static final class TracedDeserializer<T> implements Deserializer<T> {
@@ -107,6 +112,11 @@ final class TracedEncoding implements Encoding {
             try (CloseableTracer ignored = CloseableTracer.startSpan(operation)) {
                 return delegate.deserialize(input);
             }
+        }
+
+        @Override
+        public String toString() {
+            return "TracedDeserializer{delegate=" + delegate + ", operation='" + operation + "'}";
         }
     }
 }

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/TracedEncodingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/TracedEncodingTest.java
@@ -28,10 +28,17 @@ import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
 import java.io.ByteArrayInputStream;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class TracedEncodingTest {
+
+    @BeforeEach
+    void before() {
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+        Tracer.getAndClearTrace();
+    }
 
     @Test
     void testTypeString_string() {
@@ -48,8 +55,6 @@ class TracedEncodingTest {
 
     @Test
     void testSerializerOperationName() {
-        Tracer.setSampler(AlwaysSampler.INSTANCE);
-        Tracer.getAndClearTrace();
         Encoding.Serializer<String> serializer =
                 new TracedEncoding(new StubEncoding()).serializer(new TypeMarker<String>() {});
         SpanObserver mockObserver = mock(SpanObserver.class);
@@ -67,8 +72,6 @@ class TracedEncodingTest {
 
     @Test
     void testDeserializerOperationName() {
-        Tracer.setSampler(AlwaysSampler.INSTANCE);
-        Tracer.getAndClearTrace();
         Encoding.Deserializer<String> deserializer =
                 new TracedEncoding(new StubEncoding()).deserializer(new TypeMarker<String>() {});
         SpanObserver mockObserver = mock(SpanObserver.class);

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/TracedEncodingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/TracedEncodingTest.java
@@ -1,0 +1,109 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.dialogue.serde;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.io.ByteStreams;
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.tracing.AlwaysSampler;
+import com.palantir.tracing.Tracer;
+import com.palantir.tracing.api.Span;
+import com.palantir.tracing.api.SpanObserver;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class TracedEncodingTest {
+
+    @Test
+    void testTypeString_string() {
+        // non-generic types use the simple name
+        assertThat(TracedEncoding.toString(new TypeMarker<String>() {})).isEqualTo("String");
+    }
+
+    @Test
+    void testTypeString_stringList() {
+        // It's more complicated to generate 'List<String>' from Type, that can be done later if necessary
+        assertThat(TracedEncoding.toString(new TypeMarker<List<String>>() {}))
+                .isEqualTo("java.util.List<java.lang.String>");
+    }
+
+    @Test
+    void testSerializerOperationName() {
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+        Tracer.getAndClearTrace();
+        Encoding.Serializer<String> serializer =
+                new TracedEncoding(new StubEncoding()).serializer(new TypeMarker<String>() {});
+        SpanObserver mockObserver = mock(SpanObserver.class);
+        Tracer.subscribe("test", mockObserver);
+        try {
+            serializer.serialize("value", ByteStreams.nullOutputStream());
+        } finally {
+            Tracer.unsubscribe("test");
+        }
+        ArgumentCaptor<Span> captor = ArgumentCaptor.forClass(Span.class);
+        verify(mockObserver).consume(captor.capture());
+        Span span = captor.getValue();
+        assertThat(span.getOperation()).isEqualTo("Dialogue: serialize String to application/stub");
+    }
+
+    @Test
+    void testDeserializerOperationName() {
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+        Tracer.getAndClearTrace();
+        Encoding.Deserializer<String> deserializer =
+                new TracedEncoding(new StubEncoding()).deserializer(new TypeMarker<String>() {});
+        SpanObserver mockObserver = mock(SpanObserver.class);
+        Tracer.subscribe("test", mockObserver);
+        try {
+            deserializer.deserialize(new ByteArrayInputStream(new byte[0]));
+        } finally {
+            Tracer.unsubscribe("test");
+        }
+        ArgumentCaptor<Span> captor = ArgumentCaptor.forClass(Span.class);
+        verify(mockObserver).consume(captor.capture());
+        Span span = captor.getValue();
+        assertThat(span.getOperation()).isEqualTo("Dialogue: deserialize String from application/stub");
+    }
+
+    private static final class StubEncoding implements Encoding {
+
+        @Override
+        public <T> Serializer<T> serializer(TypeMarker<T> _type) {
+            return (value, output) -> {};
+        }
+
+        @Override
+        public <T> Deserializer<T> deserializer(TypeMarker<T> _type) {
+            return input -> null;
+        }
+
+        @Override
+        public String getContentType() {
+            return "application/stub";
+        }
+
+        @Override
+        public boolean supportsContentType(String _contentType) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
==COMMIT_MSG==
Tracing around dialogue encodings describing serde and I/O time per request, matching data produced by conjure-undertow on the server
==COMMIT_MSG==
