### PR TITLE
Blocking clients use the calling thread executor by default

### DIFF
--- a/changelog/@unreleased/pr-1137.v2.yml
+++ b/changelog/@unreleased/pr-1137.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Blocking clients use the calling thread executor by default
+  links:
+  - https://github.com/palantir/dialogue/pull/1137

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/UseCallingThreadExecutor.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/UseCallingThreadExecutor.java
@@ -38,7 +38,7 @@ final class UseCallingThreadExecutor {
     static final String SYSTEM_PROPERTY = "dialogue.experimental.blockoncallingthread.rate";
 
     @VisibleForTesting
-    static final float DEFAULT_PROBABILITY = 0.01f;
+    static final float DEFAULT_PROBABILITY = 1.0f;
 
     private static final Logger log = LoggerFactory.getLogger(UseCallingThreadExecutor.class);
 


### PR DESCRIPTION
We haven't encountered issues using the calling thread executor
for 1% of operations, it's time to enable the feature everywhere.

==COMMIT_MSG==
Blocking clients use the calling thread executor by default
==COMMIT_MSG==