### PR TITLE
Reduce the client TLS session cache size

### DIFF
--- a/changelog/@unreleased/pr-1067.v2.yml
+++ b/changelog/@unreleased/pr-1067.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce the client TLS session cache size
+  links:
+  - https://github.com/palantir/dialogue/pull/1067


### PR DESCRIPTION
## Before this PR
We've seen heap dumps with ~500mb of tls session cache despite an
expectation that connections are reused. These large session caches seem
to show that we are creating new sessions anyhow, so there's little
point in caching old data.

## After this PR
==COMMIT_MSG==
Reduce the client TLS session cache size
==COMMIT_MSG==

## Possible downsides?
if the cache is needed in some scenario, we may see a lower hit rate.
