### PR TITLE
RetryingChannel scheduler uses daemon threads

### DIFF
--- a/changelog/@unreleased/pr-858.v2.yml
+++ b/changelog/@unreleased/pr-858.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: RetryingChannel scheduler uses daemon threads and no longer keeps the
+    JVM alive on its own.
+  links:
+  - https://github.com/palantir/dialogue/pull/858

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -75,7 +75,7 @@ final class RetryingChannel implements EndpointChannel {
                     SharedTaggedMetricRegistries.getSingleton(),
                     new ThreadFactoryBuilder()
                             .setNameFormat(SCHEDULER_NAME + "-%d")
-                            .setDaemon(false)
+                            .setDaemon(true)
                             .build(),
                     SCHEDULER_NAME)));
 


### PR DESCRIPTION
==COMMIT_MSG==
RetryingChannel scheduler uses daemon threads and no longer keeps the JVM alive on its own.
==COMMIT_MSG==
