### PR TITLE
Clients.callBlocking provides a default implementation

### DIFF
--- a/changelog/@unreleased/pr-1106.v2.yml
+++ b/changelog/@unreleased/pr-1106.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Clients.callBlocking provides a default implementation for cross-version compatibility
+  links:
+  - https://github.com/palantir/dialogue/pull/1106

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Clients.java
@@ -39,7 +39,9 @@ public interface Clients {
     /**
      * Blocking version of {@link #call(EndpointChannel, Request, Deserializer)}.
      */
-    <T> T callBlocking(EndpointChannel channel, Request request, Deserializer<T> deserializer);
+    default <T> T callBlocking(EndpointChannel channel, Request request, Deserializer<T> deserializer) {
+        return block(call(channel, request, deserializer));
+    }
 
     default EndpointChannel bind(Channel channel, Endpoint endpoint) {
         return new EndpointChannel() {


### PR DESCRIPTION
This provides safety in case a newer target is used than implementation,
which can occur when a project pulls in generated bindings with a
newer target dep.
Long term we should consider using constraints to avoid version
slip between jars produced by the same repository.

==COMMIT_MSG==
Clients.callBlocking provides a default implementation for cross-version compatibility
==COMMIT_MSG==
