### PR TITLE
Report the difference between client and server request duration

### DIFF
--- a/changelog/@unreleased/pr-951.v2.yml
+++ b/changelog/@unreleased/pr-951.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Report the differebnce between client and server request duration
+  description: Report the difference between client and server request duration
   links:
   - https://github.com/palantir/dialogue/pull/951

--- a/changelog/@unreleased/pr-951.v2.yml
+++ b/changelog/@unreleased/pr-951.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Report the differebnce between client and server request duration
+  links:
+  - https://github.com/palantir/dialogue/pull/951

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -399,7 +399,8 @@ public final class ApacheHttpClientChannels {
                     .setMaxConnTotal(Integer.MAX_VALUE)
                     .setValidateAfterInactivity(CONNECTION_INACTIVITY_CHECK)
                     .setDnsResolver(new InstrumentedDnsResolver(SystemDefaultDnsResolver.INSTANCE))
-                    .setConnectionFactory(new TracedManagedHttpConnectionFactory(DialogueConnectionFactory.INSTANCE))
+                    .setConnectionFactory(new InstrumentedManagedHttpConnectionFactory(
+                            DialogueConnectionFactory.INSTANCE, clientConfiguration.taggedMetricRegistry(), name))
                     .build();
 
             setupConnectionPoolMetrics(conf.taggedMetricRegistry(), name, connectionManager);

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -400,7 +400,7 @@ public final class ApacheHttpClientChannels {
                     .setValidateAfterInactivity(CONNECTION_INACTIVITY_CHECK)
                     .setDnsResolver(new InstrumentedDnsResolver(SystemDefaultDnsResolver.INSTANCE))
                     .setConnectionFactory(new InstrumentedManagedHttpConnectionFactory(
-                            DialogueConnectionFactory.INSTANCE, clientConfiguration.taggedMetricRegistry(), name))
+                            DialogueConnectionFactory.INSTANCE, conf.taggedMetricRegistry(), name))
                     .build();
 
             setupConnectionPoolMetrics(conf.taggedMetricRegistry(), name, connectionManager);

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
@@ -38,11 +38,11 @@ import org.apache.hc.core5.util.Timeout;
 final class InstrumentedManagedHttpClientConnection implements ManagedHttpClientConnection {
 
     private final ManagedHttpClientConnection delegate;
-    private final Timer responseDeltaTimer;
+    private final Timer serverTimingOverhead;
 
-    InstrumentedManagedHttpClientConnection(ManagedHttpClientConnection delegate, Timer responseDeltaTimer) {
+    InstrumentedManagedHttpClientConnection(ManagedHttpClientConnection delegate, Timer serverTimingOverhead) {
         this.delegate = delegate;
-        this.responseDeltaTimer = responseDeltaTimer;
+        this.serverTimingOverhead = serverTimingOverhead;
     }
 
     @Override
@@ -122,7 +122,7 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
             // the client. Theres's not a great way to measure the difference in that case
             // so values may not be recorded.
             if (serverNanos >= 0 && deltaNanos >= 0) {
-                responseDeltaTimer.update(deltaNanos, TimeUnit.NANOSECONDS);
+                serverTimingOverhead.update(deltaNanos, TimeUnit.NANOSECONDS);
             }
         }
     }

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpConnectionFactory.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpConnectionFactory.java
@@ -27,19 +27,19 @@ import org.apache.hc.core5.http.io.HttpConnectionFactory;
 final class InstrumentedManagedHttpConnectionFactory implements HttpConnectionFactory<ManagedHttpClientConnection> {
 
     private final HttpConnectionFactory<ManagedHttpClientConnection> delegate;
-    private final Timer responseDeltaTimer;
+    private final Timer serverTimingOverhead;
 
     InstrumentedManagedHttpConnectionFactory(
             HttpConnectionFactory<ManagedHttpClientConnection> delegate,
             TaggedMetricRegistry metrics,
             String clientName) {
         this.delegate = delegate;
-        this.responseDeltaTimer = DialogueClientMetrics.of(metrics).responseDelta(clientName);
+        this.serverTimingOverhead = DialogueClientMetrics.of(metrics).serverTimingOverhead(clientName);
     }
 
     @Override
     public ManagedHttpClientConnection createConnection(Socket socket) throws IOException {
-        return new InstrumentedManagedHttpClientConnection(delegate.createConnection(socket), responseDeltaTimer);
+        return new InstrumentedManagedHttpClientConnection(delegate.createConnection(socket), serverTimingOverhead);
     }
 
     @Override

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ServerTimingParser.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ServerTimingParser.java
@@ -1,0 +1,83 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.palantir.logsafe.SafeArg;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class ServerTimingParser {
+
+    private static final Logger log = LoggerFactory.getLogger(ServerTimingParser.class);
+
+    /** Splits a header value into individual metrics. */
+    private static final Splitter METRIC_SPLITTER =
+            Splitter.on(',').trimResults().omitEmptyStrings();
+
+    private static final CharMatcher NUMERIC_MATCHER =
+            CharMatcher.inRange('0', '9').or(CharMatcher.anyOf("-."));
+
+    private static final String DURATION = ";dur=";
+    private static final long NANOSECONDS_PER_MILLISECOND = 1_000_000L;
+
+    static final long UNKNOWN = -1;
+
+    /**
+     * Returns the {@code Server-Timing} duration in nanoseconds for the
+     * given operation name or {@link #UNKNOWN} if it cannot be parsed.
+     */
+    static long getServerDurationNanos(String serverTimingValue, String operation) {
+        if (Strings.isNullOrEmpty(serverTimingValue) || !serverTimingValue.contains(operation)) {
+            return UNKNOWN;
+        }
+        try {
+            for (String segment : METRIC_SPLITTER.split(serverTimingValue)) {
+                if (segment.length() > operation.length() + DURATION.length()
+                        && segment.startsWith(operation)
+                        && segment.charAt(operation.length()) == ';') {
+                    // Ignore any extraneous fields, search for `dur`
+                    int durationStart = segment.indexOf(DURATION);
+                    if (durationStart < 0) {
+                        return UNKNOWN;
+                    }
+                    int durationValueStart = durationStart + DURATION.length();
+                    int durationValueEnd = findNumericSequenceEnd(segment, durationValueStart);
+                    String durationValue = segment.substring(durationValueStart, durationValueEnd);
+                    double durationMilliseconds = Double.parseDouble(durationValue);
+                    return (long) (NANOSECONDS_PER_MILLISECOND * durationMilliseconds);
+                }
+            }
+        } catch (RuntimeException e) {
+            // Important not to fail calls even if we fail to parse a timing value
+            log.warn("Failed to parse Server-Timing value '{}'", SafeArg.of("serverTiming", serverTimingValue), e);
+        }
+        return UNKNOWN;
+    }
+
+    private static int findNumericSequenceEnd(String string, int beginIndex) {
+        int currentIndex = beginIndex;
+        while (currentIndex < string.length() && NUMERIC_MATCHER.matches(string.charAt(currentIndex))) {
+            currentIndex++;
+        }
+        return currentIndex;
+    }
+
+    private ServerTimingParser() {}
+}

--- a/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
+++ b/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
@@ -19,6 +19,12 @@ namespaces:
         tags: [client-name, service-name, endpoint]
         docs: Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 
+      response.delta:
+        type: timer
+        tags: [client-name]
+        docs: Difference in request time reported by the client and by the server. This metric is only reported when
+          the remote server provides a `Server-Timing` response header with a timing value for `server`.
+
       create:
         type: meter
         tags: [client-name, client-type]

--- a/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
+++ b/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
@@ -19,7 +19,7 @@ namespaces:
         tags: [client-name, service-name, endpoint]
         docs: Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 
-      response.delta:
+      server.timing.overhead:
         type: timer
         tags: [client-name]
         docs: Difference in request time reported by the client and by the server. This metric is only reported when

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ServerTimingParserTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ServerTimingParserTest.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ServerTimingParserTest {
+
+    @Test
+    void testMissingValue() {
+        assertThat(ServerTimingParser.getServerDurationNanos("missedCache", "missedCache"))
+                .isEqualTo(ServerTimingParser.UNKNOWN);
+    }
+
+    @Test
+    void testSingleMetricWithValue() {
+        assertThat(ServerTimingParser.getServerDurationNanos("cpu;dur=2.4", "cpu"))
+                .isEqualTo(2400000L);
+    }
+
+    @Test
+    void testSingleMetricWithDescriptionAndValue() {
+        assertThat(ServerTimingParser.getServerDurationNanos("cache;desc=\"Cache Read\";dur=23.2", "cache"))
+                .isEqualTo(23200000L);
+    }
+
+    @Test
+    void twoMetricsWithValue() {
+        String headerValue = "db;dur=53, app;dur=47.2";
+        assertThat(ServerTimingParser.getServerDurationNanos(headerValue, "db")).isEqualTo(53_000_000);
+        assertThat(ServerTimingParser.getServerDurationNanos(headerValue, "app"))
+                .isEqualTo(47_200_000);
+    }
+}

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -7,6 +7,7 @@
 ### dialogue.client
 Dialogue client response metrics provided by the Apache client channel.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
+- `dialogue.client.response.delta` tagged `client-name` (timer): Difference in request time reported by the client and by the server. This metric is only reported when the remote server provides a `Server-Timing` response header with a timing value for `server`.
 - `dialogue.client.create` tagged `client-name`, `client-type` (meter): Marked every time a new client is created.
 - `dialogue.client.close` tagged `client-name`, `client-type` (meter): Marked every time an Apache client is successfully closed and any underlying resources released (e.g. connections and background threads).
 - `dialogue.client.connection.create` tagged `client-name`, `client-type` (timer): Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -7,7 +7,7 @@
 ### dialogue.client
 Dialogue client response metrics provided by the Apache client channel.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
-- `dialogue.client.response.delta` tagged `client-name` (timer): Difference in request time reported by the client and by the server. This metric is only reported when the remote server provides a `Server-Timing` response header with a timing value for `server`.
+- `dialogue.client.server.timing.overhead` tagged `client-name` (timer): Difference in request time reported by the client and by the server. This metric is only reported when the remote server provides a `Server-Timing` response header with a timing value for `server`.
 - `dialogue.client.create` tagged `client-name`, `client-type` (meter): Marked every time a new client is created.
 - `dialogue.client.close` tagged `client-name`, `client-type` (meter): Marked every time an Apache client is successfully closed and any underlying resources released (e.g. connections and background threads).
 - `dialogue.client.connection.create` tagged `client-name`, `client-type` (timer): Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.


### PR DESCRIPTION
This approach leverages the connection `receiveResponseHeader`
method which is as close to the socket as we can get, but has
the drawback that it cannot account for headers sent earlier
with large request entities.
In many cases the request header and entity can fit into a single
packet, so this is a reasonable trade-off, and captures data for
our most performance sensitive endpoints.

==COMMIT_MSG==
Report the difference between client and server request duration
==COMMIT_MSG==
