### PR TITLE
Downgrade Caffeine cache to 2.9.0 to avoid a java 11 requirement

### DIFF
--- a/changelog/@unreleased/pr-1134.v2.yml
+++ b/changelog/@unreleased/pr-1134.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Downgrade Caffeine cache to 2.9.0 to avoid a java 11 requirement
+  links:
+  - https://github.com/palantir/dialogue/pull/1134

--- a/versions.lock
+++ b/versions.lock
@@ -9,7 +9,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-guava:2.12.1 (2 constraints: 2f2
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.1 (3 constraints: fd37e505)
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1 (2 constraints: 2f2ba586)
 com.fasterxml.jackson.module:jackson-module-afterburner:2.12.1 (3 constraints: fd37e505)
-com.github.ben-manes.caffeine:caffeine:3.0.0 (2 constraints: bb17974d)
+com.github.ben-manes.caffeine:caffeine:2.9.0 (2 constraints: c3174d4f)
 com.google.code.findbugs:jsr305:3.0.2 (11 constraints: 6b9fbbdf)
 com.google.errorprone:error_prone_annotations:2.5.1 (8 constraints: 347c3f9d)
 com.google.guava:failureaccess:1.0.1 (1 constraints: 140ae1b4)

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,3 @@
-com.github.ben-manes.caffeine:caffeine = 3.0.0
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.guava:guava = 30.1-jre
 com.palantir.conjure:conjure = 4.14.2
@@ -47,4 +46,7 @@ com.palantir.conjure.java.runtime:* = 5.10.0
 # dependency-upgrader:OFF
 # Avoid forcing consumers to upgrade jackson
 com.fasterxml.jackson.*:jackson-* = 2.11.1
+
+# Avoid forcing a java 11 requirement
+com.github.ben-manes.caffeine:caffeine = 2.9.0
 # dependency-upgrader:ON


### PR DESCRIPTION
## Before this PR
no java8 consumers

## After this PR
==COMMIT_MSG==
Downgrade Caffeine cache to 2.9.0 to avoid a java 11 requirement
==COMMIT_MSG==

## Possible downsides?
old library version