### PR TITLE
Optimize Request.builder().from()

### DIFF
--- a/changelog/@unreleased/pr-791.v2.yml
+++ b/changelog/@unreleased/pr-791.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce allocation and eliminate some unnecessary copying from `Request.builder().from()`
+  links:
+  - https://github.com/palantir/dialogue/pull/791

--- a/dialogue-jmh/src/main/java/com/palantir/dialogue/core/RequestBuilderBenchmark.java
+++ b/dialogue-jmh/src/main/java/com/palantir/dialogue/core/RequestBuilderBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -42,8 +43,21 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 public class RequestBuilderBenchmark {
 
     private Request empty = Request.builder().build();
-    private Request nonEmpty =
-            Request.builder().putHeaderParams("Authorization", "whatever").build();
+    private Request nonEmpty = Request.builder()
+            .putHeaderParams("Authorization", "whatever")
+            .putHeaderParams("header1", "header")
+            .putHeaderParams("header2", "header")
+            .putHeaderParams("header3", "header")
+            .putHeaderParams("header4", "header")
+            .putPathParams("path1", "path")
+            .putPathParams("path2", "path")
+            .putPathParams("path3", "path")
+            .putPathParams("path4", "path")
+            .putQueryParams("query1", "query")
+            .putQueryParams("query2", "query")
+            .putQueryParams("query3", "query")
+            .putQueryParams("query4", "query")
+            .build();
 
     @Threads(1)
     @Benchmark
@@ -68,7 +82,7 @@ public class RequestBuilderBenchmark {
                 .include(RequestBuilderBenchmark.class.getSimpleName())
                 .jvmArgsPrepend("-Xmx1024m", "-Xms1024m", "-XX:+CrashOnOutOfMemoryError")
                 // .jvmArgsPrepend("-XX:+FlightRecorder", "-XX:StartFlightRecording=filename=./foo.jfr")
-                // .addProfiler(GCProfiler.class)
+                .addProfiler(GCProfiler.class)
                 .build();
         new Runner(opt).run();
     }

--- a/dialogue-jmh/src/main/java/com/palantir/dialogue/core/RequestBuilderBenchmark.java
+++ b/dialogue-jmh/src/main/java/com/palantir/dialogue/core/RequestBuilderBenchmark.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.palantir.dialogue.Request;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 12, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 12, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@SuppressWarnings({"VisibilityModifier", "DesignForExtension"})
+public class RequestBuilderBenchmark {
+
+    private Request empty = Request.builder().build();
+    private Request nonEmpty =
+            Request.builder().putHeaderParams("Authorization", "whatever").build();
+
+    @Threads(1)
+    @Benchmark
+    public Request addUserAgentToEmpty() {
+        return Request.builder()
+                .from(empty)
+                .putHeaderParams("user-agent", "hello")
+                .build();
+    }
+
+    @Threads(1)
+    @Benchmark
+    public Request addUserAgentToNonEmpty() {
+        return Request.builder()
+                .from(nonEmpty)
+                .putHeaderParams("user-agent", "hello")
+                .build();
+    }
+
+    public static void main(String[] _args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(RequestBuilderBenchmark.class.getSimpleName())
+                .jvmArgsPrepend("-Xmx1024m", "-Xms1024m", "-XX:+CrashOnOutOfMemoryError")
+                // .jvmArgsPrepend("-XX:+FlightRecorder", "-XX:StartFlightRecording=filename=./foo.jfr")
+                // .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/dialogue-jmh/src/main/java/com/palantir/dialogue/core/RequestBuilderBenchmark.java
+++ b/dialogue-jmh/src/main/java/com/palantir/dialogue/core/RequestBuilderBenchmark.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -82,7 +81,7 @@ public class RequestBuilderBenchmark {
                 .include(RequestBuilderBenchmark.class.getSimpleName())
                 .jvmArgsPrepend("-Xmx1024m", "-Xms1024m", "-XX:+CrashOnOutOfMemoryError")
                 // .jvmArgsPrepend("-XX:+FlightRecorder", "-XX:StartFlightRecording=filename=./foo.jfr")
-                .addProfiler(GCProfiler.class)
+                // .addProfiler(GCProfiler.class)
                 .build();
         new Runner(opt).run();
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -226,7 +226,7 @@ public final class Request {
         }
 
         public Request.Builder pathParams(Map<String, ? extends String> entries) {
-            pathParams = null;
+            pathParams = ImmutableMap.builder();
             return putAllPathParams(entries);
         }
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -201,7 +201,8 @@ public final class Request {
         }
 
         public Request.Builder queryParams(Multimap<String, ? extends String> entries) {
-            queryParams = ImmutableListMultimap.builder();
+            queryParams = null;
+            existingQueryParams = null;
             return putAllQueryParams(entries);
         }
 
@@ -226,7 +227,8 @@ public final class Request {
         }
 
         public Request.Builder pathParams(Map<String, ? extends String> entries) {
-            pathParams = ImmutableMap.builder();
+            pathParams = null;
+            existingPathParams = null;
             return putAllPathParams(entries);
         }
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -116,7 +116,7 @@ public final class Request {
     }
 
     public static final class Builder {
-        private static final ListMultimap<String, String> EMPTY_HEADERS =
+        private static final ImmutableListMultimap<String, String> EMPTY_HEADERS =
                 new ImmutableListMultimap.Builder<String, String>().build();
 
         @Nullable
@@ -124,7 +124,9 @@ public final class Request {
 
         // To optimize the case where we don't end up modifying the headers, we may store a reference to another
         // Request's internal headerParams object. If we need to do a mutation, then we'll copy all the elements
+        @Nullable
         private ListMultimap<String, String> existingUnmodifiableHeaderParams;
+
         private ImmutableListMultimap.Builder<String, String> queryParams = ImmutableListMultimap.builder();
         private ImmutableMap.Builder<String, String> pathParams = ImmutableMap.builder();
         private Optional<RequestBody> body = Optional.empty();

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -255,7 +255,7 @@ public final class Request {
                         .build();
 
                 if (existingUnmodifiableHeaderParams != null) {
-                    headerParams.putAll(existingUnmodifiableHeaderParams);
+                    existingUnmodifiableHeaderParams.forEach(headerParams::put);
                     existingUnmodifiableHeaderParams = null;
                 }
             }
@@ -267,7 +267,7 @@ public final class Request {
                 queryParams = ImmutableListMultimap.builder();
 
                 if (existingQueryParams != null) {
-                    queryParams.putAll(existingQueryParams);
+                    existingQueryParams.forEach(queryParams::put);
                     existingQueryParams = null;
                 }
             }
@@ -279,7 +279,7 @@ public final class Request {
                 pathParams = ImmutableMap.builder();
 
                 if (existingPathParams != null) {
-                    pathParams.putAll(existingPathParams);
+                    existingPathParams.forEach(pathParams::put);
                     existingPathParams = null;
                 }
             }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
-/** Defines the parameters of a single {@link Call} to an {@link Endpoint}. */
+/** Defines the parameters of a single call to an {@link Endpoint}. */
 @ThreadSafe
 public final class Request {
 
@@ -44,7 +44,7 @@ public final class Request {
         body = builder.body;
         headerParams = builder.unmodifiableHeaderParams();
         queryParams = builder.unmodifiableQueryParams();
-        pathParams = builder.pathParams.build();
+        pathParams = builder.unmodifiablePathParams();
     }
 
     /**
@@ -128,17 +128,22 @@ public final class Request {
         @Nullable
         private ImmutableListMultimap.Builder<String, String> queryParams;
 
-        private ImmutableMap.Builder<String, String> pathParams = ImmutableMap.builder();
+        @Nullable
+        private ImmutableMap.Builder<String, String> pathParams;
 
         private Optional<RequestBody> body = Optional.empty();
 
-        // To optimize the case where we don't end up modifying headers/queryparams/pathparams, we may store a
+        // To optimize the case where a builder doesn't end up modifying headers/queryparams/pathparams, we may store
         // references to another Request's internal objects. If we need to do a mutation, then we'll copy the elements
+        // and null these out.
         @Nullable
         private ListMultimap<String, String> existingUnmodifiableHeaderParams;
 
         @Nullable
         private ImmutableListMultimap<String, String> existingQueryParams;
+
+        @Nullable
+        private ImmutableMap<String, String> existingPathParams;
 
         private Builder() {}
 
@@ -147,62 +152,13 @@ public final class Request {
 
             existingUnmodifiableHeaderParams = Multimaps.unmodifiableListMultimap(existing.headerParams);
             existingQueryParams = existing.queryParams;
-            putAllPathParams(existing.pathParams());
+            existingPathParams = existing.pathParams;
+
             Optional<RequestBody> bodyOptional = existing.body();
             if (bodyOptional.isPresent()) {
                 body(bodyOptional);
             }
             return this;
-        }
-
-        private ListMultimap<String, String> mutableHeaderParams() {
-            if (headerParams == null) {
-                headerParams = MultimapBuilder.treeKeys(String.CASE_INSENSITIVE_ORDER)
-                        .arrayListValues()
-                        .build();
-
-                if (existingUnmodifiableHeaderParams != null) {
-                    headerParams.putAll(existingUnmodifiableHeaderParams);
-                    existingUnmodifiableHeaderParams = null;
-                }
-            }
-            return headerParams;
-        }
-
-        private ImmutableListMultimap.Builder<String, String> mutableQueryParams() {
-            if (queryParams == null) {
-                queryParams = ImmutableListMultimap.builder();
-
-                if (existingQueryParams != null) {
-                    queryParams.putAll(existingQueryParams);
-                    existingQueryParams = null;
-                }
-            }
-            return queryParams;
-        }
-
-        private ListMultimap<String, String> unmodifiableHeaderParams() {
-            if (existingUnmodifiableHeaderParams != null) {
-                return existingUnmodifiableHeaderParams;
-            }
-
-            if (headerParams != null) {
-                return Multimaps.unmodifiableListMultimap(headerParams);
-            }
-
-            return EMPTY;
-        }
-
-        public ImmutableListMultimap<String, String> unmodifiableQueryParams() {
-            if (existingQueryParams != null) {
-                return existingQueryParams;
-            }
-
-            if (queryParams != null) {
-                return queryParams.build();
-            }
-
-            return EMPTY;
         }
 
         public Request.Builder putHeaderParams(String key, String... values) {
@@ -260,22 +216,22 @@ public final class Request {
         }
 
         public Request.Builder putPathParams(String key, String value) {
-            pathParams.put(key, value);
+            mutablePathParams().put(key, value);
             return this;
         }
 
         public Request.Builder putPathParams(Map.Entry<String, ? extends String> entry) {
-            pathParams.put(entry);
+            mutablePathParams().put(entry);
             return this;
         }
 
         public Request.Builder pathParams(Map<String, ? extends String> entries) {
-            pathParams = ImmutableMap.builder();
+            pathParams = null;
             return putAllPathParams(entries);
         }
 
         public Request.Builder putAllPathParams(Map<String, ? extends String> entries) {
-            pathParams.putAll(entries);
+            mutablePathParams().putAll(entries);
             return this;
         }
 
@@ -288,6 +244,80 @@ public final class Request {
         public Request.Builder body(Optional<? extends RequestBody> value) {
             body = (Optional<RequestBody>) value;
             return this;
+        }
+
+        private ListMultimap<String, String> mutableHeaderParams() {
+            if (headerParams == null) {
+                headerParams = MultimapBuilder.treeKeys(String.CASE_INSENSITIVE_ORDER)
+                        .arrayListValues()
+                        .build();
+
+                if (existingUnmodifiableHeaderParams != null) {
+                    headerParams.putAll(existingUnmodifiableHeaderParams);
+                    existingUnmodifiableHeaderParams = null;
+                }
+            }
+            return headerParams;
+        }
+
+        private ImmutableListMultimap.Builder<String, String> mutableQueryParams() {
+            if (queryParams == null) {
+                queryParams = ImmutableListMultimap.builder();
+
+                if (existingQueryParams != null) {
+                    queryParams.putAll(existingQueryParams);
+                    existingQueryParams = null;
+                }
+            }
+            return queryParams;
+        }
+
+        private ImmutableMap.Builder<String, String> mutablePathParams() {
+            if (pathParams == null) {
+                pathParams = ImmutableMap.builder();
+
+                if (existingPathParams != null) {
+                    pathParams.putAll(existingPathParams);
+                    existingPathParams = null;
+                }
+            }
+            return pathParams;
+        }
+
+        private ListMultimap<String, String> unmodifiableHeaderParams() {
+            if (existingUnmodifiableHeaderParams != null) {
+                return existingUnmodifiableHeaderParams;
+            }
+
+            if (headerParams != null) {
+                return Multimaps.unmodifiableListMultimap(headerParams);
+            }
+
+            return EMPTY;
+        }
+
+        private ImmutableListMultimap<String, String> unmodifiableQueryParams() {
+            if (existingQueryParams != null) {
+                return existingQueryParams;
+            }
+
+            if (queryParams != null) {
+                return queryParams.build();
+            }
+
+            return EMPTY;
+        }
+
+        private ImmutableMap<String, String> unmodifiablePathParams() {
+            if (existingPathParams != null) {
+                return existingPathParams;
+            }
+
+            if (pathParams != null) {
+                return pathParams.build();
+            }
+
+            return ImmutableMap.of();
         }
 
         public Request build() {

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -52,8 +52,8 @@ public final class RequestTest {
                 Request.builder().putHeaderParams("Authorization", "foo").build();
         Request request2 = Request.builder().from(request1).build();
         assertThat(request2.headerParams())
-                .describedAs(
-                        "Re-using the exact same underlying instance is a safe optimization because Requests are immutable")
+                .describedAs("Re-using the exact same underlying instance is a safe optimization because Requests are"
+                        + " immutable")
                 .isSameAs(request1.headerParams());
     }
 

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import org.junit.jupiter.api.Test;
@@ -43,5 +44,36 @@ public final class RequestTest {
                 .putHeaderParams("other", token.toString())
                 .build();
         assertThat(request).asString().doesNotContain(sentinel);
+    }
+
+    @Test
+    void from_method_copies_headers_no_mutation() {
+        Request request1 =
+                Request.builder().putHeaderParams("Authorization", "foo").build();
+        Request request2 = Request.builder().from(request1).build();
+        assertThat(request2.headerParams())
+                .describedAs(
+                        "Re-using the exact same underlying instance is a safe optimization because Requests are immutable")
+                .isSameAs(request1.headerParams());
+    }
+
+    @Test
+    void from_method_copies_headers_with_mutation() {
+        Request request1 = Request.builder()
+                .putHeaderParams("Authorization", "foo")
+                .putHeaderParams("accept-encoding", "bar")
+                .build();
+        Request request2 = Request.builder()
+                .from(request1)
+                .putHeaderParams("accept-encoding", "baz") // TODO(dfox): I don't think users will like this behaviour
+                .putHeaderParams("another-header", "another-value")
+                .build();
+        assertThat(request2.headerParams())
+                .describedAs("We should preserve the Authorization header from request1, but we changed")
+                .isEqualTo(ImmutableMultimap.<String, String>builder()
+                        .put("Authorization", "foo")
+                        .putAll("accept-encoding", "bar", "baz")
+                        .putAll("another-header", "another-value")
+                        .build());
     }
 }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
@@ -75,5 +76,16 @@ public final class RequestTest {
                         .putAll("accept-encoding", "bar", "baz")
                         .putAll("another-header", "another-value")
                         .build());
+    }
+
+    @Test
+    void from_method_query_param_mutation() {
+        Request request1 = Request.builder().build();
+        Request request2 = Request.builder()
+                .from(request1)
+                .queryParams(ImmutableListMultimap.of("a", "A1", "a", "A2", "b", "B"))
+                .build();
+
+        System.out.println(request2.queryParams());
     }
 }


### PR DESCRIPTION
## Before this PR

As per a discussion in #dev-foundry-infra, a decent proportion of dialogue overhead is actually spent copying Requests just to add/modify a header. 

Rather than trying to optimize multimaps, we can actually get a bit of a speedup by just re-using stuff where possible. (There's no need to allocate and populate an identical map to an existing one!)

```
Benchmark                                                                     Mode  Cnt     Score     Error   Units
RequestBuilderBenchmark.addUserAgentToEmpty                                  thrpt   12  9310.828 ± 736.043  ops/ms
RequestBuilderBenchmark.addUserAgentToNonEmpty                               thrpt   12   936.356 ±  71.790  ops/ms

RequestBuilderBenchmark.addUserAgentToEmpty:·gc.alloc.rate.norm              thrpt   12   592.000 ±   0.001    B/op
RequestBuilderBenchmark.addUserAgentToNonEmpty:·gc.alloc.rate.norm           thrpt   12  2688.003 ±   0.008    B/op
```


## After this PR
==COMMIT_MSG==
Reduce allocation and eliminate some unnecessary copying from `Request.builder().from()`
==COMMIT_MSG==

Less GC due to dumb copying means servers will have more CPU available to do real work.

```
Benchmark                                                                     Mode  Cnt      Score      Error   Units
RequestBuilderBenchmark.addUserAgentToEmpty                                  thrpt   12  23070.647 ± 3011.135  ops/ms
RequestBuilderBenchmark.addUserAgentToNonEmpty                               thrpt   12   2175.030 ±  212.811  ops/ms

RequestBuilderBenchmark.addUserAgentToEmpty:·gc.alloc.rate.norm              thrpt   12    264.000 ±    0.001    B/op
RequestBuilderBenchmark.addUserAgentToNonEmpty:·gc.alloc.rate.norm           thrpt   12    744.001 ±    0.004    B/op
```

## Possible downsides?

- the _vast_ majority of dialogue users will not care about this, it's really only helpful in the case where something is making tons of network requests and is pretty maxed out on CPU...
- whenever we're micro-optimizing, there's a danger that making the code harder to understand is actually worse than a small performance hit.  I _hope_ this implementation is still easy to understand, but would like to hear if not.