### PR TITLE
Disable hc5 revapi until we've published a release

### DIFF
--- a/changelog/@unreleased/pr-840.v2.yml
+++ b/changelog/@unreleased/pr-840.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix hc5 module publications
+  links:
+  - https://github.com/palantir/dialogue/pull/840

--- a/dialogue-apache-hc5-client/build.gradle
+++ b/dialogue-apache-hc5-client/build.gradle
@@ -1,6 +1,5 @@
 apply from: "$rootDir/gradle/publish-jar.gradle"
 apply plugin: 'com.palantir.metric-schema'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
     api project(':dialogue-core')


### PR DESCRIPTION
==COMMIT_MSG==
Fix hc5 module publications
==COMMIT_MSG==
