### PR TITLE
Fix unexpected socket timeouts when configured as unlimited

### DIFF
--- a/changelog/@unreleased/pr-901.v2.yml
+++ b/changelog/@unreleased/pr-901.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix unexpected socket timeouts when configured as unlimited by using
+    a 1-day socket timeout
+  links:
+  - https://github.com/palantir/dialogue/pull/901
+  - https://issues.apache.org/jira/browse/HTTPCLIENT-2099

--- a/changelog/@unreleased/pr-901.v2.yml
+++ b/changelog/@unreleased/pr-901.v2.yml
@@ -1,7 +1,21 @@
-type: fix
-fix:
-  description: Fix unexpected socket timeouts when configured as unlimited by using
-    a 1-day socket timeout
-  links:
-  - https://github.com/palantir/dialogue/pull/901
-  - https://issues.apache.org/jira/browse/HTTPCLIENT-2099
+changes:
+  - type: fix
+    fix:
+      description: Fix unexpected socket timeouts when configured as unlimited by using
+        a 1-day socket timeout.
+      links:
+      - https://github.com/palantir/dialogue/pull/901
+      - https://issues.apache.org/jira/browse/HTTPCLIENT-2099
+  - type: improvement
+    improvement:
+      description: Updated socket timeout control to use the RequestConfig,
+        allowing us to cover the entire handshake with the connect-timeout rather than
+        only the `socket.connect` portion.
+      links:
+        - https://github.com/palantir/dialogue/pull/901
+  - type: improvement
+    improvement:
+      description: Idle connection keepalive time is no longer bounded by the socket timeout,
+        allowing low-latency clients to reuse connections without penalty.
+      links:
+        - https://github.com/palantir/dialogue/pull/901

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsIntegrationTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsIntegrationTest.java
@@ -171,7 +171,12 @@ public class DialogueClientsIntegrationTest {
                                 .readTimeout(Duration.ZERO)
                                 .writeTimeout(Duration.ZERO)
                                 .build());
-        assertThatCode(client::voidToVoid).doesNotThrowAnyException();
+        assertThatCode(client::voidToVoid)
+                .as("initial request should not throw")
+                .doesNotThrowAnyException();
+        assertThatCode(client::voidToVoid)
+                .as("subsequent requests reusing the connection should not throw")
+                .doesNotThrowAnyException();
     }
 
     @Test
@@ -190,7 +195,12 @@ public class DialogueClientsIntegrationTest {
                                 .readTimeout(Duration.ZERO)
                                 .writeTimeout(Duration.ZERO)
                                 .build());
-        assertThatCode(client::voidToVoid).doesNotThrowAnyException();
+        assertThatCode(client::voidToVoid)
+                .as("initial request should not throw")
+                .doesNotThrowAnyException();
+        assertThatCode(client::voidToVoid)
+                .as("subsequent requests reusing the connection should not throw")
+                .doesNotThrowAnyException();
     }
 
     private static String getUri(Undertow undertow) {

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsIntegrationTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue.otherpackage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.Iterables;
@@ -25,6 +26,7 @@ import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
+import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.dialogue.TestConfigurations;
 import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.dialogue.example.SampleServiceAsync;
@@ -34,12 +36,15 @@ import com.palantir.refreshable.SettableRefreshable;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.BlockingHandler;
+import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
+import javax.net.ssl.SSLContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,9 +59,13 @@ public class DialogueClientsIntegrationTest {
 
     @BeforeEach
     public void before() {
+        SSLContext sslContext = SslSocketFactories.createSslContext(TestConfigurations.SSL_CONFIG);
         undertow = Undertow.builder()
-                .addHttpListener(
-                        0, "localhost", new BlockingHandler(exchange -> undertowHandler.handleRequest(exchange)))
+                .addHttpsListener(
+                        0,
+                        "localhost",
+                        sslContext,
+                        new BlockingHandler(exchange -> undertowHandler.handleRequest(exchange)))
                 .build();
         undertow.start();
         serviceConfig = ServiceConfiguration.builder()
@@ -146,8 +155,48 @@ public class DialogueClientsIntegrationTest {
         assertThat(requestPaths).hasSize(3);
     }
 
+    @Test
+    void test_conn_timeout_with_unlimited_socket_timeout() {
+        undertowHandler = _exchange -> Thread.sleep(1_000L);
+        SampleServiceBlocking client = DialogueClients.create(Refreshable.only(null))
+                .withUserAgent(TestConfigurations.AGENT)
+                .withMaxNumRetries(0)
+                .getNonReloading(
+                        SampleServiceBlocking.class,
+                        ServiceConfiguration.builder()
+                                .addUris(getUri(undertow))
+                                .security(TestConfigurations.SSL_CONFIG)
+                                .connectTimeout(Duration.ofMillis(300))
+                                // socket timeouts use zero as a sentinel for unlimited duration
+                                .readTimeout(Duration.ZERO)
+                                .writeTimeout(Duration.ZERO)
+                                .build());
+        assertThatCode(client::voidToVoid).doesNotThrowAnyException();
+    }
+
+    @Test
+    void test_unlimited_timeouts() {
+        undertowHandler = _exchange -> Thread.sleep(1_000L);
+        SampleServiceBlocking client = DialogueClients.create(Refreshable.only(null))
+                .withUserAgent(TestConfigurations.AGENT)
+                .withMaxNumRetries(0)
+                .getNonReloading(
+                        SampleServiceBlocking.class,
+                        ServiceConfiguration.builder()
+                                .addUris(getUri(undertow))
+                                .security(TestConfigurations.SSL_CONFIG)
+                                // socket timeouts use zero as a sentinel for unlimited duration
+                                .connectTimeout(Duration.ZERO)
+                                .readTimeout(Duration.ZERO)
+                                .writeTimeout(Duration.ZERO)
+                                .build());
+        assertThatCode(client::voidToVoid).doesNotThrowAnyException();
+    }
+
     private static String getUri(Undertow undertow) {
         Undertow.ListenerInfo listenerInfo = Iterables.getOnlyElement(undertow.getListenerInfo());
-        return String.format("%s:/%s", listenerInfo.getProtcol(), listenerInfo.getAddress());
+        return String.format(
+                "%s://localhost:%d",
+                listenerInfo.getProtcol(), ((InetSocketAddress) listenerInfo.getAddress()).getPort());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HTTPCLIENT-2099

## After this PR
==COMMIT_MSG==
Fix unexpected socket timeouts when configured as unlimited by using a 1-day socket timeout
==COMMIT_MSG==

## Possible downsides?
Requests that expect to sit idle waiting for a response longer than a day won't work. Our metrics don't show any requests lasting this long, so we should be safe.
