### PR TITLE
Empty HttpEntity which doesn't attempt a write or flush

### DIFF
--- a/changelog/@unreleased/pr-928.v2.yml
+++ b/changelog/@unreleased/pr-928.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Simpler empty HttpEntity implementation which doesn't attempt a write
+    an empty array or flush the socket stream unnecessarily.
+  links:
+  - https://github.com/palantir/dialogue/pull/928

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -48,7 +48,6 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.slf4j.Logger;
@@ -56,7 +55,6 @@ import org.slf4j.LoggerFactory;
 
 final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private static final Logger log = LoggerFactory.getLogger(ApacheHttpClientBlockingChannel.class);
-    private static final HttpEntity EMPTY_ENTITY = new ByteArrayEntity(new byte[0], 0, 0, null, null, false);
 
     private final ApacheHttpClientChannels.CloseableClient client;
     private final BaseUrl baseUrl;
@@ -89,7 +87,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             RequestBody body = request.body().get();
             setBody(builder, body);
         } else if (requiresEmptyBody(endpoint)) {
-            builder.setEntity(EMPTY_ENTITY);
+            builder.setEntity(EmptyHttpEntity.INSTANCE);
         }
         try {
             CloseableHttpResponse httpClientResponse = client.apacheClient().execute(builder.build());

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/EmptyHttpEntity.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/EmptyHttpEntity.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.hc.core5.function.Supplier;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+
+/** Simplest possible empty {@link HttpEntity} implementation. */
+enum EmptyHttpEntity implements HttpEntity {
+    INSTANCE;
+
+    @Override
+    public boolean isRepeatable() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public InputStream getContent() {
+        return null;
+    }
+
+    @Override
+    public void writeTo(OutputStream _outStream) {}
+
+    @Override
+    public boolean isStreaming() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Supplier<List<? extends Header>> getTrailers() {
+        return null;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public long getContentLength() {
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getContentEncoding() {
+        return null;
+    }
+
+    @Override
+    public boolean isChunked() {
+        return false;
+    }
+
+    @Override
+    public Set<String> getTrailerNames() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyHttpEntity{}";
+    }
+}


### PR DESCRIPTION
There's no need to attempt an empty write or additional flush on
empty POST and PUT invocations.

==COMMIT_MSG==
Simpler empty HttpEntity implementation which doesn't attempt a write an empty array or flush the socket stream unnecessarily.
==COMMIT_MSG==
