### PR TITLE
Improve deprecation slf4j logging

### DIFF
--- a/changelog/@unreleased/pr-812.v2.yml
+++ b/changelog/@unreleased/pr-812.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve deprecation slf4j logging
+  links:
+  - https://github.com/palantir/dialogue/pull/812

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
@@ -85,7 +85,7 @@ final class DeprecationWarningChannel implements EndpointChannel {
             }
 
             meter.mark();
-            if (tryAcquire(channelName, endpoint)) {
+            if (log.isWarnEnabled() && tryAcquire(channelName, endpoint)) {
                 log.warn(
                         "Using a deprecated endpoint when connecting to service",
                         SafeArg.of("channelName", channelName),
@@ -93,7 +93,7 @@ final class DeprecationWarningChannel implements EndpointChannel {
                         SafeArg.of("endpointHttpMethod", endpoint.httpMethod()),
                         SafeArg.of("endpointName", endpoint.endpointName()),
                         SafeArg.of("endpointClientVersion", endpoint.version()),
-                        SafeArg.of("service", response.getFirstHeader("server").orElse("no server header provided")));
+                        SafeArg.of("server", response.getFirstHeader("server").orElse("no server header provided")));
             }
         });
     }


### PR DESCRIPTION
Previously our implementation had several issues:
* Logging was rate limited by service-name only, not including
  endpoint name.
* The logging did not include channel name.
* Multiple instances failed to preserve logging rate limiting,
  for example using the jaxrs shim which creates a new EndpointChannel
  for every request.

==COMMIT_MSG==
Improve deprecation slf4j logging
==COMMIT_MSG==
