### PR TITLE
Reduce socket timeout logging from WARN to INFO

### DIFF
--- a/changelog/@unreleased/pr-1104.v2.yml
+++ b/changelog/@unreleased/pr-1104.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce socket timeout logging from WARN to INFO
+  links:
+  - https://github.com/palantir/dialogue/pull/1104

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -487,7 +487,7 @@ public final class ApacheHttpClientChannels {
     private static Timeout getSocketTimeout(ClientConfiguration conf, String clientName) {
         long socketTimeoutMillis = conf.readTimeout().toMillis();
         if (conf.readTimeout().toMillis() != conf.writeTimeout().toMillis()) {
-            log.warn(
+            log.info(
                     "Read and write timeouts do not match, The value of the readTimeout {} will be used and write "
                             + "timeout {} will be ignored. Client: {}",
                     SafeArg.of("readTimeout", conf.readTimeout()),


### PR DESCRIPTION
## Before this PR
It's common for this to occur when read-timeout is modified, and
doesn't suggest a problem. Warnings contribute to alerting, and
should be reserved for more significant events.

## After this PR
==COMMIT_MSG==
Reduce socket timeout logging from WARN to INFO
==COMMIT_MSG==
