### PR TITLE
Allow dialogue-hc5 to support TLSv1.3 when ciphers are available

### DIFF
--- a/changelog/@unreleased/pr-870.v2.yml
+++ b/changelog/@unreleased/pr-870.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow dialogue-hc5 to support TLSv1.3 when ciphers are available
+  links:
+  - https://github.com/palantir/dialogue/pull/870

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -370,6 +370,10 @@ public final class ApacheHttpClientChannels {
             SSLSocketFactory rawSocketFactory = conf.sslSocketFactory();
             SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(
                     MetricRegistries.instrument(conf.taggedMetricRegistry(), rawSocketFactory, name),
+                    // Use 'null' to allow the supported protocols that hc5 considers secure: TLSv1.2 and (if
+                    // available) TLSv1.3.
+                    // We don't have the data to discover supported protocols directly here, which would require
+                    // either an SSLContext instance, or a Socket.
                     null,
                     supportedCipherSuites(
                             conf.enableGcmCipherSuites()

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -370,7 +370,7 @@ public final class ApacheHttpClientChannels {
             SSLSocketFactory rawSocketFactory = conf.sslSocketFactory();
             SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(
                     MetricRegistries.instrument(conf.taggedMetricRegistry(), rawSocketFactory, name),
-                    new String[] {"TLSv1.2"},
+                    null,
                     supportedCipherSuites(
                             conf.enableGcmCipherSuites()
                                     ? CipherSuites.allCipherSuites()


### PR DESCRIPTION
## Before this PR
Only TLSv1.2

## After this PR
==COMMIT_MSG==
Allow dialogue-hc5 to support TLSv1.3 when ciphers are available
==COMMIT_MSG==

Draft: I need to do some verification with this change.