### PR TITLE
Fallback default impl for Clients.bind

### DIFF
--- a/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
@@ -37,7 +37,16 @@ public interface Clients {
     @Deprecated
     <T> ListenableFuture<T> call(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
 
-    EndpointChannel bind(Channel channel, Endpoint endpoint);
+    default EndpointChannel bind(Channel channel, Endpoint endpoint) {
+        return new EndpointChannel() {
+            @Override
+            public ListenableFuture<Response> execute(Request request) {
+                // this default implementation exists just in case people take new :dialogue-target but have an old
+                // version of :dialogue-serde
+                return channel.execute(endpoint, request);
+            }
+        };
+    }
 
     /**
      * Similar to {@link com.google.common.util.concurrent.Futures#getUnchecked(Future)}, except with custom handling


### PR DESCRIPTION
We've had some unfortunate problems with the rollout of the new Clients.bind optimization, causing some users' servers to fail to start.

This solution is a little gross, but I think it should at least tide people over until they pick up the newer `:dialogue-serde` jar and actually get the meat of the optimization!

cc @natgabb