### PR TITLE
Fix Response leak in `EndToEndBenchmark.rawApacheBlocking`

### DIFF
--- a/dialogue-jmh/src/main/java/com/palantir/dialogue/core/EndToEndBenchmark.java
+++ b/dialogue-jmh/src/main/java/com/palantir/dialogue/core/EndToEndBenchmark.java
@@ -160,7 +160,7 @@ public class EndToEndBenchmark {
     @Threads(4)
     @Benchmark
     public void rawApacheBlocking() {
-        clientUtils.block(apacheChannel.execute(TestEndpoint.GET, request));
+        clientUtils.block(apacheChannel.execute(TestEndpoint.GET, request)).close();
     }
 
     private static String getUri(Undertow undertow) {


### PR DESCRIPTION
non-production code change.

==COMMIT_MSG==
Fix Response leak in `EndToEndBenchmark.rawApacheBlocking`
==COMMIT_MSG==
