### PR TITLE
Dialogue uses a safe direct executor which catches and logs failures

### DIFF
--- a/changelog/@unreleased/pr-971.v2.yml
+++ b/changelog/@unreleased/pr-971.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Dialogue uses a safe direct executor which catches and logs failures
+  links:
+  - https://github.com/palantir/dialogue/pull/971

--- a/dialogue-blocking-channels/build.gradle
+++ b/dialogue-blocking-channels/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'com.palantir.revapi'
 dependencies {
     api project(':dialogue-target')
     api 'com.google.guava:guava'
+    implementation project(':dialogue-futures')
     implementation 'com.palantir.tracing:tracing'
     implementation 'com.palantir.tritium:tritium-metrics'
     implementation 'com.palantir.safe-logging:safe-logging'

--- a/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
+++ b/dialogue-blocking-channels/src/main/java/com/palantir/dialogue/blocking/BlockingChannelAdapter.java
@@ -19,13 +19,13 @@ import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.tracing.Tracers;
 import com.palantir.tritium.metrics.MetricRegistries;
@@ -95,7 +95,7 @@ public final class BlockingChannelAdapter {
                                 }
                             }
                         },
-                        MoreExecutors.directExecutor());
+                        DialogueFutures.safeDirectExecutor());
                 return settableFuture;
             } catch (RuntimeException | Error e) {
                 // user-provided executor could throw exceptions when we try to submit runnables

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -226,7 +226,7 @@ final class RetryingChannel implements EndpointChannel {
                             span.complete();
                         }
                     },
-                    MoreExecutors.directExecutor());
+                    DialogueFutures.safeDirectExecutor());
             return result;
         }
 
@@ -298,7 +298,7 @@ final class RetryingChannel implements EndpointChannel {
                     },
                     backoffNanoseconds,
                     TimeUnit.NANOSECONDS);
-            return wrap(Futures.transformAsync(scheduled, input -> input, MoreExecutors.directExecutor()));
+            return wrap(Futures.transformAsync(scheduled, input -> input, DialogueFutures.safeDirectExecutor()));
         }
 
         private long getBackoffNanoseconds() {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/TracedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/TracedChannel.java
@@ -17,11 +17,11 @@
 package com.palantir.dialogue.core;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.tracing.CloseableSpan;
 import com.palantir.tracing.DetachedSpan;
 import com.palantir.tracing.Tracer;
@@ -58,7 +58,7 @@ final class TracedChannel implements EndpointChannel {
             future = delegate.execute(request);
         } finally {
             if (future != null) {
-                future.addListener(span::complete, MoreExecutors.directExecutor());
+                future.addListener(span::complete, DialogueFutures.safeDirectExecutor());
             } else {
                 span.complete();
             }

--- a/dialogue-futures/build.gradle
+++ b/dialogue-futures/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'org.slf4j:slf4j-api'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.assertj:assertj-guava'

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncCatchingFuture.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncCatchingFuture.java
@@ -19,7 +19,6 @@ package com.palantir.dialogue.futures;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -54,8 +53,8 @@ final class DialogueDirectAsyncCatchingFuture<T> implements ListenableFuture<T>,
                     currentFuture = future;
                     return future;
                 },
-                MoreExecutors.directExecutor());
-        output.addListener(this, MoreExecutors.directExecutor());
+                DialogueFutures.safeDirectExecutor());
+        output.addListener(this, DialogueFutures.safeDirectExecutor());
     }
 
     @Override

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncTransformationFuture.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncTransformationFuture.java
@@ -19,7 +19,6 @@ package com.palantir.dialogue.futures;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -49,8 +48,8 @@ final class DialogueDirectAsyncTransformationFuture<I, O> implements ListenableF
                     currentFuture = future;
                     return future;
                 },
-                MoreExecutors.directExecutor());
-        output.addListener(this, MoreExecutors.directExecutor());
+                DialogueFutures.safeDirectExecutor());
+        output.addListener(this, DialogueFutures.safeDirectExecutor());
     }
 
     @Override

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectTransformationFuture.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectTransformationFuture.java
@@ -19,7 +19,6 @@ package com.palantir.dialogue.futures;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.logsafe.Preconditions;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +51,7 @@ final class DialogueDirectTransformationFuture<I, O> implements ListenableFuture
         this.input = input;
         this.function = function;
         this.output = SettableFuture.create();
-        Futures.addCallback(input, this, MoreExecutors.directExecutor());
+        Futures.addCallback(input, this, DialogueFutures.safeDirectExecutor());
     }
 
     @Override

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
@@ -20,8 +20,8 @@ import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -56,14 +56,18 @@ public final class DialogueFutures {
 
     @CanIgnoreReturnValue
     public static <T> ListenableFuture<T> addDirectCallback(ListenableFuture<T> future, FutureCallback<T> callback) {
-        Futures.addCallback(future, callback, MoreExecutors.directExecutor());
+        Futures.addCallback(future, callback, safeDirectExecutor());
         return future;
     }
 
     @CanIgnoreReturnValue
     public static <T> ListenableFuture<T> addDirectListener(ListenableFuture<T> future, Runnable listener) {
-        future.addListener(listener, MoreExecutors.directExecutor());
+        future.addListener(listener, safeDirectExecutor());
         return future;
+    }
+
+    public static Executor safeDirectExecutor() {
+        return SafeDirectExecutor.INSTANCE;
     }
 
     public static <T> FutureCallback<T> onSuccess(Consumer<T> onSuccess) {

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/SafeDirectExecutor.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/SafeDirectExecutor.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.futures;
+
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** {@link Executor} implementation which catches and logs failures. */
+enum SafeDirectExecutor implements Executor {
+    INSTANCE;
+
+    private static final Logger log = LoggerFactory.getLogger(SafeDirectExecutor.class);
+
+    @Override
+    public void execute(Runnable command) {
+        try {
+            command.run();
+        } catch (Throwable t) {
+            log.error("Task submitted to a direct executor threw an exception", t);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SafeDirectExecutor{}";
+    }
+}

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -20,7 +20,6 @@ import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.dialogue.Channel;
@@ -103,7 +102,7 @@ enum DefaultClients implements Clients {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             if (!future.cancel(true)) {
-                Futures.addCallback(future, CancelListener.INSTANCE, MoreExecutors.directExecutor());
+                Futures.addCallback(future, CancelListener.INSTANCE, DialogueFutures.safeDirectExecutor());
             }
             throw new DialogueException(e);
         } catch (ExecutionException e) {

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
@@ -95,7 +94,7 @@ final class SimulationServer implements Channel {
                         activeRequests.dec();
                         globalServerTimeNanos.inc(simulation.clock().read() - beforeNanos);
                     },
-                    MoreExecutors.directExecutor());
+                    DialogueFutures.safeDirectExecutor());
 
             if (log.isDebugEnabled()) {
                 DialogueFutures.addDirectCallback(resp, DialogueFutures.onSuccess(result -> {


### PR DESCRIPTION
This resolves an issue where dialogue state could be corrupted
when Errors are thrown. In general it's not a good idea to handle
Error, however leaving Dialogue in a degraded state leads to
investigation in the wrong areas.

==COMMIT_MSG==
Dialogue uses a safe direct executor which catches and logs failures
==COMMIT_MSG==
