### PR TITLE
Fix the Encodings.AbstractJacksonEncoding serializer error message

### DIFF
--- a/changelog/@unreleased/pr-823.v2.yml
+++ b/changelog/@unreleased/pr-823.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix the Encodings.AbstractJacksonEncoding serializer error message
+  links:
+  - https://github.com/palantir/dialogue/pull/823

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encodings.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encodings.java
@@ -58,7 +58,7 @@ public final class Encodings {
                 try {
                     writer.writeValue(output, value);
                 } catch (IOException e) {
-                    throw new SafeRuntimeException("Failed to serialize payload, this is a bug", e);
+                    throw new SafeRuntimeException("Failed to serialize payload", e);
                 }
             };
         }


### PR DESCRIPTION
It's not necessarily a bug when serialization fails, we write
directly to the socket which may fail if there's a problem
in the network layer or the remote server rejects the
request.

==COMMIT_MSG==
Fix the Encodings.AbstractJacksonEncoding serializer error message
==COMMIT_MSG==
