### PR TITLE
Log httpclient creation location when debug logging is enabled

### DIFF
--- a/changelog/@unreleased/pr-1070.v2.yml
+++ b/changelog/@unreleased/pr-1070.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Log apache httpclient creation stack trace when debug logging is enabled
+  links:
+  - https://github.com/palantir/dialogue/pull/1070

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -206,12 +206,23 @@ public final class ApacheHttpClientChannels {
                     leakDetector,
                     executor,
                     clientConfiguration);
-            log.info(
-                    "Created Apache client {} {} {} {}",
-                    SafeArg.of("name", clientName),
-                    SafeArg.of("client", Integer.toHexString(System.identityHashCode(apacheClient))),
-                    UnsafeArg.of("clientConfiguration", clientConfiguration),
-                    UnsafeArg.of("executor", executor));
+            if (log.isDebugEnabled()) {
+                // If debug is enabled, log the stack trace.
+                log.debug(
+                        "Created Apache client {} {} {} {}",
+                        SafeArg.of("name", clientName),
+                        SafeArg.of("client", Integer.toHexString(System.identityHashCode(apacheClient))),
+                        UnsafeArg.of("clientConfiguration", clientConfiguration),
+                        UnsafeArg.of("executor", executor),
+                        new SafeRuntimeException("Created here"));
+            } else {
+                log.info(
+                        "Created Apache client {} {} {} {}",
+                        SafeArg.of("name", clientName),
+                        SafeArg.of("client", Integer.toHexString(System.identityHashCode(apacheClient))),
+                        UnsafeArg.of("clientConfiguration", clientConfiguration),
+                        UnsafeArg.of("executor", executor));
+            }
             Meter createMeter = DialogueClientMetrics.of(clientConfiguration.taggedMetricRegistry())
                     .create()
                     .clientName(clientName)

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -77,7 +77,7 @@ final class ChannelCache {
         int numLiveInstances = LIVE_INSTANCES.size();
         if ((numLiveInstances > 1 && log.isInfoEnabled()) || log.isDebugEnabled()) {
             log.info(
-                    "Created ChannelCache instance #{} ({} alive): {} {}",
+                    "Created ChannelCache instance #{} ({} alive): {}",
                     SafeArg.of("instanceNumber", newCache.instanceNumber),
                     SafeArg.of("totalAliveNow", numLiveInstances),
                     SafeArg.of("newCache", newCache),


### PR DESCRIPTION
## Before this PR
Lots of clients are created. Who knows where, they all use the same generic channel name!

## After this PR
==COMMIT_MSG==
Log apache httpclient creation location when debug logging is enabled
==COMMIT_MSG==