### PR TITLE
Server errors resulting from PUT requests are retried

### DIFF
--- a/changelog/@unreleased/pr-992.v2.yml
+++ b/changelog/@unreleased/pr-992.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Server errors resulting from PUT requests are retried
+  links:
+  - https://github.com/palantir/dialogue/pull/992

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -368,7 +368,7 @@ final class RetryingChannel implements EndpointChannel {
 
     /**
      * We are a bit more conservative than the definition of Safe and Idempotent in https://tools.ietf
-     * .org/html/rfc7231#section-4.2.1, as we're not sure whether developers have written non-idempotent PUT/DELETE
+     * .org/html/rfc7231#section-4.2.1, as we're not sure whether developers have written non-idempotent DELETE
      * endpoints.
      */
     private static boolean safeToRetry(HttpMethod httpMethod) {
@@ -376,8 +376,8 @@ final class RetryingChannel implements EndpointChannel {
             case GET:
             case HEAD:
             case OPTIONS:
-                return true;
             case PUT:
+                return true;
             case DELETE:
                 // in theory PUT and DELETE should be fine to retry too, we're just being conservative for now.
             case POST:

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/TestEndpoint.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/TestEndpoint.java
@@ -30,6 +30,12 @@ public enum TestEndpoint implements Endpoint {
         public HttpMethod httpMethod() {
             return HttpMethod.POST;
         }
+    },
+    PUT {
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.PUT;
+        }
     };
 
     @Override


### PR DESCRIPTION
PUT requests are considered idempotent based on rfc7231, several
internal projects already assume PUT requests are retried (in fact
the proxy does retry them). Outside of those projects, PUT is not
utilized, thus there's minimal risk.

==COMMIT_MSG==
Server errors resulting from PUT requests are retried
==COMMIT_MSG==
