### PR TITLE
Try to avoid embedding 0.0.0

### DIFF
--- a/changelog/@unreleased/pr-809.v2.yml
+++ b/changelog/@unreleased/pr-809.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Embedded user-agents will no longer include 0.0.0 if a version can
+    be found in the relevant dialogue jar
+  links:
+  - https://github.com/palantir/dialogue/pull/809

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentEndpointChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentEndpointChannel.java
@@ -56,8 +56,17 @@ final class UserAgentEndpointChannel implements EndpointChannel {
     }
 
     private static UserAgent augmentUserAgent(UserAgent baseAgent, Endpoint endpoint) {
+        String endpointDeclaredVersion = endpoint.version();
+        String endpointJarVersion = endpoint.getClass().getPackage().getImplementationVersion();
+
+        // Until conjure-java 5.14.2, we mistakenly embedded 0.0.0 in everything. This logic attempts
+        // to work-around this and produce a more helpful user agent
+        String endpointVersion = "0.0.0".equals(endpointDeclaredVersion) && endpointJarVersion != null
+                ? endpointJarVersion
+                : endpointDeclaredVersion;
+
         return baseAgent
-                .addAgent(UserAgent.Agent.of(endpoint.serviceName(), endpoint.version()))
+                .addAgent(UserAgent.Agent.of(endpoint.serviceName(), endpointVersion))
                 .addAgent(DIALOGUE_AGENT);
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentEndpointChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentEndpointChannel.java
@@ -56,14 +56,16 @@ final class UserAgentEndpointChannel implements EndpointChannel {
     }
 
     private static UserAgent augmentUserAgent(UserAgent baseAgent, Endpoint endpoint) {
-        String endpointDeclaredVersion = endpoint.version();
-        String endpointJarVersion = endpoint.getClass().getPackage().getImplementationVersion();
+        String endpointVersion = endpoint.version();
 
-        // Until conjure-java 5.14.2, we mistakenly embedded 0.0.0 in everything. This logic attempts
+        // Until conjure-java 5.14.2, we mistakenly embedded 0.0.0 in everything. This fallback logic attempts
         // to work-around this and produce a more helpful user agent
-        String endpointVersion = "0.0.0".equals(endpointDeclaredVersion) && endpointJarVersion != null
-                ? endpointJarVersion
-                : endpointDeclaredVersion;
+        if (endpointVersion.equals("0.0.0")) {
+            String jarVersion = endpoint.getClass().getPackage().getImplementationVersion();
+            if (jarVersion != null) {
+                endpointVersion = jarVersion;
+            }
+        }
 
         return baseAgent
                 .addAgent(UserAgent.Agent.of(endpoint.serviceName(), endpointVersion))


### PR DESCRIPTION
## Before this PR

Looking at graphs of user-agents in our internal log browsing product, there are a _ton_ of things that say `... LogReceiverService/0.0.0 dialogue/1.54.0`. This is because we mistakenly embedded 0.0.0 in all generated code (until https://github.com/palantir/conjure-java/pull/879) and those products have not had a reason to pick up a new log-receiver-api-dialogue jar.

This seems kinda lame, and easy to backfill.

## After this PR
==COMMIT_MSG==
Embedded user-agents will no longer include 0.0.0 if a version can be found in the relevant dialogue jar
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
