### PR TITLE
BlockingChannelAdapter never throws

### DIFF
--- a/changelog/@unreleased/pr-830.v2.yml
+++ b/changelog/@unreleased/pr-830.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: BlockingChannelAdapter never throws, even if the user-provided `executor`
+    does something unexpected
+  links:
+  - https://github.com/palantir/dialogue/pull/830

--- a/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
+++ b/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
@@ -76,11 +76,6 @@ public final class BlockingChannelAdapter {
 
         @Override
         public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
-            if (Thread.currentThread().isInterrupted()) {
-                // is someone asked to interrupt this thread, we abort early to avoid kicking off network requests
-                return Futures.immediateCancelledFuture();
-            }
-
             SettableFuture<Response> settableFuture = SettableFuture.create();
             BlockingChannelAdapterTask runnable =
                     new BlockingChannelAdapterTask(delegate, endpoint, request, settableFuture);

--- a/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
+++ b/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
@@ -76,6 +76,11 @@ public final class BlockingChannelAdapter {
 
         @Override
         public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+            if (Thread.currentThread().isInterrupted()) {
+                // is someone asked to interrupt this thread, we abort early to avoid kicking off network requests
+                return Futures.immediateCancelledFuture();
+            }
+
             SettableFuture<Response> settableFuture = SettableFuture.create();
             BlockingChannelAdapterTask runnable =
                     new BlockingChannelAdapterTask(delegate, endpoint, request, settableFuture);

--- a/dialogue-blocking-channels/src/test/java/com/palantir/dialogue/blocking/BlockingChannelAdapterTest.java
+++ b/dialogue-blocking-channels/src/test/java/com/palantir/dialogue/blocking/BlockingChannelAdapterTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -136,5 +137,18 @@ public class BlockingChannelAdapterTest {
         assertThatThrownBy(future::get)
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(RejectedExecutionException.class);
+    }
+
+    @Test
+    void testAlreadyInterrupted() {
+        BlockingChannel delegate = mock(BlockingChannel.class);
+        Channel channel = BlockingChannelAdapter.of(delegate, executor);
+
+        Thread.currentThread().interrupt();
+        ListenableFuture<Response> future =
+                channel.execute(TestEndpoint.POST, Request.builder().build());
+
+        verifyNoInteractions(delegate);
+        assertThat(future).isCancelled();
     }
 }

--- a/dialogue-blocking-channels/src/test/java/com/palantir/dialogue/blocking/BlockingChannelAdapterTest.java
+++ b/dialogue-blocking-channels/src/test/java/com/palantir/dialogue/blocking/BlockingChannelAdapterTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -137,18 +136,5 @@ public class BlockingChannelAdapterTest {
         assertThatThrownBy(future::get)
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(RejectedExecutionException.class);
-    }
-
-    @Test
-    void testAlreadyInterrupted() {
-        BlockingChannel delegate = mock(BlockingChannel.class);
-        Channel channel = BlockingChannelAdapter.of(delegate, executor);
-
-        Thread.currentThread().interrupt();
-        ListenableFuture<Response> future =
-                channel.execute(TestEndpoint.POST, Request.builder().build());
-
-        verifyNoInteractions(delegate);
-        assertThat(future).isCancelled();
     }
 }


### PR DESCRIPTION
## Before this PR

Part of the contract of a Channel is that `execute` should never throw, but instead send back a failed future. We recently saw some stacktraces from `delivery-metadata` internally that violated this, and were only caught by the NeverThrowChannel:

```
java.util.concurrent.RejectedExecutionException:
	at org.jboss.threads.RejectingExecutor.execute(RejectingExecutor.java:38)
	at org.jboss.threads.EnhancedQueueExecutor.rejectShutdown(EnhancedQueueExecutor.java:2089)
	at org.jboss.threads.EnhancedQueueExecutor.execute(EnhancedQueueExecutor.java:767)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:118)
	at com.palantir.tritium.metrics.TaggedMetricsExecutorService.submit(TaggedMetricsExecutorService.java:61)
	at com.palantir.tracing.WrappingExecutorService.submit(WrappingExecutorService.java:102)
	at com.google.common.util.concurrent.ForwardingExecutorService.submit(ForwardingExecutorService.java:109)
	at com.palantir.dialogue.blocking.BlockingChannelAdapter$BlockingChannelAdapterChannel.execute(BlockingChannelAdapter.java:82)
	at com.palantir.dialogue.core.HostMetricsChannel.execute(HostMetricsChannel.java:76)
	at com.palantir.dialogue.core.NeverThrowChannel.execute(NeverThrowChannel.java:49)
```

## After this PR
==COMMIT_MSG==
BlockingChannelAdapter never throws, even if the user-provided `executor` does something unexpected
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
