### PR TITLE
Dialogue Endpoints provide Tags.

### DIFF
--- a/changelog/@unreleased/pr-1038.v2.yml
+++ b/changelog/@unreleased/pr-1038.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue Endpoints provide a list of Tags. This is a prerequisite for
+    the conjure-java generator to provide tag data.
+  links:
+  - https://github.com/palantir/dialogue/pull/1038

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Endpoint.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Endpoint.java
@@ -16,7 +16,9 @@
 
 package com.palantir.dialogue;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Defines a single HTTP-based RPC endpoint in terms of a {@link #renderPath path} and {@link #httpMethod HTTP method},
@@ -32,4 +34,8 @@ public interface Endpoint {
     String endpointName();
 
     String version();
+
+    default Set<String> tags() {
+        return Collections.emptySet();
+    }
 }


### PR DESCRIPTION
==COMMIT_MSG==
Dialogue Endpoints provide a list of Tags. This is a prerequisite for the conjure-java generator to provide tag data.
==COMMIT_MSG==
