### PR TITLE
Dialogue retries include causal status code

### DIFF
--- a/changelog/@unreleased/pr-1214.v2.yml
+++ b/changelog/@unreleased/pr-1214.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue retries include causal status code
+  links:
+  - https://github.com/palantir/dialogue/pull/1214


### PR DESCRIPTION
Previously if trace logging was disabled, we didn't capture status
code information. This resulted in an inability to tell whether
responses causing queueing used status code 429 or 503.

==COMMIT_MSG==
Dialogue retries include causal status code
==COMMIT_MSG==
