### PR TITLE
Clients respect the server Keep-Alive timeout when present

### DIFF
--- a/changelog/@unreleased/pr-913.v2.yml
+++ b/changelog/@unreleased/pr-913.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clients respect the server Keep-Alive timeout when present
+  links:
+  - https://github.com/palantir/dialogue/pull/913

--- a/changelog/@unreleased/pr-913.v2.yml
+++ b/changelog/@unreleased/pr-913.v2.yml
@@ -1,5 +1,11 @@
-type: improvement
-improvement:
-  description: Clients respect the server Keep-Alive timeout when present
-  links:
-  - https://github.com/palantir/dialogue/pull/913
+changes:
+  - type: fix
+    fix:
+      description: Connection reuse is no longer limited to a global timeout, reducing handshake rates on high-load servers.
+      links:
+        - https://github.com/palantir/dialogue/pull/913
+  - type: improvement
+    improvement:
+      description: Clients respect the server Keep-Alive timeout when present
+      links:
+        - https://github.com/palantir/dialogue/pull/913

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -403,7 +403,6 @@ public final class ApacheHttpClientChannels {
                     .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
                     // Allow unnecessary connections to time out reducing system load.
                     .setConnPoolPolicy(PoolReusePolicy.LIFO)
-                    .setConnectionTimeToLive(IDLE_CONNECTION_TIMEOUT)
                     .setDefaultSocketConfig(SocketConfig.custom()
                             .setSoKeepAlive(true)
                             // The default socket configuration socket timeout only applies prior to request execution.
@@ -461,12 +460,8 @@ public final class ApacheHttpClientChannels {
                             .build()));
 
             CloseableHttpClient apacheClient = builder.build();
-            ScheduledFuture<?> connectionEvictorFuture = ScheduledIdleConnectionEvictor.schedule(
-                    connectionManager,
-                    // Use a shorter check duration than idle connection timeout duration in order to avoid allowing
-                    // stale connections to race the server-side timeout.
-                    Duration.ofMillis(Math.min(IDLE_CONNECTION_TIMEOUT.toMilliseconds(), 5_000)),
-                    Duration.ofMillis(IDLE_CONNECTION_TIMEOUT.toMilliseconds()));
+            ScheduledFuture<?> connectionEvictorFuture =
+                    ScheduledIdleConnectionEvictor.schedule(connectionManager, Duration.ofSeconds(5));
             return CloseableClient.wrap(apacheClient, name, connectionManager, connectionEvictorFuture, conf, executor);
         }
     }

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.hc.core5.pool.ConnPoolControl;
-import org.apache.hc.core5.util.TimeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,21 +53,16 @@ final class ScheduledIdleConnectionEvictor {
                             EXECUTOR_NAME)),
                     EXECUTOR_NAME));
 
-    static ScheduledFuture<?> schedule(
-            ConnPoolControl<?> connectionManager, Duration delayBetweenChecks, Duration maxIdleTime) {
-        return schedule(connectionManager, delayBetweenChecks, maxIdleTime, sharedScheduler.get());
+    static ScheduledFuture<?> schedule(ConnPoolControl<?> connectionManager, Duration delayBetweenChecks) {
+        return schedule(connectionManager, delayBetweenChecks, sharedScheduler.get());
     }
 
     private static ScheduledFuture<?> schedule(
-            ConnPoolControl<?> connectionManager,
-            Duration delayBetweenChecks,
-            Duration maxIdleTime,
-            ScheduledExecutorService scheduler) {
+            ConnPoolControl<?> connectionManager, Duration delayBetweenChecks, ScheduledExecutorService scheduler) {
         return scheduler.scheduleWithFixedDelay(
                 () -> {
                     try {
                         connectionManager.closeExpired();
-                        connectionManager.closeIdle(TimeValue.ofMilliseconds(maxIdleTime.toMillis()));
                     } catch (RuntimeException | Error e) {
                         log.warn("Exception caught while evicting idle connections", e);
                     }


### PR DESCRIPTION
Pooled connections are no longer limited to a reusable lifespan of 50 seconds.

The client no longer uses a fixed timeout, allowing the server
to describe itself using a `Keep-Alive: timeout=<seconds>` header.

==COMMIT_MSG==
Clients respect the server Keep-Alive timeout when present
==COMMIT_MSG==

These things are difficult to test outside of end to end verification
because connection metadata is not exposed through our APIs.