### PR TITLE
ChannelCache doesn't log existing instances

### DIFF
--- a/changelog/@unreleased/pr-783.v2.yml
+++ b/changelog/@unreleased/pr-783.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: ChannelCache doesn't log existing instances, and no longer produces
+    concurrent-modification-exceptions when additional instances are created in parallel
+    to logging.
+  links:
+  - https://github.com/palantir/dialogue/pull/783

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -81,7 +81,6 @@ final class ChannelCache {
                     SafeArg.of("instanceNumber", newCache.instanceNumber),
                     SafeArg.of("totalAliveNow", numLiveInstances),
                     SafeArg.of("newCache", newCache),
-                    SafeArg.of("existing", LIVE_INSTANCES),
                     new SafeRuntimeException("ChannelCache constructed here"));
         }
 


### PR DESCRIPTION
Jackson serializes using iterators, which are not protected by
SynchronizedSet. This results in ConcurrentModificationExceptions
when the synchronized-set is logged on channel-cache creation.

==COMMIT_MSG==
ChannelCache doesn't log existing instances, and no longer produces concurrent-modification-exceptions when additional instances are created in parallel to logging.
==COMMIT_MSG==
