### PR TITLE
Drop exceptional log level in ChannelCache under normal conditions

### DIFF
--- a/changelog/@unreleased/pr-1217.v2.yml
+++ b/changelog/@unreleased/pr-1217.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Drop exceptional log level in ChannelCache under normal conditions
+  links:
+  - https://github.com/palantir/dialogue/pull/1217

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -80,14 +80,14 @@ final class ChannelCache {
                     "Created ChannelCache instance #{} ({} alive): {}",
                     SafeArg.of("instanceNumber", newCache.instanceNumber),
                     SafeArg.of("totalAliveNow", numLiveInstances),
-                    SafeArg.of("newCache", newCache),
-                    new SafeRuntimeException("ChannelCache constructed here"));
+                    SafeArg.of("newCache", newCache));
         } else if (numLiveInstances >= 1 && log.isDebugEnabled()) {
             log.debug(
                     "Created ChannelCache instance #{} ({} alive): {}",
                     SafeArg.of("instanceNumber", newCache.instanceNumber),
                     SafeArg.of("totalAliveNow", numLiveInstances),
-                    SafeArg.of("newCache", newCache));
+                    SafeArg.of("newCache", newCache),
+                    new SafeRuntimeException("ChannelCache constructed here"));
         }
 
         return newCache;

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -75,13 +75,19 @@ final class ChannelCache {
         LIVE_INSTANCES.add(newCache);
 
         int numLiveInstances = LIVE_INSTANCES.size();
-        if ((numLiveInstances > 1 && log.isInfoEnabled()) || log.isDebugEnabled()) {
+        if ((numLiveInstances >= 10 && log.isInfoEnabled())) {
             log.info(
                     "Created ChannelCache instance #{} ({} alive): {}",
                     SafeArg.of("instanceNumber", newCache.instanceNumber),
                     SafeArg.of("totalAliveNow", numLiveInstances),
                     SafeArg.of("newCache", newCache),
                     new SafeRuntimeException("ChannelCache constructed here"));
+        } else if (numLiveInstances >= 1 && log.isDebugEnabled()) {
+            log.debug(
+                    "Created ChannelCache instance #{} ({} alive): {}",
+                    SafeArg.of("instanceNumber", newCache.instanceNumber),
+                    SafeArg.of("totalAliveNow", numLiveInstances),
+                    SafeArg.of("newCache", newCache));
         }
 
         return newCache;

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -75,19 +75,21 @@ final class ChannelCache {
         LIVE_INSTANCES.add(newCache);
 
         int numLiveInstances = LIVE_INSTANCES.size();
-        if ((numLiveInstances >= 10 && log.isInfoEnabled())) {
-            log.info(
-                    "Created ChannelCache instance #{} ({} alive): {}",
-                    SafeArg.of("instanceNumber", newCache.instanceNumber),
-                    SafeArg.of("totalAliveNow", numLiveInstances),
-                    SafeArg.of("newCache", newCache));
-        } else if (numLiveInstances >= 1 && log.isDebugEnabled()) {
-            log.debug(
-                    "Created ChannelCache instance #{} ({} alive): {}",
-                    SafeArg.of("instanceNumber", newCache.instanceNumber),
-                    SafeArg.of("totalAliveNow", numLiveInstances),
-                    SafeArg.of("newCache", newCache),
-                    new SafeRuntimeException("ChannelCache constructed here"));
+        if ((numLiveInstances > 1 && log.isInfoEnabled()) || log.isDebugEnabled()) {
+            if (numLiveInstances >= 10) {
+                log.info(
+                        "Created ChannelCache instance #{} ({} alive): {}",
+                        SafeArg.of("instanceNumber", newCache.instanceNumber),
+                        SafeArg.of("totalAliveNow", numLiveInstances),
+                        SafeArg.of("newCache", newCache),
+                        new SafeRuntimeException("ChannelCache constructed here"));
+            } else {
+                log.info(
+                        "Created ChannelCache instance #{} ({} alive): {}",
+                        SafeArg.of("instanceNumber", newCache.instanceNumber),
+                        SafeArg.of("totalAliveNow", numLiveInstances),
+                        SafeArg.of("newCache", newCache));
+            }
         }
 
         return newCache;


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

An exception was logged all the time, even under healthy conditions.

## After this PR
==COMMIT_MSG==
Drop exceptional log level in ChannelCache under normal conditions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
