### PR TITLE
Connect timeouts are retried

### DIFF
--- a/changelog/@unreleased/pr-920.v2.yml
+++ b/changelog/@unreleased/pr-920.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Connect timeouts are retried
+  links:
+  - https://github.com/palantir/dialogue/pull/920


### PR DESCRIPTION
==COMMIT_MSG==
Connect timeouts are retried
==COMMIT_MSG==

ConnectTimeoutExcetion implements SocketTimeoutException, which is not retried by default. It should be wrapped with a retryable exception..
https://github.com/palantir/dialogue/blob/6bea1de7df48d2c930a53551d8c4eeadfc256baa/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java#L325-L338