### PR TITLE
Dialogue PUT requests with no body set `Content-Length: 0`

### DIFF
--- a/changelog/@unreleased/pr-892.v2.yml
+++ b/changelog/@unreleased/pr-892.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Dialogue PUT requests with no body set `Content-Length: 0`'
+  links:
+  - https://github.com/palantir/dialogue/pull/892

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -410,6 +410,13 @@ public abstract class AbstractChannelTest {
         assertThat(server.takeRequest().getHeader("Content-Length")).isEqualTo("0");
     }
 
+    @Test
+    public void putIncludesZeroContentLength() throws InterruptedException {
+        endpoint.method = HttpMethod.PUT;
+        channel.execute(endpoint, request);
+        assertThat(server.takeRequest().getHeader("Content-Length")).isEqualTo("0");
+    }
+
     private static Buffer zip(String content) throws IOException {
         Buffer gzipBytes = new Buffer();
         Buffer rawBytes = new Buffer();


### PR DESCRIPTION
==COMMIT_MSG==
Dialogue PUT requests with no body set `Content-Length: 0`
==COMMIT_MSG==
