### PR TITLE
Test coverage for PathTemplates with empty string variables

### DIFF
--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PathTemplateTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PathTemplateTest.java
@@ -57,6 +57,13 @@ public final class PathTemplateTest {
     }
 
     @Test
+    public void testEmptyVariableSegment() {
+        PathTemplate template =
+                PathTemplate.builder().fixed("a").variable("var").fixed("c").build();
+        assertThat(fill(template, ImmutableMap.of("var", ""))).isEqualTo("/a//c");
+    }
+
+    @Test
     public void testFixedAndVariableSegments() {
         PathTemplate template = PathTemplate.builder()
                 .fixed("a")


### PR DESCRIPTION
==COMMIT_MSG==
Test coverage for PathTemplates with empty string variables
==COMMIT_MSG==
