### PR TITLE
Fix UnsupportedOperationException with old dialouge bindings

### DIFF
--- a/changelog/@unreleased/pr-912.v2.yml
+++ b/changelog/@unreleased/pr-912.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix UnsupportedOperationException with old dialouge bindings
+  links:
+  - https://github.com/palantir/dialogue/pull/912

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyEndpointChannels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyEndpointChannels.java
@@ -96,9 +96,8 @@ public final class StickyEndpointChannels implements Supplier<Channel> {
          */
         @Deprecated
         @Override
-        public ListenableFuture<Response> execute(Endpoint _endpoint, Request _request) {
-            // TODO(dfox): remove this by adding client factory method taking a 'EndpointChannelFactory' not a 'Channel'
-            throw new UnsupportedOperationException("Not implemented");
+        public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+            return endpoint(endpoint).execute(request);
         }
 
         @Override


### PR DESCRIPTION
==COMMIT_MSG==
Fix UnsupportedOperationException with old dialouge bindings
==COMMIT_MSG==