### PR TITLE
Response implementations provide a delegating getFirstHeader override

### DIFF
--- a/changelog/@unreleased/pr-832.v2.yml
+++ b/changelog/@unreleased/pr-832.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Response implementations provide a delegating getFirstHeader override
+  links:
+  - https://github.com/palantir/dialogue/pull/832

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -118,6 +118,14 @@ final class ContentDecodingChannel implements EndpointChannel {
             return headers;
         }
 
+        @Override
+        public Optional<String> getFirstHeader(String header) {
+            if (!allowHeader(header)) {
+                return Optional.empty();
+            }
+            return delegate.getFirstHeader(header);
+        }
+
         // Remove the content-encoding header once content is decompressed, otherwise consumers may attempt
         // to decode again.
         private static boolean allowHeader(String headerName) {

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -295,6 +295,11 @@ final class SimulationServer implements Channel {
             }
 
             @Override
+            public Optional<String> getFirstHeader(String header) {
+                return delegate.getFirstHeader(header);
+            }
+
+            @Override
             public void close() {
                 sim.globalResponseClose.inc();
                 delegate.close();


### PR DESCRIPTION
This method is substantially more performant in some cases as it
can avoid building an entire ListMultimap

## After this PR
==COMMIT_MSG==
Response implementations provide a delegating getFirstHeader override
==COMMIT_MSG==
