### PR TITLE
Fix massive synchronization and gc cost of jaxrs clients

### DIFF
--- a/changelog/@unreleased/pr-908.v2.yml
+++ b/changelog/@unreleased/pr-908.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix massive synchronization and gc cost of jaxrs clients
+  links:
+  - https://github.com/palantir/dialogue/pull/908

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -53,8 +53,9 @@ enum DefaultClients implements Clients {
     @Override
     public <T> ListenableFuture<T> call(
             Channel channel, Endpoint endpoint, Request request, Deserializer<T> deserializer) {
-        EndpointChannel endpointChannel = bind(channel, endpoint);
-        return call(endpointChannel, request, deserializer);
+        // When this method is called, the EndpointChannel can be used at most once. Do not use the bind function
+        // because the reloadable state setup cost will never be recovered in this case.
+        return call(new EndpointChannelAdapter(endpoint, channel), request, deserializer);
     }
 
     @Override


### PR DESCRIPTION
Do not attempt to magically bind reloadable channels for a
one-shot invocation.

==COMMIT_MSG==
Fix massive synchronization and gc cost of jaxrs clients
==COMMIT_MSG==

## Before

```
Benchmark                         Mode  Cnt       Score       Error  Units
Benchmarks.jaxrsDialogueClient    thrpt    4   19571.205 ±  2295.951  ops/s
Benchmarks.pureDialogueClient     thrpt    4  103466.692 ± 16021.078  ops/s
```

## After

```
Benchmark                         Mode  Cnt       Score       Error  Units
Benchmarks.jaxrsDialogueClient    thrpt    4   76504.935 ± 14078.987  ops/s
Benchmarks.pureDialogueClient     thrpt    4  104787.366 ± 25389.212  ops/s
```