### PR TITLE
Reduce peak thread count using a scheduled executor for eviction

### DIFF
--- a/changelog/@unreleased/pr-859.v2.yml
+++ b/changelog/@unreleased/pr-859.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce peak thread count using a scheduled executor for eviction
+  links:
+  - https://github.com/palantir/dialogue/pull/859

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closer;
 import com.google.common.primitives.Ints;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.conjure.java.api.config.service.BasicCredentials;
 import com.palantir.conjure.java.client.config.CipherSuites;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
@@ -50,7 +49,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ThreadFactory;
 import java.util.stream.LongStream;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSocketFactory;
@@ -441,18 +439,6 @@ public final class ApacheHttpClientChannels {
                     Duration.ofMillis(idleConnectionTimeoutMillis));
             return CloseableClient.wrap(apacheClient, name, connectionManager, connectionEvictorFuture, conf, executor);
         }
-    }
-
-    private static ThreadFactory idleConnectionEvictorThreadFactory(String clientName, TaggedMetricRegistry metrics) {
-        Preconditions.checkNotNull(clientName, "Client name is required");
-        Preconditions.checkNotNull(metrics, "TaggedMetricRegistry is required");
-        return MetricRegistries.instrument(
-                metrics,
-                new ThreadFactoryBuilder()
-                        .setNameFormat(clientName + "-IdleConnectionEvictor-%d")
-                        .setDaemon(true)
-                        .build(),
-                "DialogueIdleConnectionEvictor");
     }
 
     /**

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import com.google.common.base.Suppliers;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.tritium.metrics.MetricRegistries;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.hc.core5.pool.ConnPoolControl;
+import org.apache.hc.core5.util.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Connection evictor based on the hc5 IdleConnectionEvictor, but using a scheduled executor instead of
+ * a new thread for each pool.
+ */
+final class ScheduledIdleConnectionEvictor {
+    private static final Logger log = LoggerFactory.getLogger(ScheduledIdleConnectionEvictor.class);
+    private static final String EXECUTOR_NAME = "DialogueIdleConnectionEvictor";
+    /*
+     * Shared single thread executor is reused between idle connection evictors.
+     */
+    @SuppressWarnings("deprecation") // Singleton registry for a singleton executor
+    private static final Supplier<ScheduledExecutorService> sharedScheduler =
+            Suppliers.memoize(() -> Executors.newSingleThreadScheduledExecutor(MetricRegistries.instrument(
+                    SharedTaggedMetricRegistries.getSingleton(),
+                    new ThreadFactoryBuilder()
+                            .setNameFormat(EXECUTOR_NAME + "-%d")
+                            .setDaemon(true)
+                            .build(),
+                    EXECUTOR_NAME)));
+
+    static ScheduledFuture<?> schedule(
+            ConnPoolControl<?> connectionManager, Duration delayBetweenChecks, Duration maxIdleTime) {
+        return schedule(connectionManager, delayBetweenChecks, maxIdleTime, sharedScheduler.get());
+    }
+
+    private static ScheduledFuture<?> schedule(
+            ConnPoolControl<?> connectionManager,
+            Duration delayBetweenChecks,
+            Duration maxIdleTime,
+            ScheduledExecutorService scheduler) {
+        return scheduler.scheduleWithFixedDelay(
+                () -> {
+                    try {
+                        connectionManager.closeExpired();
+                        connectionManager.closeIdle(TimeValue.ofMilliseconds(maxIdleTime.toMillis()));
+                    } catch (RuntimeException | Error e) {
+                        log.warn("Exception caught while evicting idle connections", e);
+                    }
+                },
+                delayBetweenChecks.toMillis(),
+                delayBetweenChecks.toMillis(),
+                TimeUnit.MILLISECONDS);
+    }
+}

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
@@ -74,4 +74,6 @@ final class ScheduledIdleConnectionEvictor {
                 delayBetweenChecks.toMillis(),
                 TimeUnit.MILLISECONDS);
     }
+
+    private ScheduledIdleConnectionEvictor() {}
 }


### PR DESCRIPTION
## Before this PR

Previously each connection pool had its own idle connection eviction
thread which slept in a loop.

## After this PR
Now we reuse a single threaded
scheduled executor to schedule all evictions.
==COMMIT_MSG==
Reduce peak thread count using a scheduled executor for eviction
==COMMIT_MSG==

## Possible downsides?
This scheduler isn't passed in, and is a global singleton. Singletons are bad. However, this singleton is shared between all consumers (jaxrsclients, DialogueClients, wc factory, etc) to reduce thread churn.
It's possible a misbehaving pool could have a bug which results in the eviction thread blocking for longer than we expect.
