### PR TITLE
TraceEnrichingChannel uses the traceId from TraceMetadata

### DIFF
--- a/changelog/@unreleased/pr-1111.v2.yml
+++ b/changelog/@unreleased/pr-1111.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: TraceEnrichingChannel uses the traceId from TraceMetadata
+  links:
+  - https://github.com/palantir/dialogue/pull/1111

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/TraceEnrichingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/TraceEnrichingChannel.java
@@ -64,7 +64,7 @@ final class TraceEnrichingChannel implements Channel {
 
         Request.Builder tracedRequest = Request.builder()
                 .from(request)
-                .putHeaderParams(TraceHttpHeaders.TRACE_ID, Tracer.getTraceId())
+                .putHeaderParams(TraceHttpHeaders.TRACE_ID, metadata.getTraceId())
                 .putHeaderParams(TraceHttpHeaders.SPAN_ID, metadata.getSpanId())
                 .putHeaderParams(TraceHttpHeaders.IS_SAMPLED, Tracer.isTraceObservable() ? "1" : "0");
 


### PR DESCRIPTION
Probably worthwhile to include `isTraceObservable` in the
`TraceMetadata` as well, but we can do that separately.

## Before this PR
Unnecessary additional static data access.

## After this PR
==COMMIT_MSG==
TraceEnrichingChannel uses the traceId from TraceMetadata
==COMMIT_MSG==
