### PR TITLE
QueuedChannel logs cancellation exceptions at debug

### DIFF
--- a/changelog/@unreleased/pr-925.v2.yml
+++ b/changelog/@unreleased/pr-925.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: QueuedChannel logs cancellation exceptions at debug to reduce noise.
+  links:
+  - https://github.com/palantir/dialogue/pull/925

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -34,6 +34,7 @@ import com.palantir.tracing.DetachedSpan;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Deque;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -277,7 +278,11 @@ final class QueuedChannel implements Channel {
         @Override
         public void onFailure(Throwable throwable) {
             if (!response.setException(throwable)) {
-                log.info("Call failed after the future completed", throwable);
+                if (throwable instanceof CancellationException) {
+                    log.debug("Call was canceled", throwable);
+                } else {
+                    log.info("Call failed after the future completed", throwable);
+                }
             }
             schedule();
         }


### PR DESCRIPTION
No need to produce noise in the logs in this case -- we don't log
a stack trace in the onSuccess path when the future has been
canceled.

==COMMIT_MSG==
QueuedChannel logs cancellation exceptions at debug to reduce noise.
==COMMIT_MSG==