### PR TITLE
Support http OPTIONS

### DIFF
--- a/changelog/@unreleased/pr-802.v2.yml
+++ b/changelog/@unreleased/pr-802.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Endpoints can now specify http OPTIONS verb
+  links:
+  - https://github.com/palantir/dialogue/pull/802

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientBlockingChannel.java
@@ -74,6 +74,8 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                     endpoint.httpMethod() != HttpMethod.GET, "GET endpoints must not have a request body");
             Preconditions.checkArgument(
                     endpoint.httpMethod() != HttpMethod.HEAD, "HEAD endpoints must not have a request body");
+            Preconditions.checkArgument(
+                    endpoint.httpMethod() != HttpMethod.OPTIONS, "OPTIONS endpoints must not have a request body");
             RequestBody body = request.body().get();
             setBody(builder, body);
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -375,6 +375,7 @@ final class RetryingChannel implements EndpointChannel {
         switch (httpMethod) {
             case GET:
             case HEAD:
+            case OPTIONS:
                 return true;
             case PUT:
             case DELETE:

--- a/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionBlockingChannel.java
+++ b/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionBlockingChannel.java
@@ -85,6 +85,8 @@ final class HttpUrlConnectionBlockingChannel implements BlockingChannel {
                     endpoint.httpMethod() != HttpMethod.GET, "GET endpoints must not have a request body");
             Preconditions.checkArgument(
                     endpoint.httpMethod() != HttpMethod.HEAD, "HEAD endpoints must not have a request body");
+            Preconditions.checkArgument(
+                    endpoint.httpMethod() != HttpMethod.OPTIONS, "OPTIONS endpoints must not have a request body");
             RequestBody body = request.body().get();
             connection.setChunkedStreamingMode(1024 * 8);
             connection.setRequestProperty("content-type", body.contentType());

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -68,6 +68,9 @@ public final class HttpChannel implements Channel {
         Preconditions.checkArgument(
                 !(request.body().isPresent() && endpoint.httpMethod() == HttpMethod.HEAD),
                 "HEAD endpoints must not have a request body");
+        Preconditions.checkArgument(
+                !(request.body().isPresent() && endpoint.httpMethod() == HttpMethod.OPTIONS),
+                "OPTIONS endpoints must not have a request body");
         httpRequest.method(endpoint.httpMethod().name(), toBody(request));
 
         // Fill headers

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
@@ -80,6 +80,11 @@ public final class OkHttpChannel implements Channel {
                 Preconditions.checkArgument(!request.body().isPresent(), "HEAD endpoints must not have a request body");
                 okRequest = okRequest.head();
                 break;
+            case OPTIONS:
+                Preconditions.checkArgument(
+                        !request.body().isPresent(), "OPTIONS endpoints must not have a request body");
+                okRequest = okRequest.method("OPTIONS", null);
+                break;
             case POST:
                 okRequest = okRequest.post(toOkHttpBody(request.body()));
                 break;
@@ -92,11 +97,6 @@ public final class OkHttpChannel implements Channel {
                 break;
             case PATCH:
                 okRequest = okRequest.patch(toOkHttpBody(request.body()));
-                break;
-            case OPTIONS:
-                Preconditions.checkArgument(
-                        !request.body().isPresent(), "OPTIONS endpoints must not have a request body");
-                okRequest = okRequest.method("OPTIONS", null);
                 break;
         }
 

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannel.java
@@ -93,6 +93,11 @@ public final class OkHttpChannel implements Channel {
             case PATCH:
                 okRequest = okRequest.patch(toOkHttpBody(request.body()));
                 break;
+            case OPTIONS:
+                Preconditions.checkArgument(
+                        !request.body().isPresent(), "OPTIONS endpoints must not have a request body");
+                okRequest = okRequest.method("OPTIONS", null);
+                break;
         }
 
         // Fill headers

--- a/dialogue-target/src/main/java/com/palantir/dialogue/HttpMethod.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/HttpMethod.java
@@ -24,4 +24,5 @@ public enum HttpMethod {
     PATCH,
     POST,
     PUT,
+    OPTIONS
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/HttpMethod.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/HttpMethod.java
@@ -18,11 +18,11 @@ package com.palantir.dialogue;
 
 /** The HTTP methods supported by Dialogue. */
 public enum HttpMethod {
-    DELETE,
     GET,
     HEAD,
+    OPTIONS,
     PATCH,
     POST,
     PUT,
-    OPTIONS
+    DELETE,
 }

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -228,6 +228,14 @@ public abstract class AbstractChannelTest {
     }
 
     @Test
+    public void options_failsWhenBodyIsGiven() {
+        endpoint.method = HttpMethod.OPTIONS;
+        request = Request.builder().from(request).body(body).build();
+        assertThatThrownBy(() -> channel.execute(endpoint, request).get())
+                .hasMessageContaining("OPTIONS endpoints must not have a request body");
+    }
+
+    @Test
     public void head_failsWhenBodyReturned() throws ExecutionException, InterruptedException {
         endpoint.method = HttpMethod.HEAD;
         Response response = channel.execute(endpoint, request).get();

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
-import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestResponse;
@@ -75,10 +74,6 @@ final class SimulationServer implements Channel {
 
     @Override
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
-        if (endpoint.httpMethod() == HttpMethod.OPTIONS) {
-            return Futures.immediateFuture(new TestResponse().code(204));
-        }
-
         Meter perEndpointRequests = MetricNames.requestMeter(simulation.taggedMetrics(), serverName, endpoint);
 
         activeRequests.inc();

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestResponse;
@@ -74,6 +75,10 @@ final class SimulationServer implements Channel {
 
     @Override
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+        if (endpoint.httpMethod() == HttpMethod.OPTIONS) {
+            return Futures.immediateFuture(new TestResponse().code(204));
+        }
+
         Meter perEndpointRequests = MetricNames.requestMeter(simulation.taggedMetrics(), serverName, endpoint);
 
         activeRequests.inc();


### PR DESCRIPTION
## Before this PR

https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS is an HTTP verb that all of our servers implement because browser CORS preflight requests require it. Just like 'PATCH', I'm not intending this to be usable from conjure defined APIs, but it will be a useful implementation detail of the $ saving PR: https://github.com/palantir/dialogue/pull/794

## After this PR
==COMMIT_MSG==
Endpoints can now specify http OPTIONS verb
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
