### PR TITLE
Update DialogueClientsTest uris to avoid resolving internally

### DIFF
--- a/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsTest.java
@@ -57,12 +57,12 @@ class DialogueClientsTest {
             .putServices(
                     "multipass",
                     PartialServiceConfiguration.builder()
-                            .addUris("https://multipass")
+                            .addUris("https://multipass.fake.palantir.com")
                             .build())
             .putServices(
                     "email-service",
                     PartialServiceConfiguration.builder()
-                            .addUris("https://email-service")
+                            .addUris("https://email-service.fake.palantir.com")
                             .build())
             .putServices(
                     "zero-uris-service", PartialServiceConfiguration.builder().build())


### PR DESCRIPTION
==COMMIT_MSG==
Update DialogueClientsTest uris to avoid resolving internally, fixes a local test flake
==COMMIT_MSG==
