### PR TITLE
The validateAfterInactivity duration may be modified via a sysprop

### DIFF
--- a/changelog/@unreleased/pr-915.v2.yml
+++ b/changelog/@unreleased/pr-915.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    The validateAfterInactivity duration may be modified via a sysprop.
+    The `dialogue.experimental.inactivity.check.threshold.millis` property
+    can be used to modify the inactivity timeout for connection health
+    checks. This is not meant to be a permanent fixture, but to allow
+    us to assess the tradeoff between our current four second value and
+    a higher value for less frequent hiccups.
+  links:
+  - https://github.com/palantir/dialogue/pull/915

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -329,7 +329,8 @@ public final class ApacheHttpClientChannels {
         // dropwizard: 30 seconds (see idleTimeout in the linked docs)
         // https://www.dropwizard.io/en/latest/manual/configuration.html#Connectors
         // wc: 60 seconds (internal)
-        private static final TimeValue CONNECTION_INACTIVITY_CHECK = TimeValue.ofSeconds(4);
+        private static final TimeValue CONNECTION_INACTIVITY_CHECK = TimeValue.ofMilliseconds(
+                Integer.getInteger("dialogue.experimental.inactivity.check.threshold.millis", 4_000));
 
         @Nullable
         private ClientConfiguration clientConfiguration;


### PR DESCRIPTION
==COMMIT_MSG==
The validateAfterInactivity duration may be modified via a sysprop.
The `dialogue.experimental.inactivity.check.threshold.millis` property
can be used to modify the inactivity timeout for connection health
checks. This is not meant to be a permanent fixture, but to allow
us to assess the tradeoff between our current four second value and
a higher value for less frequent hiccups.
==COMMIT_MSG==
