### PR TITLE
Undo deprecation of Clients.call

### DIFF
--- a/changelog/@unreleased/pr-786.v2.yml
+++ b/changelog/@unreleased/pr-786.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`Clients.call` is no longer deprecated, to make adoption easier in
+    repos that have `-Werror` specified.'
+  links:
+  - https://github.com/palantir/dialogue/pull/786

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
@@ -32,9 +32,8 @@ public interface Clients {
 
     /**
      * Makes a request to the specified {@link Endpoint} and deserializes the response using a provided deserializer.
-     * @deprecated prefer {@link #bind} as this allows pre-computing values to save CPU
+     * Deprecated. prefer {@link #bind} as this allows pre-computing values to save CPU
      */
-    @Deprecated
     <T> ListenableFuture<T> call(Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer);
 
     default EndpointChannel bind(Channel channel, Endpoint endpoint) {


### PR DESCRIPTION
We've got into a state where repos are unable to take conjure-java upgrades because it needs newer Witchcraft, and they're unable to take Witchcraft upgrades because their old dialogue codegen uses a method which is now deprecated.

```
> Task :share-link-service-api:share-link-service-api-dialogue:compileJava FAILED
/Volumes/git/share-link-service/share-link-service-api/share-link-service-api-dialogue/src/generated/java/com/palantir/share/link/api/ShareLinkServiceAsync.java:88: warning: [deprecation] <T>call(Channel,Endpoint,Request,Deserializer<T>) in Clients has been deprecated
                        .call(_channel, DialogueShareLinkEndpoints.getLinks, _request.build(), getLinksDeserializer);
                        ^
```

Coupling excavators like this is pretty bad because it makes everything take longer to merge.