### PR TITLE
[pure refactor] Emphasise usage of NeverThrowChannel

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -131,9 +131,8 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 Channel channel = cf.channelFactory().create(uri);
                 channel = HostMetricsChannel.create(cf, channel, uri);
                 channel = new TraceEnrichingChannel(channel);
-                LimitedChannel limited = new ChannelToLimitedChannelAdapter(channel);
                 perUriChannels.add(ConcurrencyLimitedChannel.create(
-                        cf, limited, cf.overrideSingleHostIndex().orElse(uriIndex)));
+                        cf, channel, cf.overrideSingleHostIndex().orElse(uriIndex)));
             }
             ImmutableList<LimitedChannel> channels = perUriChannels.build();
 
@@ -151,7 +150,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = TracedChannel.create(channel, endpoint);
                 channel = TimingEndpointChannel.create(cf, channel, endpoint);
                 channel = new InterruptionChannel(channel);
-                return NeverThrowChannel.create(channel); // this must come last as a defensive backstop
+                return new NeverThrowEndpointChannel(channel); // this must come last as a defensive backstop
             };
 
             Meter createMeter = DialogueClientMetrics.of(cf.clientConf().taggedMetricRegistry())

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -64,7 +64,7 @@ final class QueuedChannel implements Channel {
     private static final Logger log = LoggerFactory.getLogger(QueuedChannel.class);
 
     private final Deque<DeferredCall> queuedCalls;
-    private final LimitedChannel delegate;
+    private final NeverThrowLimitedChannel delegate;
     private final String channelName;
     // Tracks requests that are current executing in delegate and are not tracked in queuedCalls
     private final AtomicInteger queueSizeEstimate = new AtomicInteger(0);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/TraceEnrichingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/TraceEnrichingChannel.java
@@ -33,7 +33,7 @@ import com.palantir.tracing.api.TraceHttpHeaders;
 final class TraceEnrichingChannel implements Channel {
     private static final String OPERATION = "Dialogue-http-request";
     private static final String INITIAL = OPERATION + " initial";
-    private final Channel delegate;
+    private final NeverThrowChannel delegate; // important to ensure the span is definitely completed!
 
     TraceEnrichingChannel(Channel delegate) {
         this.delegate = new NeverThrowChannel(delegate);

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -67,8 +67,7 @@ public class ConcurrencyLimitedChannelTest {
 
     @BeforeEach
     public void before() {
-        channel = new ConcurrencyLimitedChannel(
-                new ChannelToLimitedChannelAdapter(delegate), mockLimiter, "channel", 0, metrics);
+        channel = new ConcurrencyLimitedChannel(delegate, mockLimiter, "channel", 0, metrics);
 
         responseFuture = SettableFuture.create();
         lenient().when(delegate.execute(endpoint, request)).thenReturn(responseFuture);
@@ -121,11 +120,7 @@ public class ConcurrencyLimitedChannelTest {
     @Test
     public void testWithDefaultLimiter() {
         channel = new ConcurrencyLimitedChannel(
-                new ChannelToLimitedChannelAdapter(delegate),
-                ConcurrencyLimitedChannel.createLimiter(),
-                "channel",
-                0,
-                metrics);
+                delegate, ConcurrencyLimitedChannel.createLimiter(), "channel", 0, metrics);
 
         assertThat(channel.maybeExecute(endpoint, request)).contains(responseFuture);
     }


### PR DESCRIPTION
## Before this PR

While investigating #pds-132792, we had a hypothesis that the concurrency limiter's `inflight` AtomicInteger was being incremented, but then an exception thrown when calling the delegate, leading to it never being decremented again.

On closer reading, I don't actually think this is possible because we were already using a `NeverThrowChannel`, but I didn't spot this on the first read through, so figured it might be worth rejigging for clarity.

## After this PR
==COMMIT_MSG==
Emphasis usage of NeverThrowChannel in cases where correctness relies on a listener being run (e.g. ConcurrencyLimitedChannel, QueuedChannel and TraceEnrichingChannel).
==COMMIT_MSG==

_This PR is mostly cosmetic tbh_

## Possible downsides?

