### PR TITLE
Better concurrency limiter metrics for StickyEndpointChannels

### DIFF
--- a/changelog/@unreleased/pr-895.v2.yml
+++ b/changelog/@unreleased/pr-895.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: For users of `getStickyChannels`, ConcurrencyLimiter metrics are now
+    correctly attributed to each hostIndex. Previously, they were all attributed to
+    `hostIndex:0`.
+  links:
+  - https://github.com/palantir/dialogue/pull/895

--- a/dialogue-clients/build.gradle
+++ b/dialogue-clients/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 
     testImplementation project(':dialogue-test-common')
     testImplementation project(':dialogue-serde')

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -18,7 +18,6 @@ package com.palantir.dialogue.clients;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;


### PR DESCRIPTION
## Before this PR

In PDS-125841, @diogoholanda flagged that we're seeing more throttling behaviour internally when using the "internal atlasdb-proxy" with dialogue compared to when it was using c-j-r. I'm a little confused as to _why_ dialogue was actually less good than before, and the graphs are hard to interpret because the sticky endpoint channels (and per host) all ascribe their concurrency limits to 'hostIndex: 0', so we only get one line when we should get n lines.

## After this PR
==COMMIT_MSG==
For users of `getStickyChannels`, ConcurrencyLimiter metrics are now correctly attributed to each hostIndex. Previously, they were all attributed to `hostIndex:0`.
==COMMIT_MSG==

## Possible downsides?
- a gross extra API method on the DialogueChannel builder
