### PR TITLE
Prevent clients from being collected while streams are read

### DIFF
--- a/changelog/@unreleased/pr-844.v2.yml
+++ b/changelog/@unreleased/pr-844.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Prevent clients from being collected while streams are read
+  links:
+  - https://github.com/palantir/dialogue/pull/844


### PR DESCRIPTION
This fixes a subtle, uncommon issue where clients are created for
a single use, and an InputStream is returned after which the client
can be freed. If the garbage collector reaped the client before
the stream was finished being read, a socketexception was thrown.

==COMMIT_MSG==
Prevent clients from being collected while streams are read
==COMMIT_MSG==

I tried to put together a reasonable test for this without much success, but verified in a heap dump that the only reference to the client instance was the finalizer queue before this fix, and not after.