### PR TITLE
Dialogue client exceptions are given additional diagnostic arguments

### DIFF
--- a/changelog/@unreleased/pr-1132.v2.yml
+++ b/changelog/@unreleased/pr-1132.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue client exceptions are given additional diagnostic arguments
+  links:
+  - https://github.com/palantir/dialogue/pull/1132

--- a/dialogue-apache-hc5-client/build.gradle
+++ b/dialogue-apache-hc5-client/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api 'org.apache.httpcomponents.client5:httpclient5'
     implementation project(':dialogue-blocking-channels')
     implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'com.palantir.tracing:tracing-api'
     implementation 'com.palantir.tritium:tritium-metrics'
     implementation 'com.palantir.safethreadlocalrandom:safe-thread-local-random'
     implementation 'com.palantir.tracing:tracing'

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -161,6 +161,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
         }
 
         @Override
+        @SuppressWarnings("UnsynchronizedOverridesSynchronized") // nop
         public Throwable fillInStackTrace() {
             // no-op: stack trace generation is expensive, this type exists
             // to simply associate diagnostic information with a failure.


### PR DESCRIPTION
## Before this PR
No way to directly associate a single client exception with a request received by the server.
Only SafeConnectTimeoutException provided additional failure args, not other failure types.

## After this PR
==COMMIT_MSG==
Dialogue client exceptions are given additional diagnostic arguments
==COMMIT_MSG==
