### PR TITLE
Dialogue produces a safe NPE when null values are received

### DIFF
--- a/changelog/@unreleased/pr-1148.v2.yml
+++ b/changelog/@unreleased/pr-1148.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Dialogue produces a safe NPE when unexpected null values are received
+  links:
+  - https://github.com/palantir/dialogue/pull/1148

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encodings.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/Encodings.java
@@ -69,9 +69,7 @@ public final class Encodings {
             return input -> {
                 try (InputStream inputStream = input) {
                     T value = reader.readValue(inputStream);
-                    // Bad input should result in a 4XX response status, throw IAE rather than NPE.
-                    Preconditions.checkArgument(value != null, "cannot deserialize a JSON null value");
-                    return value;
+                    return Preconditions.checkNotNull(value, "cannot deserialize a JSON null value");
                 } catch (MismatchedInputException e) {
                     throw new SafeRuntimeException(
                             "Failed to deserialize response stream. Syntax error?",

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/EncodingsTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/EncodingsTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.palantir.dialogue.TypeMarker;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.ByteArrayInputStream;
@@ -58,7 +57,7 @@ public final class EncodingsTest {
     public void json_deserialize_rejectsNulls() throws IOException {
         // TODO(rfink): Do we need to test this for all primitive types?
         assertThatThrownBy(() -> deserialize(asStream("null"), new TypeMarker<String>() {}))
-                .isInstanceOf(SafeIllegalArgumentException.class);
+                .isInstanceOf(SafeNullPointerException.class);
         assertThat(deserialize(asStream("null"), new TypeMarker<Optional<String>>() {}))
                 .isEmpty();
     }


### PR DESCRIPTION
Previously we used code borrowed from a server implementation
which produced an IAE that some frameworks will transform into
a 4xx. That behavior is incorrect when a client receives an
unexpected null value, and the client should produce a 5xx.

==COMMIT_MSG==
Dialogue produces a safe NPE when unexpected null values are received
==COMMIT_MSG==