### PR TITLE
fix #1143: Gracefully handle service names which aren't valid agents

### DIFF
--- a/changelog/@unreleased/pr-1144.v2.yml
+++ b/changelog/@unreleased/pr-1144.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Gracefully handle service names which aren't valid agents
+  links:
+  - https://github.com/palantir/dialogue/pull/1144

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UserAgentEndpointChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UserAgentEndpointChannelTest.java
@@ -29,7 +29,6 @@ import com.palantir.dialogue.TestEndpoint;
 import com.palantir.dialogue.UrlBuilder;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -48,9 +47,6 @@ public final class UserAgentEndpointChannelTest {
 
     @Captor
     private ArgumentCaptor<Request> requestCaptor;
-
-    @BeforeEach
-    public void before() {}
 
     private Request request = Request.builder()
             .putHeaderParams("header", "value")

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UserAgentEndpointChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UserAgentEndpointChannelTest.java
@@ -21,9 +21,13 @@ import static org.mockito.Mockito.verify;
 
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.TestEndpoint;
+import com.palantir.dialogue.UrlBuilder;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,12 +49,8 @@ public final class UserAgentEndpointChannelTest {
     @Captor
     private ArgumentCaptor<Request> requestCaptor;
 
-    private EndpointChannel channel;
-
     @BeforeEach
-    public void before() {
-        channel = UserAgentEndpointChannel.create(delegate, TestEndpoint.POST, baseAgent);
-    }
+    public void before() {}
 
     private Request request = Request.builder()
             .putHeaderParams("header", "value")
@@ -60,6 +60,7 @@ public final class UserAgentEndpointChannelTest {
 
     @Test
     public void injectsDialogueVersionAndEndpointVersion() {
+        EndpointChannel channel = UserAgentEndpointChannel.create(delegate, TestEndpoint.POST, baseAgent);
         // Special case: In IDEs, tests are run against classes (not JARs) and thus don't carry versions.
         String dialogueVersion = Optional.ofNullable(Channel.class.getPackage().getImplementationVersion())
                 .orElse("0.0.0");
@@ -68,5 +69,43 @@ public final class UserAgentEndpointChannelTest {
         verify(delegate).execute(requestCaptor.capture());
         assertThat(requestCaptor.getValue().headerParams().get("user-agent"))
                 .containsExactly("test-class/1.2.3 service/1.0.0 dialogue/" + dialogueVersion);
+    }
+
+    @Test
+    public void testServiceNameIsNotValidConjureAgent() {
+        EndpointChannel channel = UserAgentEndpointChannel.create(
+                delegate,
+                new Endpoint() {
+                    @Override
+                    public void renderPath(Map<String, String> params, UrlBuilder url) {}
+
+                    @Override
+                    public HttpMethod httpMethod() {
+                        return HttpMethod.GET;
+                    }
+
+                    @Override
+                    public String serviceName() {
+                        return "Service_Name";
+                    }
+
+                    @Override
+                    public String endpointName() {
+                        return "endpoint";
+                    }
+
+                    @Override
+                    public String version() {
+                        return "4.5.6";
+                    }
+                },
+                baseAgent);
+        // Special case: In IDEs, tests are run against classes (not JARs) and thus don't carry versions.
+        String dialogueVersion = Optional.ofNullable(Channel.class.getPackage().getImplementationVersion())
+                .orElse("0.0.0");
+        channel.execute(request);
+        verify(delegate).execute(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().headerParams().get("user-agent"))
+                .containsExactly("test-class/1.2.3 dialogue/" + dialogueVersion);
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UserAgentEndpointChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UserAgentEndpointChannelTest.java
@@ -77,7 +77,7 @@ public final class UserAgentEndpointChannelTest {
                 delegate,
                 new Endpoint() {
                     @Override
-                    public void renderPath(Map<String, String> params, UrlBuilder url) {}
+                    public void renderPath(Map<String, String> _params, UrlBuilder _url) {}
 
                     @Override
                     public HttpMethod httpMethod() {


### PR DESCRIPTION
In a future change we may wish to massage these values into a valid
format, however it's rare that this occurs, so excluding the data
is a reasonable enough path forward for now.

## Before this PR
Exceptions

## After this PR
==COMMIT_MSG==
Gracefully handle service names which aren't valid agents
==COMMIT_MSG==