### PR TITLE
Dialogue POST requests with no body set `Content-Length: 0`

### DIFF
--- a/changelog/@unreleased/pr-891.v2.yml
+++ b/changelog/@unreleased/pr-891.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+    Dialogue POST requests with no body set `Content-Length: 0`
+
+    https://tools.ietf.org/html/rfc7230#section-3.3.2 recommends setting
+    a content-length on POST requests with no body. Some proxies strictly
+    validate this and respond 411 when the content-length is not specified.
+  links:
+  - https://github.com/palantir/dialogue/pull/891

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -46,6 +46,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.slf4j.Logger;
@@ -53,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private static final Logger log = LoggerFactory.getLogger(ApacheHttpClientBlockingChannel.class);
+    private static final HttpEntity EMPTY_ENTITY = new ByteArrayEntity(new byte[0], 0, 0, null, null, false);
 
     private final ApacheHttpClientChannels.CloseableClient client;
     private final BaseUrl baseUrl;
@@ -84,6 +86,8 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                     endpoint.httpMethod() != HttpMethod.OPTIONS, "OPTIONS endpoints must not have a request body");
             RequestBody body = request.body().get();
             setBody(builder, body);
+        } else if (endpoint.httpMethod() == HttpMethod.POST) {
+            builder.setEntity(EMPTY_ENTITY);
         }
         CloseableHttpResponse httpClientResponse = client.apacheClient().execute(builder.build());
         // Defensively ensure that resources are closed if failures occur within this block,

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -87,6 +87,8 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             RequestBody body = request.body().get();
             setBody(builder, body);
         } else if (endpoint.httpMethod() == HttpMethod.POST) {
+            // https://tools.ietf.org/html/rfc7230#section-3.3.2 recommends setting a content-length
+            // on empty post requests. Some components may respond 411 if the content-length is not present.
             builder.setEntity(EMPTY_ENTITY);
         }
         CloseableHttpResponse httpClientResponse = client.apacheClient().execute(builder.build());

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -403,6 +403,13 @@ public abstract class AbstractChannelTest {
         assertThat(result.get().code()).isEqualTo(200);
     }
 
+    @Test
+    public void postIncludesZeroContentLength() throws InterruptedException {
+        endpoint.method = HttpMethod.POST;
+        channel.execute(endpoint, request);
+        assertThat(server.takeRequest().getHeader("Content-Length")).isEqualTo("0");
+    }
+
     private static Buffer zip(String content) throws IOException {
         Buffer gzipBytes = new Buffer();
         Buffer rawBytes = new Buffer();


### PR DESCRIPTION
==COMMIT_MSG==
Dialogue POST requests with no body set `Content-Length: 0`

https://tools.ietf.org/html/rfc7230#section-3.3.2 recommends setting
a content-length on POST requests with no body. Some proxies strictly
validate this and respond 411 when the content-length is not specified.
==COMMIT_MSG==
