### PR TITLE
[wip] representative sticky tests

### DIFF
--- a/dialogue-client-verifier/src/test/resources/log4j2-test.xml
+++ b/dialogue-client-verifier/src/test/resources/log4j2-test.xml
@@ -24,5 +24,8 @@
         <Root level="info">
             <AppenderRef ref="Console"/>
         </Root>
+        <Logger name="com.palantir.dialogue.core.ConcurrencyLimitedChannel" level="debug">
+            <AppenderRef ref="Console"/>
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## Before this PR

DD graphs showed more throttling when an important internal product used internal-ski-product with dialogue compared to when they rolled back to c-j-r:
![image](https://user-images.githubusercontent.com/3473798/87070235-66e88080-c210-11ea-90b6-0e25f05f1188.png)

I'd like to be able to tinker with the balanced score tracker to see if we can improve this, but need a somewhat representative workflow to be able to iterate.

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

Example output:
```
Completed 30 transactions, each making 400 requests.
successResponses = {node2=2800, node3=3200, node0=2800, node1=3200}
limitedResponses = {node2=578, node3=671, node0=569, node1=660}
```

NOTE: this is _not_ reproducible, because the guava ratelimiter doesn't allow injecting a clock.  I think I'll probably make another reproducible one using codahale meters, just wanted to get this one going cos it's easy.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
