### PR TITLE
DialogueException whitelists some messages

### DIFF
--- a/changelog/@unreleased/pr-825.v2.yml
+++ b/changelog/@unreleased/pr-825.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: DialogueException propagates certain known-safe exception messages
+  links:
+  - https://github.com/palantir/dialogue/pull/825

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
@@ -48,6 +48,7 @@ final class DialogueException extends RuntimeException implements SafeLoggable {
             case "Connection reset":
             case "Connection reset by peer":
             case "Broken pipe (Write failed)":
+            case "The target server failed to respond":
                 return cause.getMessage();
             default:
                 return MESSAGE;

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
@@ -44,16 +44,11 @@ final class DialogueException extends RuntimeException implements SafeLoggable {
             return MESSAGE;
         }
 
-        String causeMessage = cause.getMessage();
-        if (causeMessage == null) {
-            return MESSAGE;
-        }
-
-        switch (causeMessage) {
+        switch (cause.getMessage()) {
             case "Connection reset":
             case "Connection reset by peer":
             case "Broken pipe (Write failed)":
-                return causeMessage;
+                return cause.getMessage();
             default:
                 return MESSAGE;
         }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
@@ -44,12 +44,16 @@ final class DialogueException extends RuntimeException implements SafeLoggable {
             return MESSAGE;
         }
 
-        switch (cause.getMessage()) {
+        String causeMessage = cause.getMessage();
+        if (causeMessage == null) {
+            return MESSAGE;
+        }
+
+        switch (causeMessage) {
             case "Connection reset":
             case "Connection reset by peer":
             case "Broken pipe (Write failed)":
-            case "The target server failed to respond":
-                return cause.getMessage();
+                return causeMessage;
             default:
                 return MESSAGE;
         }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
@@ -53,6 +53,8 @@ final class DialogueException extends RuntimeException implements SafeLoggable {
             case "Connection reset":
             case "Connection reset by peer":
             case "Broken pipe (Write failed)":
+            case "Remote host terminated the handshake":
+            case "SSL peer shut down incorrectly":
                 return causeMessage;
             default:
                 return MESSAGE;

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DialogueException.java
@@ -26,7 +26,7 @@ final class DialogueException extends RuntimeException implements SafeLoggable {
     private static final String MESSAGE = "Dialogue transport failure";
 
     DialogueException(Throwable cause) {
-        super(MESSAGE, cause);
+        super(copyWhitelistedSafeMessages(cause), cause);
     }
 
     @Override
@@ -37,5 +37,25 @@ final class DialogueException extends RuntimeException implements SafeLoggable {
     @Override
     public List<Arg<?>> getArgs() {
         return ImmutableList.of();
+    }
+
+    private static String copyWhitelistedSafeMessages(Throwable cause) {
+        if (cause == null) {
+            return MESSAGE;
+        }
+
+        String causeMessage = cause.getMessage();
+        if (causeMessage == null) {
+            return MESSAGE;
+        }
+
+        switch (causeMessage) {
+            case "Connection reset":
+            case "Connection reset by peer":
+            case "Broken pipe (Write failed)":
+                return causeMessage;
+            default:
+                return MESSAGE;
+        }
     }
 }


### PR DESCRIPTION
## Before this PR

I was just fixing up some tests in WC and saw the following stacktrace:

```
com.palantir.conjure.java.dialogue.serde.DialogueException: Dialogue transport failure

	at com.palantir.conjure.java.dialogue.serde.DefaultClients.block(DefaultClients.java:131)
	at com.palantir.conjure.java.client.jaxrs.DialogueFeignClient.execute(DialogueFeignClient.java:103)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:97)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:76)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
	at com.sun.proxy.$Proxy39.get(Unknown Source)
	at com.palantir.witchcraft.UndertowServerTests.endpoint_takes_precedence_over_fallback(UndertowServerTests.java:200)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: javax.net.ssl.SSLException: Connection reset
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:127)
```

It struck me that this would actually be kinda annoying to debug in production, because the `Connection reset` message would be redacted, requiring extra manual steps to get access to.

## After this PR
==COMMIT_MSG==
DialogueException propagates certain known-safe exception messages
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
