### PR TITLE
Disable the markdown check to allow builds when unrelated sites have outages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,13 +142,6 @@ jobs:
       - store_test_results: { path: ~/junit }
       - store_artifacts: { path: ~/artifacts }
 
-  markdown:
-    docker: [{ image: 'raviqqe/liche:0.1.1' }]
-    steps:
-      - checkout
-      - run: /liche -d . -r . -v
-
-
 workflows:
   version: 2
   build:
@@ -162,9 +155,6 @@ workflows:
 
       - check:
           requires: [ compile ]
-          filters: { tags: { only: /.*/ } }
-
-      - markdown:
           filters: { tags: { only: /.*/ } }
 
       - trial-publish:


### PR DESCRIPTION
## Before this PR
Can't PR or publish.

## After this PR
==COMMIT_MSG==
Disable the markdown check to allow builds when unrelated sites have outages
==COMMIT_MSG==

## Possible downsides?
Markdown might have issues.
