### PR TITLE
Dialogue allows the default port to be used based on the input URI

### DIFF
--- a/changelog/@unreleased/pr-1194.v2.yml
+++ b/changelog/@unreleased/pr-1194.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue allows the default port to be used based on the input URI
+  links:
+  - https://github.com/palantir/dialogue/pull/1194

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -98,8 +98,9 @@ public final class BaseUrl {
         private DefaultUrlBuilder(URL url) {
             this.protocol = url.getProtocol();
             this.host = url.getHost();
-            this.port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();
-            Preconditions.checkArgument(port >= 0 && port <= 65535, "port must be in range [0, 65535]");
+            this.port = url.getPort();
+            Preconditions.checkArgument(
+                    port >= -1 && port <= 65535, "port must be in range [0, 65535] or default [-1]");
             String strippedBasePath = stripSlashes(url.getPath());
             if (!strippedBasePath.isEmpty()) {
                 encodedPathSegments(strippedBasePath);
@@ -155,7 +156,8 @@ public final class BaseUrl {
             try {
                 Preconditions.checkNotNull(protocol, "protocol must be set");
                 Preconditions.checkNotNull(host, "host must be set");
-                Preconditions.checkArgument(port != -1, "port must be set");
+                // Allow default ports
+                Preconditions.checkArgument(port >= -1, "port must be set");
 
                 StringBuilder file = new StringBuilder();
                 encodePath(pathSegments, file);

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -38,22 +38,23 @@ public final class UrlBuilderTest {
     }
 
     @Test
-    public void populatesDefaultPort() throws Exception {
+    public void doesNotPopulateDefaultPort() throws Exception {
+        // Some servers do not allow ports in the Host header, so we respect the input URI.
         assertThat(BaseUrl.DefaultUrlBuilder.from(new URL("http://host"))
                         .build()
                         .toString())
-                .isEqualTo("http://host:80");
+                .isEqualTo("http://host");
         assertThat(BaseUrl.DefaultUrlBuilder.from(new URL("https://host"))
                         .build()
                         .toString())
-                .isEqualTo("https://host:443");
+                .isEqualTo("https://host");
     }
 
     @Test
     public void validatesPort() {
         assertThatThrownBy(() -> BaseUrl.DefaultUrlBuilder.from(new URL("http://host:65536"))
                         .build())
-                .hasMessage("port must be in range [0, 65535]");
+                .hasMessage("port must be in range [0, 65535] or default [-1]");
     }
 
     @Test


### PR DESCRIPTION
This behavior is based on the configured URI -- URIs which provide
a port result in a `Host` header containing a port, and those which
rely on the implicit default (e.g. http -> 80, https -> 443) do
not include the port in their `Host` header.

## Before this PR
It turns out some servers require that the default port is used,
and _not_ included in URIs. Until we have a better way to test this
I've opted not to exclude default ports everywhere, only when
the provided URI doesn't include a port. Testing is difficult because
permissions are required to run a server on port 80 or 443 to verify,
however I have validated that this behaves in the way we expect
locally.

## After this PR
==COMMIT_MSG==
Dialogue allows the default port to be used based on the input URI
==COMMIT_MSG==

## Possible downsides?
Difficult to test as described above
