### PR TITLE
Chill out log line

### DIFF
--- a/changelog/@unreleased/pr-991.v2.yml
+++ b/changelog/@unreleased/pr-991.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: False positive log lines warning about `Multiple ({}) objects contribute
+    to the same gauge, taking the average (beware this may be misleading) {} {}` will
+    no longer appear - these will only show up if the different constituent values
+    are _actually_ different.
+  links:
+  - https://github.com/palantir/dialogue/pull/991

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -250,7 +251,9 @@ final class BalancedScoreTracker {
                     c -> c.computeScoreSnapshot().getScore(),
                     longStream -> {
                         long[] longs = longStream.toArray();
-                        if (log.isInfoEnabled() && longs.length > 1) {
+                        if (log.isInfoEnabled()
+                                && longs.length > 1
+                                && LongStream.of(longs).distinct().count() > 1) {
                             log.info(
                                     "Multiple ({}) objects contribute to the same gauge, taking the average "
                                             + "(beware this may be misleading) {} {}",


### PR DESCRIPTION
## Before this PR

I've been seeing a few log lines around startup saying `Multiple ({}) objects contribute to the same gauge, taking the average (beware this may be misleading) {} {}`.  

This is _kinda_ interesting, but ultimately a false positive because it helpfully showed me the array of values was all zero: `values: "[0, 0]"`, so averaging zeros is totally fine.

## After this PR
==COMMIT_MSG==
False positive log lines warning about `Multiple ({}) objects contribute to the same gauge, taking the average (beware this may be misleading) {} {}` will no longer appear - these will only show up if the different constituent values are _actually_ different.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
