### PR TITLE
Handshakes are timed out based on the connect timeout

### DIFF
--- a/changelog/@unreleased/pr-1089.v2.yml
+++ b/changelog/@unreleased/pr-1089.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Handshake time is bounded based on the connect timeout
+  links:
+  - https://github.com/palantir/dialogue/pull/1089

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -114,6 +114,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                     e,
                     SafeArg.of("durationMillis", durationMillis),
                     SafeArg.of("connectTimeout", client.clientConfiguration().connectTimeout()),
+                    SafeArg.of("socketTimeout", client.clientConfiguration().readTimeout()),
                     SafeArg.of("clientName", client.name()));
         }
     }

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTimeoutTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTimeoutTest.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Test;
+
+class ApacheHttpClientChannelsTimeoutTest {
+    private static final String NAME = "name";
+
+    @Test
+    void testConnectionTimeoutUsed() {
+        Timeout connectTimeout = Timeout.ofSeconds(15);
+        Timeout socketTimeout = Timeout.ofSeconds(30);
+        assertThat(ApacheHttpClientChannels.getHandshakeTimeout(connectTimeout, socketTimeout, NAME))
+                .as("Expected the connect timeout")
+                .isEqualTo(connectTimeout);
+    }
+
+    @Test
+    void testDefaultTimeoutUsed() {
+        Timeout connectTimeout = Timeout.ofMilliseconds(1);
+        Timeout socketTimeout = Timeout.ofSeconds(30);
+        assertThat(ApacheHttpClientChannels.getHandshakeTimeout(connectTimeout, socketTimeout, NAME))
+                .as("Default timeout expected when the connect timeout is low and the socket timeout is large")
+                .isEqualTo(ApacheHttpClientChannels.DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    @Test
+    void testSocketTimeoutUsed() {
+        Timeout connectTimeout = Timeout.ofMilliseconds(1);
+        Timeout socketTimeout = Timeout.ofSeconds(5);
+        assertThat(ApacheHttpClientChannels.getHandshakeTimeout(connectTimeout, socketTimeout, NAME))
+                .as("The lesser of the socket timeout and default timeout should be used: Expected the socket timeout")
+                .isEqualTo(socketTimeout);
+    }
+}


### PR DESCRIPTION
Note: I don't want this to merge until we've collected some initial data using #1088

## Before this PR
Our metrics for time to create connections (including socket bind + handshake) have a soft cap around ten seconds, with many spikes substantially higher where we're only bounded by the socket timeout (default 5 minutes).
A previous attempt to resolve this problem resulted in a self-ddos for clients with unusually low connect timeouts. It's not unusual for a handshake to take a couple hundred milliseconds. See #930 for the revert.

## After this PR
==COMMIT_MSG==
Handshake time is bounded based on the connect timeout
==COMMIT_MSG==

Note that the connect timeout isn't always used directly, only
if it's ten seconds or greater. Otherwise, the minimum of ten seconds
and the configured socket timeout is used. This allows us to
retry on another host when handshakes are blocked (gc storm on
the target) without risking overwhelming hosts when the connect
timeout is set to an unusually low value.

## Possible downsides?
It's possible that there are common >5s gc pauses after which we want to allow connections to be created. It's hard to imagine that we would want to wait so long for a handshake, and in most cases we're better off penalizing the host to prevent subsequent slow attempts.

## Future work
The default handshake value (internal concept, not part of the configuration) is set to a relatively conservative ten seconds. We should monitor the metrics and reduce our value further if we don't encounter problems.