### PR TITLE
Thread interruption behaviour

### DIFF
--- a/changelog/@unreleased/pr-831.v2.yml
+++ b/changelog/@unreleased/pr-831.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: When the `interrupted` flag is set on a thread, any attempt to make
+    Dialogue network calls from that thread will immediately short-circuit and return
+    a `SafeRuntimeException`.
+  links:
+  - https://github.com/palantir/dialogue/pull/831

--- a/changelog/@unreleased/pr-831.v2.yml
+++ b/changelog/@unreleased/pr-831.v2.yml
@@ -2,6 +2,6 @@ type: improvement
 improvement:
   description: When the `interrupted` flag is set on a thread, any attempt to make
     Dialogue network calls from that thread will immediately short-circuit and return
-    a `SafeRuntimeException`.
+    a `DialogueException` with an `InterruptedException` cause.
   links:
   - https://github.com/palantir/dialogue/pull/831

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -139,6 +139,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = new ContentDecodingChannel(channel);
                 channel = TracedChannel.create(channel, endpoint);
                 channel = TimingEndpointChannel.create(cf, channel, endpoint);
+                channel = new InterruptionChannel(channel);
                 return NeverThrowChannel.create(channel); // this must come last as a defensive backstop
             };
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/InterruptionChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/InterruptionChannel.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+
+final class InterruptionChannel implements EndpointChannel {
+    private final EndpointChannel endpointChannel;
+
+    InterruptionChannel(EndpointChannel endpointChannel) {
+        this.endpointChannel = endpointChannel;
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Request request) {
+        if (Thread.currentThread().isInterrupted()) {
+            return Futures.immediateFailedFuture(new InterruptedException());
+        }
+
+        return endpointChannel.execute(request);
+    }
+
+    @Override
+    public String toString() {
+        return "DetectInterruptionChannel{" + endpointChannel + '}';
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/InterruptionChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/InterruptionChannel.java
@@ -40,6 +40,6 @@ final class InterruptionChannel implements EndpointChannel {
 
     @Override
     public String toString() {
-        return "DetectInterruptionChannel{" + endpointChannel + '}';
+        return "InterruptionChannel{" + endpointChannel + '}';
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.Futures;
@@ -135,6 +137,23 @@ public final class DialogueChannelTest {
 
         // only when we access things do we allow exceptions
         assertThatThrownBy(() -> Futures.getUnchecked(future)).hasCauseInstanceOf(NoClassDefFoundError.class);
+    }
+
+    @Test
+    public void when_thread_is_interrupted_no_calls_to_delegate() {
+        Channel delegate = mock(Channel.class);
+
+        channel = DialogueChannel.builder()
+                .channelName("my-channel")
+                .clientConfiguration(stubConfig)
+                .channelFactory(_uri -> delegate)
+                .build();
+
+        Thread.currentThread().interrupt();
+        ListenableFuture<Response> future = channel.execute(endpoint, request);
+
+        assertThat(future).isDone();
+        verifyNoInteractions(delegate);
     }
 
     @Test

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
@@ -153,6 +153,7 @@ public final class DialogueChannelTest {
         ListenableFuture<Response> future = channel.execute(endpoint, request);
 
         assertThat(future).isDone();
+        assertThat(future).isNotCancelled();
         verifyNoInteractions(delegate);
     }
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/InterruptionChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/InterruptionChannelTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InterruptionChannelTest {
+
+    @Mock
+    EndpointChannel delegate;
+
+    @Test
+    void name() {
+        InterruptionChannel channel = new InterruptionChannel(delegate);
+
+        Thread.currentThread().interrupt();
+        ListenableFuture<Response> future = channel.execute(Request.builder().build());
+
+        assertThat(future).isDone();
+    }
+}

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -102,7 +102,7 @@ enum DefaultClients implements Clients {
             if (!future.cancel(true)) {
                 Futures.addCallback(future, CancelListener.INSTANCE, MoreExecutors.directExecutor());
             }
-            throw new SafeRuntimeException("Interrupted waiting for future", e);
+            throw new DialogueException(e);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
 

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
@@ -104,8 +104,8 @@ public class DefaultClientsBlockingTest {
         ListenableFuture<Object> future = SettableFuture.create();
         Thread.currentThread().interrupt();
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(future))
-                .isInstanceOf(SafeRuntimeException.class)
-                .hasMessage("Interrupted waiting for future");
+                .isInstanceOf(DialogueException.class)
+                .hasCauseInstanceOf(InterruptedException.class);
         // Clear interrupted state as well as test.
         assertThat(Thread.interrupted())
                 .as("getUnchecked should not clear interrupted state")
@@ -120,8 +120,8 @@ public class DefaultClientsBlockingTest {
         future.set(responseBody);
         Thread.currentThread().interrupt();
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(future))
-                .isInstanceOf(SafeRuntimeException.class)
-                .hasMessage("Interrupted waiting for future");
+                .isInstanceOf(DialogueException.class)
+                .hasCauseInstanceOf(InterruptedException.class);
         // Clear interrupted state as well as test.
         assertThat(Thread.interrupted())
                 .as("getUnchecked should not clear interrupted state")
@@ -136,8 +136,8 @@ public class DefaultClientsBlockingTest {
         future.set(Optional.of(responseBody));
         Thread.currentThread().interrupt();
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(future))
-                .isInstanceOf(SafeRuntimeException.class)
-                .hasMessage("Interrupted waiting for future");
+                .isInstanceOf(DialogueException.class)
+                .hasCauseInstanceOf(InterruptedException.class);
         // Clear interrupted state as well as test.
         assertThat(Thread.interrupted())
                 .as("getUnchecked should not clear interrupted state")


### PR DESCRIPTION
## Before this PR

Saw some logs recently from `delivery-metadata` which I _think_ are coming from around the time that things are shutting down.  This made me realise that because we don't check `Thread.isInterrupted()` we might be running a bunch of code even after a user has asked a thread to stop, which might result in confusing exceptions.

## After this PR
==COMMIT_MSG==
When the `interrupted` flag is set on a thread, any attempt to make Dialogue network calls from that thread will immediately short-circuit and return a `SafeRuntimeException`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
