### PR TITLE
InactivityValidationAwareConnectionKeepAliveStrategy logging rate limit

### DIFF
--- a/changelog/@unreleased/pr-949.v2.yml
+++ b/changelog/@unreleased/pr-949.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: InactivityValidationAwareConnectionKeepAliveStrategy logging rate limit
+    to prevent excessive logging when servers are rolling
+  links:
+  - https://github.com/palantir/dialogue/pull/949


### PR DESCRIPTION
==COMMIT_MSG==
InactivityValidationAwareConnectionKeepAliveStrategy logging rate limit to prevent excessive logging when servers are rolling
==COMMIT_MSG==
