### PR TITLE
[Experiment] Use Request#attachments to associate requests coming from same sticky channel instance.

### DIFF
--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -41,7 +41,6 @@ import com.palantir.dialogue.Response;
 import com.palantir.dialogue.clients.DialogueClients.PerHostClientFactory;
 import com.palantir.dialogue.clients.DialogueClients.StickyChannelFactory;
 import com.palantir.dialogue.core.DialogueChannel;
-import com.palantir.dialogue.core.LimitedChannelAttachments;
 import com.palantir.dialogue.core.StickyEndpointChannels;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -54,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -210,12 +208,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         return new StickyChannelFactory() {
             @Override
             public Channel getStickyChannel() {
-                Channel underlyingChannel = bestSupplier.get().get();
-                UUID id = UUID.randomUUID();
-                return (endpoint, request) -> {
-                    LimitedChannelAttachments.addLimitingKey(request, id);
-                    return underlyingChannel.execute(endpoint, request);
-                };
+                return bestSupplier.get().get();
             }
 
             @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
@@ -34,6 +34,6 @@ public final class LimitedChannelAttachments {
 
     @CheckForNull
     static UUID getLimitingKeyOrDefault(Request request) {
-        return request.attachments().getOrDefault(LIMITER_KEY, null);
+        return request.attachments().getOrDefault(LIMITER_KEY, GLOBAL_QUEUE);
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
@@ -31,6 +31,7 @@ public final class LimitedChannelAttachments {
         request.attachments().put(LIMITER_KEY, value);
     }
 
+    @SuppressWarnings("NullAway")
     static UUID getLimitingKeyOrDefault(Request request) {
         return request.attachments().getOrDefault(LIMITER_KEY, GLOBAL_QUEUE);
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
@@ -19,7 +19,6 @@ package com.palantir.dialogue.core;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestAttachmentKey;
 import java.util.UUID;
-import javax.annotation.CheckForNull;
 
 public final class LimitedChannelAttachments {
 
@@ -32,7 +31,6 @@ public final class LimitedChannelAttachments {
         request.attachments().put(LIMITER_KEY, value);
     }
 
-    @CheckForNull
     static UUID getLimitingKeyOrDefault(Request request) {
         return request.attachments().getOrDefault(LIMITER_KEY, GLOBAL_QUEUE);
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
@@ -19,11 +19,12 @@ package com.palantir.dialogue.core;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestAttachmentKey;
 import java.util.UUID;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 
 public final class LimitedChannelAttachments {
 
     private static final RequestAttachmentKey<UUID> LIMITER_KEY = RequestAttachmentKey.create(UUID.class);
-    private static final UUID GLOBAL_QUEUE = UUID.randomUUID();
 
     private LimitedChannelAttachments() {}
 
@@ -31,8 +32,8 @@ public final class LimitedChannelAttachments {
         request.attachments().put(LIMITER_KEY, value);
     }
 
-    @SuppressWarnings("NullAway")
-    static UUID getLimitingKeyOrDefault(Request request) {
-        return request.attachments().getOrDefault(LIMITER_KEY, GLOBAL_QUEUE);
+    @CheckForNull
+    static UUID getLimitingKeyOrDefault(Request request, @Nullable UUID defaultValue) {
+        return request.attachments().getOrDefault(LIMITER_KEY, defaultValue);
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannelAttachments.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestAttachmentKey;
+import java.util.UUID;
+import javax.annotation.CheckForNull;
+
+public final class LimitedChannelAttachments {
+
+    private static final RequestAttachmentKey<UUID> LIMITER_KEY = RequestAttachmentKey.create(UUID.class);
+    private static final UUID GLOBAL_QUEUE = UUID.randomUUID();
+
+    private LimitedChannelAttachments() {}
+
+    public static void addLimitingKey(Request request, UUID value) {
+        request.attachments().put(LIMITER_KEY, value);
+    }
+
+    @CheckForNull
+    static UUID getLimitingKeyOrDefault(Request request) {
+        return request.attachments().getOrDefault(LIMITER_KEY, null);
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyEndpointChannels.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyEndpointChannels.java
@@ -34,6 +34,7 @@ import com.palantir.random.SafeThreadLocalRandom;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -64,7 +65,12 @@ public final class StickyEndpointChannels implements Supplier<Channel> {
      */
     @Override
     public Channel get() {
-        return new Sticky(channels, tracker);
+        Channel underlyingChannel = new Sticky(channels, tracker);
+        UUID id = UUID.randomUUID();
+        return (endpoint, request) -> {
+            LimitedChannelAttachments.addLimitingKey(request, id);
+            return underlyingChannel.execute(endpoint, request);
+        };
     }
 
     @Override

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -29,7 +29,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
-import com.palantir.dialogue.RequestAttachments;
 import com.palantir.dialogue.Response;
 import com.palantir.tracing.TestTracing;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -57,9 +56,6 @@ public class QueuedChannelTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Request request;
-
-    @Mock
-    private RequestAttachments requestAttachments;
 
     @Mock
     private Response mockResponse;

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -147,6 +147,7 @@ public class QueuedChannelTest {
     }
 
     @Test
+    @SuppressWarnings("StrictUnusedVariable")
     public void testQueueExecutesFairly() {
         UUID txn1 = UUID.randomUUID();
         UUID txn2 = UUID.randomUUID();
@@ -175,6 +176,7 @@ public class QueuedChannelTest {
         return tx1req1Response;
     }
 
+    @SuppressWarnings("UnusedMethod")
     private ListenableFuture<Response> respondImmediately(Request req) {
         when(delegate.maybeExecute(endpoint, req)).thenReturn(Optional.of(Futures.immediateFuture(mockResponse)));
         ListenableFuture<Response> tx1req1Response =

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestAttachments;
 import com.palantir.dialogue.Response;
 import com.palantir.tracing.TestTracing;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -37,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,8 +55,11 @@ public class QueuedChannelTest {
     @Mock
     private Endpoint endpoint;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Request request;
+
+    @Mock
+    private RequestAttachments requestAttachments;
 
     @Mock
     private Response mockResponse;
@@ -117,7 +122,7 @@ public class QueuedChannelTest {
     @Test
     public void testQueuedRequestExecutedOnNextSubmission_throws() throws ExecutionException, InterruptedException {
         // First request is limited by the channel and queued
-        Request queuedRequest = Mockito.mock(Request.class);
+        Request queuedRequest = Mockito.mock(Request.class, Answers.RETURNS_DEEP_STUBS);
         when(delegate.maybeExecute(endpoint, queuedRequest)).thenReturn(Optional.empty());
         ListenableFuture<Response> queuedFuture =
                 queuedChannel.maybeExecute(endpoint, queuedRequest).get();

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/StickyEndpointChannelsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/StickyEndpointChannelsTest.java
@@ -157,6 +157,14 @@ class StickyEndpointChannelsTest {
                 .allSatisfy(string -> assertThat(string).doesNotContain("[three]"));
     }
 
+    @Test
+    public void sticky_channels_are_fair() {
+        StickyEndpointChannels channels = builder()
+                .channels(ImmutableList.of(
+                        miniServer("one", serve204), miniServer("two", serve204), miniServer("three", immediate429)))
+                .build();
+    }
+
     private EndpointChannelFactory miniServer(String serverName, Supplier<ListenableFuture<Response>> response) {
         return endpoint -> _request -> {
             requests.add(String.format("[%s] [%s]", serverName, endpoint.endpointName()));


### PR DESCRIPTION
## Before this PR

Clients using sticky channels have no way of enforcing fairness between "transactions" (that's what we use sticky channels to approximate).

## After this PR
==COMMIT_MSG==
StickyChannels provide fairness.
==COMMIT_MSG==

## Possible downsides?

* Queue implementation uses synchronized, so not good, but probably given enough brain cycles can come up with something non-blocking.
* Need to think how to write a test that this actually does what I expect.
