### PR TITLE
use metric-schema for our lazy gauges

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:3.30.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.3.0'
-        classpath 'com.palantir.metricschema:gradle-metric-schema:0.5.7'
+        classpath 'com.palantir.metricschema:gradle-metric-schema:0.5.8'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:4.25.0'
     }
 }

--- a/changelog/@unreleased/pr-860.v2.yml
+++ b/changelog/@unreleased/pr-860.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: All Dialogue metrics now use metric-schema generated code, ensuring
+    that they all have libraryName & libraryVersion tags.
+  links:
+  - https://github.com/palantir/dialogue/pull/860

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -35,7 +35,6 @@ import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tritium.metrics.MetricRegistries;
-import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.Closeable;
 import java.io.IOException;
@@ -116,32 +115,37 @@ public final class ApacheHttpClientChannels {
             TaggedMetricRegistry taggedMetrics,
             String clientName,
             PoolingHttpClientConnectionManager connectionManager) {
+
         DialogueInternalWeakReducingGauge.getOrCreate(
                 taggedMetrics,
-                clientPoolSizeMetricName(clientName, "idle"),
+                DialogueClientPoolMetrics.of(taggedMetrics)
+                        .size()
+                        .clientName(clientName)
+                        .state("idle")
+                        .buildMetricName(),
                 pool -> pool.getTotalStats().getAvailable(),
                 LongStream::sum,
                 connectionManager);
         DialogueInternalWeakReducingGauge.getOrCreate(
                 taggedMetrics,
-                clientPoolSizeMetricName(clientName, "leased"),
+                DialogueClientPoolMetrics.of(taggedMetrics)
+                        .size()
+                        .clientName(clientName)
+                        .state("leased")
+                        .buildMetricName(),
                 pool -> pool.getTotalStats().getLeased(),
                 LongStream::sum,
                 connectionManager);
         DialogueInternalWeakReducingGauge.getOrCreate(
                 taggedMetrics,
-                clientPoolSizeMetricName(clientName, "pending"),
+                DialogueClientPoolMetrics.of(taggedMetrics)
+                        .size()
+                        .clientName(clientName)
+                        .state("pending")
+                        .buildMetricName(),
                 pool -> pool.getTotalStats().getPending(),
                 LongStream::sum,
                 connectionManager);
-    }
-
-    private static MetricName clientPoolSizeMetricName(String clientName, String state) {
-        return MetricName.builder()
-                .safeName("dialogue.client.pool.size")
-                .putSafeTags("client-name", clientName)
-                .putSafeTags("state", state)
-                .build();
     }
 
     /** Intentionally opaque wrapper type - we don't want people using the inner Apache client directly. */

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -283,11 +283,11 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
         }
 
         for (int hostIndex = 0; hostIndex < channels.size(); hostIndex++) {
-            MetricName metricName = MetricName.builder()
-                    .safeName("dialogue.balanced.score")
-                    .putSafeTags("channel-name", channelName)
-                    .putSafeTags("hostIndex", Integer.toString(hostIndex))
-                    .build();
+            MetricName metricName = DialogueBalancedMetrics.of(taggedMetrics)
+                    .score()
+                    .channelName(channelName)
+                    .hostIndex(Integer.toString(hostIndex))
+                    .buildMetricName();
             // Weak gauge ensures this object can be GCd. Itherwise the tagged metric registry could hold the last ref!
             // Defensive averaging for the possibility that people create multiple channels with the same channelName.
             DialogueInternalWeakReducingGauge.getOrCreate(

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -77,11 +77,11 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
                 uriIndex != -1, "uriIndex must be specified", SafeArg.of("channel-name", channelName));
         weakGauge(
                 taggedMetrics,
-                MetricName.builder()
-                        .safeName("dialogue.concurrencylimiter.max")
-                        .putSafeTags("channel-name", channelName)
-                        .putSafeTags("hostIndex", Integer.toString(uriIndex))
-                        .build(),
+                DialogueConcurrencylimiterMetrics.of(taggedMetrics)
+                        .max()
+                        .channelName(channelName)
+                        .hostIndex(Integer.toString(uriIndex))
+                        .buildMetricName(),
                 this,
                 ConcurrencyLimitedChannel::getMax);
     }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -30,7 +30,6 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
-import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -151,14 +150,13 @@ public class ConcurrencyLimitedChannelTest {
         when(mockLimiter.acquire()).thenReturn(Optional.empty());
     }
 
+    @SuppressWarnings("unchecked")
     private Number getMax() {
-        MetricName metricName = MetricName.builder()
-                .safeName("dialogue.concurrencylimiter.max")
-                .putSafeTags("channel-name", "channel")
-                .putSafeTags("hostIndex", "0")
-                .build();
-        assertThat(metrics.getMetrics().keySet()).contains(metricName);
-        Gauge<Object> gauge = metrics.gauge(metricName).get();
-        return (Number) gauge.getValue();
+        Gauge<Number> metric = (Gauge<Number>) metrics.getMetrics().entrySet().stream()
+                .filter(entry -> entry.getKey().safeName().equals("dialogue.concurrencylimiter.max"))
+                .findFirst()
+                .get()
+                .getValue();
+        return metric.getValue();
     }
 }


### PR DESCRIPTION
## Before this PR

We'd landed the fancy new `libraryName` and `libraryOrigin` functionality in metric-schema, but some of our metrics weren't using these because they'd been manually created.  Now that metric-schema offers a getter (https://github.com/palantir/metric-schema/pull/293), we can make _everything_ use metric schema.

## After this PR
==COMMIT_MSG==
All Dialogue metrics now use metric-schema generated code, ensuring that they all have libraryName & libraryVersion tags.
==COMMIT_MSG==

cc @carterkozak 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
