### PR TITLE
DialogueClients takes advantage of the EndpointChannel bind optimization

### DIFF
--- a/changelog/@unreleased/pr-818.v2.yml
+++ b/changelog/@unreleased/pr-818.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: Clients constructed using DialogueClients and modern conjure-java (5.17.0+)
+    now spend slightly fewer CPU cycles on each RPC call, because they use the bind
+    method to do per-endpoint setup once at construction time instead of before every
+    rpc. Benchmarks show a 21k -> 27k request/sec improvement against a trivial ping
+    endpoint.
+  links:
+  - https://github.com/palantir/dialogue/pull/818

--- a/dialogue-clients/build.gradle
+++ b/dialogue-clients/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
 
     testImplementation project(':dialogue-test-common')
+    testImplementation project(':dialogue-serde')
     testImplementation project(':dialogue-example:dialogue-example-dialogue')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.clients.ReloadingClientFactory.LiveReloadingChannel;
+import com.palantir.dialogue.example.SampleServiceBlocking;
+import com.palantir.refreshable.Refreshable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReloadingClientFactoryTest {
+    private final DefaultConjureRuntime runtime =
+            DefaultConjureRuntime.builder().build();
+
+    interface Foo extends Channel, EndpointChannelFactory {}
+
+    @Mock
+    Foo channel;
+
+    @Mock
+    EndpointChannel endpointChannel;
+
+    @Test
+    void plain_codegen_uses_the_EndpointChannelFactory() {
+        when(channel.endpoint(any())).thenReturn(endpointChannel);
+
+        SampleServiceBlocking.of(channel, runtime);
+
+        // ensure we use the bind method
+        verify(channel, atLeastOnce()).endpoint(any());
+    }
+
+    @Test
+    void live_reloading_wrapper_still_uses_the_EndpointChannelFactory() {
+        when(channel.endpoint(any())).thenReturn(endpointChannel);
+
+        LiveReloadingChannel live = new LiveReloadingChannel(Refreshable.create(channel), runtime.clients());
+        SampleServiceBlocking.of(live, runtime);
+
+        // ensure we use the bind method
+        verify(channel, atLeastOnce()).endpoint(any());
+    }
+}

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -194,8 +194,8 @@ enum DefaultClients implements Clients {
         private final Channel channel;
 
         EndpointChannelAdapter(Endpoint endpoint, Channel channel) {
-            this.endpoint = endpoint;
-            this.channel = channel;
+            this.endpoint = Preconditions.checkNotNull(endpoint, "Endpoint must not be null");
+            this.channel = Preconditions.checkNotNull(channel, "Channel must not be null");
         }
 
         @Override


### PR DESCRIPTION
## Before this PR

@bavardage reported that he was seeing a lot of the following stacktrace:

```
13:36:34.102 [ForkJoinPool-1-worker-15] DEBUG com.palantir.conjure.java.dialogue.serde.DefaultClients - Channel of type LiveReloadingChannel does not implement EndpointChannelFactory, which is recommended for maximum performance. Falling back to lambda impl.
com.palantir.logsafe.exceptions.SafeRuntimeException: Exception for stacktrace
	at com.palantir.conjure.java.dialogue.serde.DefaultClients.bind(DefaultClients.java:81)
	at com.palantir.conjure.java.dialogue.serde.DefaultClients.call(DefaultClients.java:55)
```

This is pretty sad, because it means I spent all this time building the fancy 'bind' optimization in https://github.com/palantir/dialogue/pull/764, but because LiveReloadingChannel never implemented the magic interface, _nobody was actually getting this optimization!!!_

```
Benchmark                                  Mode  Cnt       Score       Error  Units
EndToEndBenchmark.dialogueBlocking        thrpt   16   21813.837 ±   837.945  ops/s
EndToEndBenchmark.rawApacheBlocking       thrpt   16   20436.592 ±   960.568  ops/s
EndToEndBenchmark.setZeroNetworkDialogue  thrpt   16  371603.457 ± 10369.373  ops/s
```

## After this PR
==COMMIT_MSG==
Clients constructed using `DialogueClients` and modern conjure-java (5.17.0+) now spend slightly fewer CPU cycles on each RPC call, because they use the `bind` method to do per-endpoint setup once at construction time instead of before every rpc. Benchmarks show a 21k -> 27k request/sec improvement against a trivial ping endpoint.
==COMMIT_MSG==

```
Benchmark                                  Mode  Cnt       Score       Error  Units
EndToEndBenchmark.dialogueBlocking        thrpt   16   27345.824 ±  1843.425  ops/s
EndToEndBenchmark.rawApacheBlocking       thrpt   16   25026.853 ±  1958.190  ops/s
EndToEndBenchmark.setZeroNetworkDialogue  thrpt   16  376254.738 ± 23785.571  ops/s
```

## Possible downsides?
- This mistake happened because we're using an instanceof check to detect when to go on the fast path, so the types weren't clear enough. This is probably gonna hit us again unless we fix this.
