### PR TITLE
Drop the log level of RttSampler bounds checking

### DIFF
--- a/changelog/@unreleased/pr-839.v2.yml
+++ b/changelog/@unreleased/pr-839.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Drop the log level of RttSampler bounds checking because there's nothing
+    to worry about.
+  links:
+  - https://github.com/palantir/dialogue/pull/839

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RttSampler.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RttSampler.java
@@ -104,7 +104,7 @@ final class RttSampler {
             OptionalLong rtt = snapshots[i];
             float rttSpectrum = rtt.isPresent() ? ((float) (rtt.getAsLong() - bestRttNanos)) / rttRange : 0;
             if (rttSpectrum < 0f || rttSpectrum > 1f) {
-                log.warn(
+                log.info(
                         "rttSpectrum should be between 0 and 1",
                         SafeArg.of("value", Float.toString(rttSpectrum)),
                         SafeArg.of("hostIndex", i));


### PR DESCRIPTION
This check used to throw, but small variances allowed values to be
a hair beyond 1.0. There's no reason to alarm product owners
when this happens.

==COMMIT_MSG==
Drop the log level of RttSampler bounds checking because there's nothing to worry about.
==COMMIT_MSG==
