### PR TITLE
Fix BALANCED_RTT (and add simulations)

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -92,6 +92,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
         this.rttSampler = samplingEnabled == RttSampling.DEFAULT_OFF ? null : new RttSampler(channels, clock);
         this.channels = IntStream.range(0, channels.size())
                 .mapToObj(index -> new MutableChannelWithStats(
+                        index,
                         channels.get(index),
                         clock,
                         PerHostObservability.create(channels, taggedMetrics, channelName, index)))
@@ -133,15 +134,17 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
     }
 
     private static SortableChannel[] computeScores(
-            @Nullable RttSampler rttSampler, List<MutableChannelWithStats> chans) {
+            @Nullable RttSampler rttSampler, List<MutableChannelWithStats> shuffledChannels) {
         // if the feature is disabled (i.e. RttSampling.DEFAULT_OFF), then we just consider every host to have a
         // rttSpectrum of '0'
-        float[] rttSpectrums = rttSampler != null ? rttSampler.computeRttSpectrums() : new float[chans.size()];
+        float[] rttSpectrums =
+                rttSampler != null ? rttSampler.computeRttSpectrums() : new float[shuffledChannels.size()];
 
-        SortableChannel[] snapshotArray = new SortableChannel[chans.size()];
-        for (int i = 0; i < chans.size(); i++) {
-            MutableChannelWithStats channel = chans.get(i);
-            float rttSpectrum = rttSpectrums[i];
+        SortableChannel[] snapshotArray = new SortableChannel[shuffledChannels.size()];
+        for (int i = 0; i < shuffledChannels.size(); i++) {
+            MutableChannelWithStats channel = shuffledChannels.get(i);
+            // beware rttSpectrums have the original order, but shuffledChannels are shuffled, so 'i' won't line up
+            float rttSpectrum = rttSpectrums[channel.hostIndex];
             snapshotArray[i] = channel.computeScore(rttSpectrum);
         }
 
@@ -167,6 +170,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
     }
 
     private static final class MutableChannelWithStats implements LimitedChannel {
+        private final int hostIndex;
         private final LimitedChannel delegate;
         private final FutureCallback<Response> updateStats;
         private final PerHostObservability observability;
@@ -180,7 +184,9 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
          */
         private final CoarseExponentialDecayReservoir recentFailuresReservoir;
 
-        MutableChannelWithStats(LimitedChannel delegate, Ticker clock, PerHostObservability observability) {
+        MutableChannelWithStats(
+                int hostIndex, LimitedChannel delegate, Ticker clock, PerHostObservability observability) {
+            this.hostIndex = hostIndex;
             this.delegate = delegate;
             this.recentFailuresReservoir = new CoarseExponentialDecayReservoir(clock::read, FAILURE_MEMORY);
             this.observability = observability;
@@ -235,7 +241,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
                     + Ints.saturatedCast(Math.round(failureReservoir))
                     + Ints.saturatedCast(Math.round(rttSpectrum * RTT_WEIGHT));
 
-            observability.debugLogComputedScore(requestsInflight, failureReservoir, rttSpectrum, score);
+            observability.traceLogComputedScore(requestsInflight, failureReservoir, rttSpectrum, score);
             return new SortableChannel(score, this);
         }
 
@@ -339,9 +345,9 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             }
         }
 
-        void debugLogComputedScore(int inflight, double failures, float rttSpectrum, int score) {
-            if (log.isDebugEnabled()) {
-                log.debug(
+        void traceLogComputedScore(int inflight, double failures, float rttSpectrum, int score) {
+            if (log.isTraceEnabled()) {
+                log.trace(
                         "Computed score ({} {}) {}",
                         channelName,
                         hostIndex,

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -120,11 +120,13 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
         for (SortableChannel channel : sortableChannels) {
             Optional<ListenableFuture<Response>> maybe = channel.delegate.maybeExecute(endpoint, request);
             if (maybe.isPresent()) {
+                log.info("Sending request to {}", channel.delegate.delegate);
                 if (rttSampler != null) {
                     rttSampler.maybeSampleRtts();
                 }
                 return maybe;
             }
+            log.info("Limited refused, on to the next one");
         }
 
         return Optional.empty();
@@ -142,6 +144,8 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             float rttSpectrum = rttSpectrums[i];
             snapshotArray[i] = channel.computeScore(rttSpectrum);
         }
+
+        log.info("Scores on the doors {}", Arrays.asList(snapshotArray));
         return snapshotArray;
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -338,7 +338,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
         void debugLogComputedScore(int inflight, double failures, float rttSpectrum, int score) {
             if (log.isDebugEnabled()) {
                 log.debug(
-                        "Computed score",
+                        "Computed score ({} {}) {}",
                         channelName,
                         hostIndex,
                         SafeArg.of("score", score),

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -121,13 +121,11 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
         for (SortableChannel channel : sortableChannels) {
             Optional<ListenableFuture<Response>> maybe = channel.delegate.maybeExecute(endpoint, request);
             if (maybe.isPresent()) {
-                log.info("Sending request to {}", channel.delegate.delegate);
                 if (rttSampler != null) {
                     rttSampler.maybeSampleRtts();
                 }
                 return maybe;
             }
-            log.info("Limited refused, on to the next one");
         }
 
         return Optional.empty();
@@ -148,7 +146,6 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             snapshotArray[i] = channel.computeScore(rttSpectrum);
         }
 
-        log.info("Scores on the doors {}", Arrays.asList(snapshotArray));
         return snapshotArray;
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RttSampler.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RttSampler.java
@@ -32,6 +32,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.UrlBuilder;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Arrays;
@@ -157,10 +158,11 @@ final class RttSampler {
                             .mapToLong(rtt -> rtt.getRttNanos().orElse(Long.MAX_VALUE))
                             .toArray();
                     log.debug(
-                            "RTTs {} {} {}",
+                            "RTTs {} {} {} {}",
                             SafeArg.of("nanos", result),
                             SafeArg.of("millis", millis),
-                            SafeArg.of("best", Arrays.toString(best)));
+                            SafeArg.of("best", Arrays.toString(best)),
+                            UnsafeArg.of("channels", channels));
                 }
             }
 

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
-import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestResponse;
@@ -75,10 +74,6 @@ final class SimulationServer implements Channel {
 
     @Override
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
-        if (endpoint.httpMethod() == HttpMethod.OPTIONS) {
-            return Futures.immediateFuture(new TestResponse().code(204));
-        }
-
         Meter perEndpointRequests = MetricNames.requestMeter(simulation.taggedMetrics(), serverName, endpoint);
 
         activeRequests.inc();

--- a/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
@@ -527,7 +527,7 @@ final class SimulationTest {
                         .serverName("faraway")
                         .simulation(simulation)
                         .handler(RttEndpoint.INSTANCE, h -> h.response(200).responseTime(Duration.ofMillis(2)))
-                        .handler(h -> h.response(responseFunction).responseTime(Duration.ofMillis(31)))
+                        .handler(h -> h.response(responseFunction).responseTime(Duration.ofMillis(40)))
                         .build());
 
         st = strategy;

--- a/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
@@ -534,8 +534,7 @@ final class SimulationTest {
         result = Benchmark.builder()
                 .simulation(simulation)
                 .requestsPerSecond(20)
-                .numRequests(50)
-                // .sendUntil(Duration.ofMinutes(25))
+                .sendUntil(Duration.ofMinutes(25))
                 .client(strategy.getChannel(simulation, servers))
                 .abortAfter(Duration.ofHours(1))
                 .run();

--- a/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
@@ -534,7 +534,8 @@ final class SimulationTest {
         result = Benchmark.builder()
                 .simulation(simulation)
                 .requestsPerSecond(20)
-                .sendUntil(Duration.ofMinutes(25))
+                .numRequests(50)
+                // .sendUntil(Duration.ofMinutes(25))
                 .client(strategy.getChannel(simulation, servers))
                 .abortAfter(Duration.ofHours(1))
                 .run();

--- a/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
@@ -522,12 +522,18 @@ final class SimulationTest {
                         .simulation(simulation)
                         .handler(RttEndpoint.INSTANCE, h -> h.response(200).responseTime(Duration.ofMillis(1)))
                         .handler(h -> h.response(responseFunction).responseTime(Duration.ofMillis(30)))
+                        .until(Duration.ofMinutes(15), "slowdown halfway")
+                        .handler(RttEndpoint.INSTANCE, h -> h.response(200).responseTime(Duration.ofMillis(1)))
+                        .handler(h -> h.response(responseFunction).responseTime(Duration.ofMillis(300)))
                         .build(),
                 SimulationServer.builder()
                         .serverName("faraway")
                         .simulation(simulation)
                         .handler(RttEndpoint.INSTANCE, h -> h.response(200).responseTime(Duration.ofMillis(2)))
-                        .handler(h -> h.response(responseFunction).responseTime(Duration.ofMillis(40)))
+                        .handler(h -> h.response(responseFunction).responseTime(Duration.ofMillis(31)))
+                        .until(Duration.ofMinutes(15), "slowdown halfway")
+                        .handler(RttEndpoint.INSTANCE, h -> h.response(200).responseTime(Duration.ofMillis(2)))
+                        .handler(h -> h.response(responseFunction).responseTime(Duration.ofMillis(301)))
                         .build());
 
         st = strategy;

--- a/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
@@ -16,7 +16,6 @@
 
 package com.palantir.dialogue.core;
 
-import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
@@ -75,13 +74,12 @@ public enum Strategy {
             Supplier<Map<String, SimulationServer>> channelSupplier,
             UnaryOperator<ClientConfiguration.Builder> applyConfig) {
         return RefreshingChannelFactory.RefreshingChannel.create(
-                () -> channelSupplier.get().keySet(), _uris -> {
+                () -> channelSupplier.get().keySet(), uris -> {
                     return DialogueChannel.builder()
                             .channelName(SimulationUtils.CHANNEL_NAME)
                             .clientConfiguration(applyConfig
                                     .apply(ClientConfiguration.builder()
-                                            .uris(ImmutableList.copyOf(
-                                                    channelSupplier.get().keySet()))
+                                            .uris(uris)
                                             .from(STUB_CONFIG)
                                             .taggedMetricRegistry(sim.taggedMetrics()))
                                     .build())

--- a/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
+++ b/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e12f96037d0cf606c1411b9c2f34fffcacab2f15bfefdc6f4f74fc48152a867
+size 101774

--- a/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
+++ b/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e12f96037d0cf606c1411b9c2f34fffcacab2f15bfefdc6f4f74fc48152a867
-size 101774
+oid sha256:96d24ef5c897da84fe2d7ad8362dabb334f1320b5d3910fec83e27a7c68b42d8
+size 103646

--- a/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d58b378872234c687a57297271dfaa60394864f9f4d5c0ae1d1090d0ac3d5f76
-size 101116
+oid sha256:f6d62665812176ddccff72719eefcaec9d2993ea0569983d27d6257bdfc4851f
+size 115339

--- a/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c8af5bf28df1ed9f3777ffa4a8ecf5057b7f228fda89a14d93854df42e9de8b
-size 302120
+oid sha256:d58b378872234c687a57297271dfaa60394864f9f4d5c0ae1d1090d0ac3d5f76
+size 101116

--- a/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8af5bf28df1ed9f3777ffa4a8ecf5057b7f228fda89a14d93854df42e9de8b
+size 302120

--- a/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15e65ff56878c0c9fb97f66d4bfd0ff01a6f8fefbd3be8c5886afceed5380777
+size 301276

--- a/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4b2c775f6ec2ae94a53f14680904e5caa633454079bff7cea98984cc76d6e2d
-size 123533
+oid sha256:5b9ef9575407e178973ac741c701db75bf69a15e9e608cd9def8b00d7ef14b4e
+size 100093

--- a/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b9ef9575407e178973ac741c701db75bf69a15e9e608cd9def8b00d7ef14b4e
-size 100093
+oid sha256:be4dec7ab1535c55ff950664e87f1978b967c26c8d4f56beb7ef2c45da296cf4
+size 114428

--- a/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15e65ff56878c0c9fb97f66d4bfd0ff01a6f8fefbd3be8c5886afceed5380777
-size 301276
+oid sha256:b4b2c775f6ec2ae94a53f14680904e5caa633454079bff7cea98984cc76d6e2d
+size 123533

--- a/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
+++ b/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be4dec7ab1535c55ff950664e87f1978b967c26c8d4f56beb7ef2c45da296cf4
-size 114428
+oid sha256:b124f4f1daf21ec78921a2d0d38ff27da082c26af06029c2221e06e23597496e
+size 119086

--- a/simulation/src/test/resources/log4j2-test.xml
+++ b/simulation/src/test/resources/log4j2-test.xml
@@ -24,10 +24,10 @@
         <Root level="warn">
             <AppenderRef ref="Console"/>
         </Root>
-        <Logger name="com.palantir.dialogue.core.BalancedNodeSelectionStrategyChannel" level="info">
+        <Logger name="com.palantir.dialogue.core.BalancedNodeSelectionStrategyChannel" level="warn">
             <AppenderRef ref="Console"/>
         </Logger>
-        <Logger name="com.palantir.dialogue.core.RttSampler" level="debug">
+        <Logger name="com.palantir.dialogue.core.RttSampler" level="warn">
             <AppenderRef ref="Console"/>
         </Logger>
     </Loggers>

--- a/simulation/src/test/resources/log4j2-test.xml
+++ b/simulation/src/test/resources/log4j2-test.xml
@@ -24,5 +24,11 @@
         <Root level="warn">
             <AppenderRef ref="Console"/>
         </Root>
+        <Logger name="com.palantir.dialogue.core.BalancedNodeSelectionStrategyChannel" level="debug">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Logger name="com.palantir.dialogue.core.RttSampler" level="debug">
+            <AppenderRef ref="Console"/>
+        </Logger>
     </Loggers>
 </Configuration>

--- a/simulation/src/test/resources/log4j2-test.xml
+++ b/simulation/src/test/resources/log4j2-test.xml
@@ -24,7 +24,7 @@
         <Root level="warn">
             <AppenderRef ref="Console"/>
         </Root>
-        <Logger name="com.palantir.dialogue.core.BalancedNodeSelectionStrategyChannel" level="debug">
+        <Logger name="com.palantir.dialogue.core.BalancedNodeSelectionStrategyChannel" level="info">
             <AppenderRef ref="Console"/>
         </Logger>
         <Logger name="com.palantir.dialogue.core.RttSampler" level="debug">

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -7,9 +7,9 @@
                    black_hole[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=59.2%	client_mean=PT0.600655114S 	server_cpu=PT11M49.8S     	client_received=1183/2000	server_resps=1183	codes={200=1183}
                        black_hole[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=91.5%	client_mean=PT0.6S         	server_cpu=PT18M17.4S     	client_received=1829/2000	server_resps=1829	codes={200=1829}
                                  black_hole[UNLIMITED_ROUND_ROBIN].txt:	success=91.4%	client_mean=PT0.6S         	server_cpu=PT18M16.8S     	client_received=1828/2000	server_resps=1828	codes={200=1828}
-                     cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.035846666S 	server_cpu=PT17M55.4S     	client_received=30000/30000	server_resps=30000	codes={200=30000}
-                         cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}
-                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}
+                     cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.138584666S 	server_cpu=PT1H9M17.54S   	client_received=30000/30000	server_resps=30000	codes={200=30000}
+                         cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.138103933S 	server_cpu=PT1H9M7.615S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
+                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.138103933S 	server_cpu=PT1H9M7.615S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
              drastic_slowdown[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT2.947028083S 	server_cpu=PT41M8.862333314S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                  drastic_slowdown[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                            drastic_slowdown[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -8,8 +8,8 @@
                        black_hole[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=91.5%	client_mean=PT0.6S         	server_cpu=PT18M17.4S     	client_received=1829/2000	server_resps=1829	codes={200=1829}
                                  black_hole[UNLIMITED_ROUND_ROBIN].txt:	success=91.4%	client_mean=PT0.6S         	server_cpu=PT18M16.8S     	client_received=1828/2000	server_resps=1828	codes={200=1828}
                      cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.035846666S 	server_cpu=PT17M55.4S     	client_received=30000/30000	server_resps=30000	codes={200=30000}
-                         cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
-                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.0346S      	server_cpu=PT1.736S       	client_received=50/50	server_resps=54	codes={200=50}
+                         cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}
+                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}
              drastic_slowdown[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT2.947028083S 	server_cpu=PT41M8.862333314S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                  drastic_slowdown[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                            drastic_slowdown[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -9,7 +9,7 @@
                                  black_hole[UNLIMITED_ROUND_ROBIN].txt:	success=91.4%	client_mean=PT0.6S         	server_cpu=PT18M16.8S     	client_received=1828/2000	server_resps=1828	codes={200=1828}
                      cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.035846666S 	server_cpu=PT17M55.4S     	client_received=30000/30000	server_resps=30000	codes={200=30000}
                          cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
-                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
+                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.0346S      	server_cpu=PT1.736S       	client_received=50/50	server_resps=54	codes={200=50}
              drastic_slowdown[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT2.947028083S 	server_cpu=PT41M8.862333314S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                  drastic_slowdown[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                            drastic_slowdown[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -9,7 +9,7 @@
                                  black_hole[UNLIMITED_ROUND_ROBIN].txt:	success=91.4%	client_mean=PT0.6S         	server_cpu=PT18M16.8S     	client_received=1828/2000	server_resps=1828	codes={200=1828}
                      cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.138584666S 	server_cpu=PT1H9M17.54S   	client_received=30000/30000	server_resps=30000	codes={200=30000}
                          cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.138103933S 	server_cpu=PT1H9M7.615S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
-                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.138103933S 	server_cpu=PT1H9M7.615S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
+                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.138486133S 	server_cpu=PT1H9M14.584S  	client_received=30000/30000	server_resps=30000	codes={200=30000}
              drastic_slowdown[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT2.947028083S 	server_cpu=PT41M8.862333314S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                  drastic_slowdown[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                            drastic_slowdown[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}

--- a/simulation/src/test/resources/report.md
+++ b/simulation/src/test/resources/report.md
@@ -7,6 +7,9 @@
                    black_hole[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=59.2%	client_mean=PT0.600655114S 	server_cpu=PT11M49.8S     	client_received=1183/2000	server_resps=1183	codes={200=1183}
                        black_hole[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=91.5%	client_mean=PT0.6S         	server_cpu=PT18M17.4S     	client_received=1829/2000	server_resps=1829	codes={200=1829}
                                  black_hole[UNLIMITED_ROUND_ROBIN].txt:	success=91.4%	client_mean=PT0.6S         	server_cpu=PT18M16.8S     	client_received=1828/2000	server_resps=1828	codes={200=1828}
+                     cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT0.035846666S 	server_cpu=PT17M55.4S     	client_received=30000/30000	server_resps=30000	codes={200=30000}
+                         cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
+                                   cross_az[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
              drastic_slowdown[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=100.0%	client_mean=PT2.947028083S 	server_cpu=PT41M8.862333314S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                  drastic_slowdown[CONCURRENCY_LIMITER_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}
                            drastic_slowdown[UNLIMITED_ROUND_ROBIN].txt:	success=100.0%	client_mean=PT0.251969999S 	server_cpu=PT16M47.879999984S	client_received=4000/4000	server_resps=4000	codes={200=4000}
@@ -72,6 +75,21 @@ slowdown_and_error_thresholds[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt:	success=
 ## `black_hole[UNLIMITED_ROUND_ROBIN]`
 <table><tr><th>develop</th><th>current</th></tr>
 <tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/black_hole[UNLIMITED_ROUND_ROBIN].png" /></td><td><image width=400 src="black_hole[UNLIMITED_ROUND_ROBIN].png" /></td></tr></table>
+
+
+## `cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png" /></td><td><image width=400 src="cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].png" /></td></tr></table>
+
+
+## `cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png" /></td><td><image width=400 src="cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].png" /></td></tr></table>
+
+
+## `cross_az[UNLIMITED_ROUND_ROBIN]`
+<table><tr><th>develop</th><th>current</th></tr>
+<tr><td><image width=400 src="https://media.githubusercontent.com/media/palantir/dialogue/develop/simulation/src/test/resources/cross_az[UNLIMITED_ROUND_ROBIN].png" /></td><td><image width=400 src="cross_az[UNLIMITED_ROUND_ROBIN].png" /></td></tr></table>
 
 
 ## `drastic_slowdown[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR]`

--- a/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
+++ b/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.035846666S 	server_cpu=PT17M55.4S     	client_received=30000/30000	server_resps=30000	codes={200=30000}
+success=100.0%	client_mean=PT0.138584666S 	server_cpu=PT1H9M17.54S   	client_received=30000/30000	server_resps=30000	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
+++ b/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_PIN_UNTIL_ERROR].txt
@@ -1,0 +1,1 @@
+success=100.0%	client_mean=PT0.035846666S 	server_cpu=PT17M55.4S     	client_received=30000/30000	server_resps=30000	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
+success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
@@ -1,0 +1,1 @@
+success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[CONCURRENCY_LIMITER_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}
+success=100.0%	client_mean=PT0.138103933S 	server_cpu=PT1H9M7.615S   	client_received=30000/30000	server_resps=32998	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.138103933S 	server_cpu=PT1H9M7.615S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
+success=100.0%	client_mean=PT0.138486133S 	server_cpu=PT1H9M14.584S  	client_received=30000/30000	server_resps=30000	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
@@ -1,0 +1,1 @@
+success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.0346S      	server_cpu=PT1.736S       	client_received=50/50	server_resps=54	codes={200=50}
+success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.030003666S 	server_cpu=PT15M4.607S    	client_received=30000/30000	server_resps=32998	codes={200=30000}
+success=100.0%	client_mean=PT0.138103933S 	server_cpu=PT1H9M7.615S   	client_received=30000/30000	server_resps=32998	codes={200=30000}

--- a/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
+++ b/simulation/src/test/resources/txt/cross_az[UNLIMITED_ROUND_ROBIN].txt
@@ -1,1 +1,1 @@
-success=100.0%	client_mean=PT0.034969333S 	server_cpu=PT17M33.577S   	client_received=30000/30000	server_resps=32998	codes={200=30000}
+success=100.0%	client_mean=PT0.0346S      	server_cpu=PT1.736S       	client_received=50/50	server_resps=54	codes={200=50}


### PR DESCRIPTION
## Before this PR

My original PR contained a bug where I zipped up two arrays by index, but one of them was shuffled and the other wasn't. This made all the fancy RTT measuring _100% pointless_ 🤦.

Luckily we haven't cut a release yet, so I think the first release with BALANCED_RTT should still work!

## After this PR
==COMMIT_MSG==
Fix BALANCED_RTT (and add simulations)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
