### PR TITLE
Dialogue apache clients use the read timeout as socket timeout

### DIFF
--- a/changelog/@unreleased/pr-803.v2.yml
+++ b/changelog/@unreleased/pr-803.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue apache clients use the read timeout as socket timeout
+  links:
+  - https://github.com/palantir/dialogue/pull/803

--- a/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc4-client/src/main/java/com/palantir/dialogue/hc4/ApacheHttpClientChannels.java
@@ -355,8 +355,14 @@ public final class ApacheHttpClientChannels {
                     !conf.fallbackToCommonNameVerification(), "fallback-to-common-name-verification is not supported");
             Preconditions.checkArgument(!conf.meshProxy().isPresent(), "Mesh proxy is not supported");
 
-            long socketTimeoutMillis =
-                    Math.max(conf.readTimeout().toMillis(), conf.writeTimeout().toMillis());
+            long socketTimeoutMillis = conf.readTimeout().toMillis();
+            if (conf.readTimeout().toMillis() != conf.writeTimeout().toMillis()) {
+                log.warn(
+                        "Read and write timeouts do not match, The value of the readTimeout {} will be used and write "
+                                + "timeout {} will be ignored.",
+                        SafeArg.of("readTimeout", conf.readTimeout()),
+                        SafeArg.of("writeTimeout", conf.writeTimeout()));
+            }
             int connectTimeout = Ints.checkedCast(conf.connectTimeout().toMillis());
             // Most of our servers use a keep-alive timeout of one minute, by using a slightly lower value on the
             // client side we can avoid unnecessary retries due to race conditions when servers close idle connections


### PR DESCRIPTION
Previously we used the maximum value which broke consumers with
reduced read timeout in order to prevent excessive blocking.

Apache HttpClient does not support separate read and write
timeouts.

==COMMIT_MSG==
Dialogue apache clients use the read timeout as socket timeout
==COMMIT_MSG==

## Possible downsides?
Risks: It's possible that some services rely on a modified write
timeout which would have similar problems, but this scenario is
much less common.

Alternatives considered: I thought about using the minimum of
read and write timeout, but that runs into similar problems when
the read timeout is increased.
