### PR TITLE
DialogueInternalWeakReducingGauge tolerates unusual tagged metric registries

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -222,3 +222,12 @@ acceptedBreaks:
         \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory::getStickyChannels(java.lang.String)"
       justification: "Adding methods to Dialogue.ReloadingFactory is not an ABI break\
         \ (just API)"
+  "1.73.1":
+    com.palantir.dialogue:dialogue-core:
+    - code: "java.method.removed"
+      old: "method <T> com.palantir.dialogue.core.DialogueInternalWeakReducingGauge<T>\
+        \ com.palantir.dialogue.core.DialogueInternalWeakReducingGauge<T>::getOrCreate(com.palantir.tritium.metrics.registry.TaggedMetricRegistry,\
+        \ com.palantir.tritium.metrics.registry.MetricName, java.util.function.ToLongFunction<T>,\
+        \ java.util.function.Function<java.util.stream.LongStream, java.lang.Number>,\
+        \ T)"
+      justification: "Type is named DialogueInternal and documented as internal-only"

--- a/changelog/@unreleased/pr-922.v2.yml
+++ b/changelog/@unreleased/pr-922.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: DialogueInternalWeakReducingGauge tolerates unusual tagged metric registries
+  links:
+  - https://github.com/palantir/dialogue/pull/922

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -129,7 +129,7 @@ public final class ApacheHttpClientChannels {
             String clientName,
             PoolingHttpClientConnectionManager connectionManager) {
 
-        DialogueInternalWeakReducingGauge.getOrCreate(
+        DialogueInternalWeakReducingGauge.register(
                 taggedMetrics,
                 DialogueClientPoolMetrics.of(taggedMetrics)
                         .size()
@@ -139,7 +139,7 @@ public final class ApacheHttpClientChannels {
                 pool -> pool.getTotalStats().getAvailable(),
                 LongStream::sum,
                 connectionManager);
-        DialogueInternalWeakReducingGauge.getOrCreate(
+        DialogueInternalWeakReducingGauge.register(
                 taggedMetrics,
                 DialogueClientPoolMetrics.of(taggedMetrics)
                         .size()
@@ -149,7 +149,7 @@ public final class ApacheHttpClientChannels {
                 pool -> pool.getTotalStats().getLeased(),
                 LongStream::sum,
                 connectionManager);
-        DialogueInternalWeakReducingGauge.getOrCreate(
+        DialogueInternalWeakReducingGauge.register(
                 taggedMetrics,
                 DialogueClientPoolMetrics.of(taggedMetrics)
                         .size()

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
@@ -244,7 +244,7 @@ final class BalancedScoreTracker {
                     .buildMetricName();
             // Weak gauge ensures this object can be GCd. Itherwise the tagged metric registry could hold the last ref!
             // Defensive averaging for the possibility that people create multiple channels with the same channelName.
-            DialogueInternalWeakReducingGauge.getOrCreate(
+            DialogueInternalWeakReducingGauge.register(
                     taggedMetrics,
                     metricName,
                     c -> c.computeScoreSnapshot().getScore(),


### PR DESCRIPTION
## Before this PR

@bavardage reported a problem in #dev-foundry-infra:

```
 Caused by: java.lang.ClassCastException: com.palantir.spark.module.metrics.DefaultBufferingTaggedMetricRegistry$$Lambda$703/983984263 cannot be cast to com.palantir.dialogue.core.DialogueInternalWeakReducingGauge
    	at com.palantir.dialogue.core.DialogueInternalWeakReducingGauge.getOrCreate(DialogueInternalWeakReducingGauge.java:71)
    	at com.palantir.dialogue.hc5.ApacheHttpClientChannels.setupConnectionPoolMetrics(ApacheHttpClientChannels.java:133)
    	at com.palantir.dialogue.hc5.ApacheHttpClientChannels.access$500(ApacheHttpClientChannels.java:87)
    	at com.palantir.dialogue.hc5.ApacheHttpClientChannels$ClientBuilder.build(ApacheHttpClientChannels.java:415)
    	at com.palantir.dialogue.clients.ChannelCache.getApacheClient(ChannelCache.java:152)
    	at com.palantir.dialogue.clients.ChannelCache.createNonLiveReloadingChannel(ChannelCache.java:113)
```

## After this PR
==COMMIT_MSG==
DialogueInternalWeakReducingGauge tolerates unusual tagged metric registries
==COMMIT_MSG==

## Possible downsides?
- people will weird TaggedMetricRegistries may find their metrics slightly more misleading
