### PR TITLE
Annotation based solution to avoid static method string matching

### DIFF
--- a/changelog/@unreleased/pr-1138.v2.yml
+++ b/changelog/@unreleased/pr-1138.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Annotation based solution to avoid static method string matching
+  links:
+  - https://github.com/palantir/dialogue/pull/1138

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -81,21 +81,21 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
     @Override
     public <T> T get(Class<T> serviceClass, String serviceName) {
-        Channel channel = getChannel(serviceName);
+        EndpointChannelFactory factory = getChannel(serviceName);
         ConjureRuntime runtime = params.runtime();
-        return Reflection.callStaticFactoryMethod(serviceClass, channel, runtime);
+        return Reflection.callStaticEndpointChannelFactoryMethod(serviceClass, factory, runtime);
     }
 
     @Override
     public <T> T getNonReloading(Class<T> clazz, ServiceConfiguration serviceConf) {
-        Channel channel = cache.getNonReloadingChannel(
+        EndpointChannelFactory factory = cache.getNonReloadingChannel(
                 params, serviceConf, ChannelNames.nonReloading(clazz, params), OptionalInt.empty());
 
-        return Reflection.callStaticFactoryMethod(clazz, channel, params.runtime());
+        return Reflection.callStaticEndpointChannelFactoryMethod(clazz, factory, params.runtime());
     }
 
     @Override
-    public Channel getChannel(String serviceName) {
+    public LiveReloadingChannel getChannel(String serviceName) {
         Preconditions.checkNotNull(serviceName, "serviceName");
         String channelName = ChannelNames.reloading(serviceName, params);
 
@@ -166,10 +166,15 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
                 return perHostDialogueChannels.map(ImmutableList::copyOf);
             }
 
+            private Refreshable<List<DialogueChannel>> getPerHostChannelsInternal() {
+                return perHostDialogueChannels.map(ImmutableList::copyOf);
+            }
+
             @Override
             public <T> Refreshable<List<T>> getPerHost(Class<T> clientInterface) {
-                return getPerHostChannels().map(channels -> channels.stream()
-                        .map(chan -> Reflection.callStaticFactoryMethod(clientInterface, chan, params.runtime()))
+                return getPerHostChannelsInternal().map(channels -> channels.stream()
+                        .map(chan -> Reflection.callStaticEndpointChannelFactoryMethod(
+                                clientInterface, (EndpointChannelFactory) chan, params.runtime()))
                         .collect(ImmutableList.toImmutableList()));
             }
 

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReflectionTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReflectionTest.java
@@ -1,0 +1,105 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.EndpointChannelFactory;
+import org.junit.jupiter.api.Test;
+
+class ReflectionTest {
+    private static final ConjureRuntime RUNTIME =
+            DefaultConjureRuntime.builder().build();
+
+    @Test
+    void testAnnotationIsPreferred() {
+        Channel channel = mock(Channel.class);
+        Client0 client = Reflection.callStaticFactoryMethod(Client0.class, channel, RUNTIME);
+        assertThat(client).isEqualTo(Client0Impls.THIRD);
+    }
+
+    @Test
+    void testChannelFactoryUsedOverEndpointFactory() {
+        // No real reason for this decision other than historical context, no reason to move to an intermediate
+        // factory when the annotation model is preferred.
+        Channel channel = mock(Channel.class);
+        Client1 client = Reflection.callStaticFactoryMethod(Client1.class, channel, RUNTIME);
+        assertThat(client).isEqualTo(Client1Impls.SECOND);
+    }
+
+    @Test
+    void testStaticEndpointChannelFactoryIsUsed() {
+        Channel channel = mock(Channel.class);
+        Client2 client = Reflection.callStaticFactoryMethod(Client2.class, channel, RUNTIME);
+        assertThat(client).isNotNull();
+    }
+
+    @DialogueService(Client0Factory.class)
+    interface Client0 {
+
+        static Client0 of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+            return Client0Impls.FIRST;
+        }
+
+        static Client0 of(Channel _channel, ConjureRuntime _runtime) {
+            return Client0Impls.SECOND;
+        }
+    }
+
+    public static final class Client0Factory implements DialogueServiceFactory<Client0> {
+
+        @Override
+        public Client0 create(EndpointChannelFactory EndpointChannelFactory, ConjureRuntime runtime) {
+            return Client0Impls.THIRD;
+        }
+    }
+
+    enum Client0Impls implements Client0 {
+        FIRST,
+        SECOND,
+        THIRD;
+    }
+
+    interface Client1 {
+
+        static Client1 of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+            return Client1Impls.FIRST;
+        }
+
+        static Client1 of(Channel _channel, ConjureRuntime _runtime) {
+            return Client1Impls.SECOND;
+        }
+    }
+
+    enum Client1Impls implements Client1 {
+        FIRST,
+        SECOND;
+    }
+
+    interface Client2 {
+
+        static Client2 of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+            return new Client2() {};
+        }
+    }
+}

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReflectionTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReflectionTest.java
@@ -69,7 +69,7 @@ class ReflectionTest {
     public static final class Client0Factory implements DialogueServiceFactory<Client0> {
 
         @Override
-        public Client0 create(EndpointChannelFactory EndpointChannelFactory, ConjureRuntime runtime) {
+        public Client0 create(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
             return Client0Impls.THIRD;
         }
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/DialogueService.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/DialogueService.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DialogueService {
+
+    /** Factory used to create an instance of the annotated class. */
+    Class<? extends DialogueServiceFactory<?>> value();
+}

--- a/dialogue-target/src/main/java/com/palantir/dialogue/DialogueServiceFactory.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/DialogueServiceFactory.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+/**
+ * {@link DialogueServiceFactory} creates a DialogueService of type {@link T}.
+ */
+public interface DialogueServiceFactory<T> {
+
+    /** Create a dialogue service. */
+    T create(EndpointChannelFactory EndpointChannelFactory, ConjureRuntime runtime);
+}

--- a/dialogue-target/src/main/java/com/palantir/dialogue/DialogueServiceFactory.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/DialogueServiceFactory.java
@@ -22,5 +22,5 @@ package com.palantir.dialogue;
 public interface DialogueServiceFactory<T> {
 
     /** Create a dialogue service. */
-    T create(EndpointChannelFactory EndpointChannelFactory, ConjureRuntime runtime);
+    T create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime);
 }


### PR DESCRIPTION
This approach uses the old implemnetation as a fallback, but allows
us to simplify creation using an intermediate factory that must
provide a public no-arg constructor.

This will help us unify the annotation processor and conjure generated
services.

==COMMIT_MSG==
Annotation based solution to avoid static method string matching
==COMMIT_MSG==
