### PR TITLE
Report metrics describing the time spent creating a new connection

### DIFF
--- a/changelog/@unreleased/pr-935.v2.yml
+++ b/changelog/@unreleased/pr-935.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Report metrics describing the time spent creating a new connection
+    using the `dialogue.client.connection.create` timer.
+  links:
+  - https://github.com/palantir/dialogue/pull/935

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -85,6 +85,7 @@ import org.slf4j.LoggerFactory;
 
 public final class ApacheHttpClientChannels {
     private static final Logger log = LoggerFactory.getLogger(ApacheHttpClientChannels.class);
+    private static final String CLIENT_TYPE = "apache-hc5";
 
     private ApacheHttpClientChannels() {}
 
@@ -163,7 +164,6 @@ public final class ApacheHttpClientChannels {
 
     /** Intentionally opaque wrapper type - we don't want people using the inner Apache client directly. */
     public static final class CloseableClient implements Closeable {
-        private static final String CLIENT_TYPE = "apache-hc5";
 
         private final String clientName;
         private final CloseableHttpClient apacheClient;
@@ -433,7 +433,8 @@ public final class ApacheHttpClientChannels {
                     // Connection pool lifecycle must be managed separately. This allows us to configure a more
                     // precise IdleConnectionEvictor.
                     .setConnectionManagerShared(true)
-                    .setConnectionManager(new TracedPoolingHttpClientConnectionManager(connectionManager))
+                    .setConnectionManager(new InstrumentedPoolingHttpClientConnectionManager(
+                            connectionManager, conf.taggedMetricRegistry(), name, CLIENT_TYPE))
                     .setRoutePlanner(new SystemDefaultRoutePlanner(null, conf.proxy()))
                     .disableAutomaticRetries()
                     // Must be disabled otherwise connections are not reused when client certificates are provided

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
@@ -158,7 +158,7 @@ final class InstrumentedPoolingHttpClientConnectionManager
 
     @Override
     public String toString() {
-        return "TracedPoolingHttpClientConnectionManager{" + manager + '}';
+        return "InstrumentedPoolingHttpClientConnectionManager{" + manager + '}';
     }
 
     private static final class TracedLeaseRequest implements LeaseRequest {

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
@@ -85,7 +85,7 @@ final class InstrumentedPoolingHttpClientConnectionManager
     @Override
     public void connect(ConnectionEndpoint endpoint, TimeValue connectTimeout, HttpContext context) throws IOException {
         try (CloseableTracer ignored = CloseableTracer.startSpan("Dialogue ConnectionManager.connect");
-                Context _timer = connectTimer.time()) {
+                Context timer = connectTimer.time()) {
             manager.connect(endpoint, connectTimeout, context);
         }
     }

--- a/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
+++ b/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
@@ -28,3 +28,8 @@ namespaces:
         type: meter
         tags: [client-name, client-type]
         docs: Marked every time an Apache client is successfully closed and any underlying resources released (e.g. connections and background threads).
+
+      connection.create:
+        type: timer
+        tags: [client-name, client-type]
+        docs: Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -9,6 +9,7 @@ Dialogue client response metrics provided by the Apache client channel.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.create` tagged `client-name`, `client-type` (meter): Marked every time a new client is created.
 - `dialogue.client.close` tagged `client-name`, `client-type` (meter): Marked every time an Apache client is successfully closed and any underlying resources released (e.g. connections and background threads).
+- `dialogue.client.connection.create` tagged `client-name`, `client-type` (timer): Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.
 
 ### dialogue.client.pool
 Connection pool metrics from the dialogue Apache client.


### PR DESCRIPTION
==COMMIT_MSG==
Report metrics describing the time spent creating a new connection using the `dialogue.client.connection.create` timer.
==COMMIT_MSG==
