### PR TITLE
Dialogue url encoding escapes uri sub-delimiter characters

### DIFF
--- a/changelog/@unreleased/pr-854.v2.yml
+++ b/changelog/@unreleased/pr-854.v2.yml
@@ -1,0 +1,14 @@
+type: fix
+fix:
+  description: |-
+    Dialogue url encoding escapes Uri sub-delimiter characters.
+    The BaseUrl encoder was implemented to strictly follow rfc3986
+    URI generic syntax, however it did not take into account the
+    [section-3.3](https://tools.ietf.org/html/rfc3986#section-3.3)
+    which describes scheme-specific (http, in our case) reserved
+    characters.
+    We ensure broader compatibility with existing http infrastructure
+    by encoding characters that may be used by some http client and
+    server implementations.
+  links:
+  - https://github.com/palantir/dialogue/pull/854

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -219,12 +219,14 @@ public final class BaseUrl {
         private static final CharMatcher UNRESERVED = DIGIT.or(ALPHA).or(CharMatcher.anyOf("-._~"));
         private static final CharMatcher SUB_DELIMS = CharMatcher.anyOf("!$&'()*+,;=");
         private static final CharMatcher IS_HOST = UNRESERVED.or(SUB_DELIMS);
-        private static final CharMatcher IS_P_CHAR = UNRESERVED.or(SUB_DELIMS);
+        private static final CharMatcher IS_P_CHAR = UNRESERVED;
         private static final CharMatcher IS_PATH = UNRESERVED.or(SUB_DELIMS).or(CharMatcher.anyOf("/"));
-        // The RFC permits percent-encoding any character. We also percent encode '+' because otherwise most servers
-        // interpret it as an url encoded space.
-        private static final CharMatcher IS_QUERY_CHAR =
-                IS_P_CHAR.or(CharMatcher.anyOf("/?")).and(CharMatcher.noneOf("=&+"));
+        // The RFC permits percent-encoding any character. We also percent encode sub-delimiters to avoid
+        // incompatibilities with http specification beyond the general URI definition per
+        // https://tools.ietf.org/html/rfc3986#section-3.3
+        // > URI producing applications often use the reserved characters allowed in a segment to
+        // > delimit scheme-specific or dereference-handler-specific subcomponents.
+        private static final CharMatcher IS_QUERY_CHAR = IS_P_CHAR.or(CharMatcher.anyOf("/?"));
 
         static boolean isHost(String maybeHost) {
             return IS_HOST.matchesAllOf(maybeHost) || isIpv6Host(maybeHost);

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -66,7 +66,8 @@ public final class UrlBuilderTest {
                         .pathSegment("!@#$%^&*()_+{}[]|\\|\"':;/?.>,<~`")
                         .build()
                         .toString())
-                .isEqualTo("http://host:80/!%40%23$%25%5E&*()_+%7B%7D%5B%5D%7C%5C%7C%22'%3A;%2F%3F.%3E,%3C~%60");
+                .isEqualTo("http://host:80/%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
+                        + "%5B%5D%7C%5C%7C%22%27%3A%3B%2F%3F.%3E%2C%3C~%60");
     }
 
     @Test
@@ -114,7 +115,7 @@ public final class UrlBuilderTest {
     public void encodesQueryParams() throws Exception {
         assertThat(minimalUrl().queryParam("foo", "bar").build().toString()).isEqualTo("http://host:80?foo=bar");
         assertThat(minimalUrl().queryParam("question?&", "answer!&").build().toString())
-                .isEqualTo("http://host:80?question?%26=answer!%26");
+                .isEqualTo("http://host:80?question?%26=answer%21%26");
     }
 
     @Test
@@ -153,14 +154,15 @@ public final class UrlBuilderTest {
 
     @Test
     public void urlEncoder_encodePathSegment_onlyEncodesNonReservedChars() {
-        String nonReserved = "aAzZ09!$&'()*+,;=";
+        String nonReserved = "aAzZ09";
         assertThat(BaseUrl.UrlEncoder.encodePathSegment(nonReserved)).isEqualTo(nonReserved);
-        assertThat(BaseUrl.UrlEncoder.encodePathSegment("/")).isEqualTo("%2F");
+        assertThat(BaseUrl.UrlEncoder.encodePathSegment("/!$&'()*+,;="))
+                .isEqualTo("%2F%21%24%26%27%28%29%2A%2B%2C%3B%3D");
     }
 
     @Test
     public void urlEncoder_encodeQuery_onlyEncodesNonReservedChars() {
-        String nonReserved = "aAzZ09!$'()*,;/?";
+        String nonReserved = "aAzZ09/?";
         assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue(nonReserved)).isEqualTo(nonReserved);
         assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("@[]{}ßçö"))
                 .isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");


### PR DESCRIPTION
==COMMIT_MSG==
Dialogue url encoding escapes Uri sub-delimiter characters.
The BaseUrl encoder was implemented to strictly follow rfc3986
URI generic syntax, however it did not take into account the
[section-3.3](https://tools.ietf.org/html/rfc3986#section-3.3)
which describes scheme-specific (http, in our case) reserved
characters.
We ensure broader compatibility with existing http infrastructure
by encoding characters that may be used by some http client and
server implementations.
==COMMIT_MSG==
