### PR TITLE
Dialogue clients use a sympathetic validation interval

### DIFF
--- a/changelog/@unreleased/pr-948.v2.yml
+++ b/changelog/@unreleased/pr-948.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: Dialogue clients use a sympathetic validation interval
+  description: Dialogue clients use a sympathetic validation interval when servers
+    explicitly set a `Keep-Alive`  response header including a timeout duration.
   links:
   - https://github.com/palantir/dialogue/pull/948

--- a/changelog/@unreleased/pr-948.v2.yml
+++ b/changelog/@unreleased/pr-948.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue clients use a sympathetic validation interval
+  links:
+  - https://github.com/palantir/dialogue/pull/948

--- a/changelog/@unreleased/pr-948.v2.yml
+++ b/changelog/@unreleased/pr-948.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: Dialogue clients use a sympathetic validation interval when servers
-    explicitly set a `Keep-Alive`  response header including a timeout duration.
+    explicitly set a `Keep-Alive` response header including a timeout duration.
   links:
   - https://github.com/palantir/dialogue/pull/948

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -421,6 +421,8 @@ public final class ApacheHttpClientChannels {
                     // Connection pool lifecycle must be managed separately. This allows us to configure a more
                     // precise IdleConnectionEvictor.
                     .setConnectionManagerShared(true)
+                    .setKeepAliveStrategy(
+                            new InactivityValidationAwareConnectionKeepAliveStrategy(connectionManager, name))
                     .setConnectionManager(new InstrumentedPoolingHttpClientConnectionManager(
                             connectionManager, conf.taggedMetricRegistry(), name, CLIENT_TYPE))
                     .setRoutePlanner(new SystemDefaultRoutePlanner(null, conf.proxy()))

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategy.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategy.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import com.palantir.logsafe.SafeArg;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hc.client5.http.ConnectionKeepAliveStrategy;
+import org.apache.hc.client5.http.impl.DefaultConnectionKeepAliveStrategy;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HeaderElements;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class InactivityValidationAwareConnectionKeepAliveStrategy implements ConnectionKeepAliveStrategy {
+    private static final Logger log =
+            LoggerFactory.getLogger(InactivityValidationAwareConnectionKeepAliveStrategy.class);
+
+    private static final ConnectionKeepAliveStrategy DELEGATE = DefaultConnectionKeepAliveStrategy.INSTANCE;
+    private final PoolingHttpClientConnectionManager connectionManager;
+    private final String clientName;
+    private final TimeValue defaultValidateAfterInactivity;
+    /**
+     * This field is used for observability. It's possible, though unlikely, that the value can get out of sync
+     * with the connection manager in some scenarios.
+     */
+    private final AtomicReference<TimeValue> currentValidationInterval;
+
+    InactivityValidationAwareConnectionKeepAliveStrategy(
+            PoolingHttpClientConnectionManager connectionManager, String clientName) {
+        this.connectionManager = connectionManager;
+        this.clientName = clientName;
+        // Store the initial inactivity interval to restore if responses re received without
+        // keep-alive headers.
+        this.defaultValidateAfterInactivity = connectionManager.getValidateAfterInactivity();
+        this.currentValidationInterval = new AtomicReference<>(defaultValidateAfterInactivity);
+    }
+
+    @Override
+    public TimeValue getKeepAliveDuration(HttpResponse response, HttpContext context) {
+        TimeValue result = DELEGATE.getKeepAliveDuration(response, context);
+        if (result != null
+                // Only use keep-alive values from 2xx responses
+                && response.getCode() / 100 == 2) {
+            TimeValue newInterval =
+                    containsKeepAliveHeaderWithTimeout(response) ? result : defaultValidateAfterInactivity;
+            TimeValue previousInterval = currentValidationInterval.getAndSet(newInterval);
+            if (!Objects.equals(previousInterval, newInterval)) {
+                log.info(
+                        "Updating the validation interval for {} from {} to {}",
+                        SafeArg.of("client", clientName),
+                        SafeArg.of("previousInterval", previousInterval),
+                        SafeArg.of("newInterval", newInterval));
+            }
+            // Simple volatile write, no need to protect this in the getAndSet check. The getAndSet may race this call
+            // so it's best to completely decouple the two.
+            connectionManager.setValidateAfterInactivity(newInterval);
+        }
+        return result;
+    }
+
+    private static boolean containsKeepAliveHeaderWithTimeout(HttpResponse response) {
+        Header keepAlive = response.getFirstHeader(HeaderElements.KEEP_ALIVE);
+        if (keepAlive != null) {
+            String keepAliveValue = keepAlive.getValue();
+            return keepAliveValue != null && keepAliveValue.contains("timeout=");
+        }
+        return false;
+    }
+}

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategyTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategyTest.java
@@ -1,0 +1,93 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.apache.hc.core5.util.TimeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InactivityValidationAwareConnectionKeepAliveStrategyTest {
+
+    private static final HttpClientContext CONTEXT = new HttpClientContext();
+    private static final TimeValue INITIAL_TIMEOUT = TimeValue.ofSeconds(5);
+
+    @Mock
+    private PoolingHttpClientConnectionManager manager;
+
+    @BeforeEach
+    void beforeEach() {
+        when(manager.getValidateAfterInactivity()).thenReturn(INITIAL_TIMEOUT);
+    }
+
+    @Test
+    void testNoKeepAliveHeader() {
+        InactivityValidationAwareConnectionKeepAliveStrategy strategy =
+                new InactivityValidationAwareConnectionKeepAliveStrategy(manager, "name");
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(200);
+        TimeValue value = strategy.getKeepAliveDuration(response, CONTEXT);
+        assertThat(value).isEqualTo(CONTEXT.getRequestConfig().getConnectionKeepAlive());
+        verify(manager).setValidateAfterInactivity(eq(INITIAL_TIMEOUT));
+    }
+
+    @Test
+    void testKeepAliveHeaderWithTimeout() {
+        InactivityValidationAwareConnectionKeepAliveStrategy strategy =
+                new InactivityValidationAwareConnectionKeepAliveStrategy(manager, "name");
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(200);
+        response.addHeader("Keep-Alive", "timeout=60");
+        TimeValue value = strategy.getKeepAliveDuration(response, CONTEXT);
+        TimeValue expected = TimeValue.ofSeconds(60);
+        assertThat(value).isEqualTo(expected);
+        verify(manager).setValidateAfterInactivity(eq(expected));
+    }
+
+    @Test
+    void testKeepAliveHeaderWithTimeoutIgnoredNon2xx() {
+        InactivityValidationAwareConnectionKeepAliveStrategy strategy =
+                new InactivityValidationAwareConnectionKeepAliveStrategy(manager, "name");
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(500);
+        response.addHeader("Keep-Alive", "timeout=60");
+        TimeValue value = strategy.getKeepAliveDuration(response, CONTEXT);
+        assertThat(value).isEqualTo(TimeValue.ofSeconds(60));
+        verify(manager, never()).setValidateAfterInactivity(any());
+    }
+
+    @Test
+    void testKeepAliveHeaderWithoutTimeout() {
+        InactivityValidationAwareConnectionKeepAliveStrategy strategy =
+                new InactivityValidationAwareConnectionKeepAliveStrategy(manager, "name");
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(200);
+        response.addHeader("Keep-Alive", "max=60");
+        TimeValue value = strategy.getKeepAliveDuration(response, CONTEXT);
+        assertThat(value).isEqualTo(CONTEXT.getRequestConfig().getConnectionKeepAlive());
+        verify(manager).setValidateAfterInactivity(eq(INITIAL_TIMEOUT));
+    }
+}


### PR DESCRIPTION
This doesn't impact clients unless a Keep-Alive response header
is sent with a timeout value. When the server specifies a timeout,
clients trust the server to maintain connections as was foretold.
This design centralizes configuration on the server so clients
needn't be updated to match server configuration.

==COMMIT_MSG==
Dialogue clients use a sympathetic validation interval
==COMMIT_MSG==

## Possible downsides?
If unexpected servers (proxies) set a response `Keep-Alive` header, but fail to uphold the contract this could result in degraded performance.