### PR TITLE
parse header BALANCED_RTT2

### DIFF
--- a/changelog/@unreleased/pr-819.v2.yml
+++ b/changelog/@unreleased/pr-819.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: The `BALANCED_RTT2` node-selection-strategy header can be used to enable
+    the experimental dialogue feature that prioritises routing traffic towards the
+    lowest latency node.
+  links:
+  - https://github.com/palantir/dialogue/pull/819

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueNodeSelectionStrategy.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueNodeSelectionStrategy.java
@@ -37,7 +37,7 @@ enum DialogueNodeSelectionStrategy {
     PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE,
     BALANCED,
     @Beta
-    BALANCED_RTT,
+    BALANCED_RTT2,
     UNKNOWN;
 
     private static final Logger log = LoggerFactory.getLogger(DialogueNodeSelectionStrategy.class);
@@ -62,8 +62,8 @@ enum DialogueNodeSelectionStrategy {
                 return PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE;
             case "BALANCED":
                 return BALANCED;
-            case "BALANCED_RTT":
-                return BALANCED_RTT;
+            case "BALANCED_RTT2":
+                return BALANCED_RTT2;
         }
 
         log.info("Received unknown selection strategy {}", SafeArg.of("strategy", string));

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -144,7 +144,7 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
                         .channel(new BalancedNodeSelectionStrategyChannel(
                                 channels, random, tick, metrics, channelName, RttSampling.DEFAULT_OFF))
                         .build();
-            case BALANCED_RTT:
+            case BALANCED_RTT2:
                 return channelBuilder
                         .channel(new BalancedNodeSelectionStrategyChannel(
                                 channels, random, tick, metrics, channelName, RttSampling.ENABLED))

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueNodeSelectionStrategyTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueNodeSelectionStrategyTest.java
@@ -32,8 +32,8 @@ class DialogueNodeSelectionStrategyTest {
     void parses_multiple_strategies() {
         assertThat(DialogueNodeSelectionStrategy.fromHeader("BALANCED, PIN_UNTIL_ERROR"))
                 .containsExactly(DialogueNodeSelectionStrategy.BALANCED, DialogueNodeSelectionStrategy.PIN_UNTIL_ERROR);
-        assertThat(DialogueNodeSelectionStrategy.fromHeader("BALANCED_RTT, BALANCED"))
-                .containsExactly(DialogueNodeSelectionStrategy.BALANCED_RTT, DialogueNodeSelectionStrategy.BALANCED);
+        assertThat(DialogueNodeSelectionStrategy.fromHeader("BALANCED_RTT2,BALANCED"))
+                .containsExactly(DialogueNodeSelectionStrategy.BALANCED_RTT2, DialogueNodeSelectionStrategy.BALANCED);
         assertThat(DialogueNodeSelectionStrategy.fromHeader("BALANCED_FUTURE_EXPERIMENT, BALANCED"))
                 .containsExactly(DialogueNodeSelectionStrategy.UNKNOWN, DialogueNodeSelectionStrategy.BALANCED);
     }

--- a/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/SimulationTest.java
@@ -550,7 +550,7 @@ final class SimulationTest {
     private static String serverSideNodeSelectionStrategy(Strategy strategy) {
         switch (strategy) {
             case CONCURRENCY_LIMITER_ROUND_ROBIN:
-                return "BALANCED_RTT";
+                return "BALANCED_RTT2";
             case CONCURRENCY_LIMITER_PIN_UNTIL_ERROR:
                 return "PIN_UNTIL_ERROR";
             case UNLIMITED_ROUND_ROBIN:


### PR DESCRIPTION
## Before this PR

I can't use the BALANCED_RTT header anymore because clients out there might still have the buggy code that caused pds-121981. However, since carter has landed the fix for this in https://github.com/palantir/dialogue/pull/814, we should be able to use a new header to unblock a new gradual rollout.

## After this PR
==COMMIT_MSG==
The `BALANCED_RTT2` node-selection-strategy header can be used to enable the experimental dialogue feature that prioritises routing traffic towards the lowest latency node.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
