### PR TITLE
Support custom encoders for primitive types

### DIFF
--- a/changelog/@unreleased/pr-1233.v2.yml
+++ b/changelog/@unreleased/pr-1233.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue annotation now support using custom encoders with primitive types.
+  links:
+  - https://github.com/palantir/dialogue/pull/1233

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomStringParameterEncoder.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomStringParameterEncoder.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.service;
+
+import com.palantir.dialogue.annotations.ListParamEncoder;
+import com.palantir.dialogue.annotations.ParamEncoder;
+import java.util.Collections;
+import java.util.List;
+
+public final class MyCustomStringParameterEncoder implements ParamEncoder<String>, ListParamEncoder<String> {
+    @Override
+    public String toParamValue(String value) {
+        return value;
+    }
+
+    @Override
+    public List<String> toParamValues(String value) {
+        return Collections.singletonList(value);
+    }
+}

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 // Annotation processor is not invoked directly here.
 // @DialogueService(MyServiceDialogueServiceFactory.class)
+@SuppressWarnings("TooManyArguments")
 public interface MyService {
 
     @Request(method = HttpMethod.POST, path = "/greet")
@@ -64,6 +65,8 @@ public interface MyService {
                     MyCustomParamType query1,
             @Request.QueryParam(value = "q2", encoder = MyCustomParamTypeParameterEncoder.class)
                     Optional<MyCustomParamType> query2,
+            @Request.QueryParam(value = "q3", encoder = MyCustomStringParameterEncoder.class) String query3,
+            @Request.QueryParam(value = "q4", encoder = MyCustomStringParameterEncoder.class) Optional<String> query4,
             // Path parameter variable name must match the request path component
             @Request.PathParam UUID myPathParam,
             @Request.PathParam(encoder = MyCustomParamTypeParameterEncoder.class) MyCustomParamType myPathParam2,

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -67,6 +67,10 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             private final ListParamEncoder<MyCustomParamType> paramsQuery2Encoder =
                     new MyCustomParamTypeParameterEncoder();
 
+            private final ListParamEncoder<String> paramsQuery3Encoder = new MyCustomStringParameterEncoder();
+
+            private final ListParamEncoder<String> paramsQuery4Encoder = new MyCustomStringParameterEncoder();
+
             private final ParamEncoder<MyCustomParamType> paramsMyPathParam2Encoder =
                     new MyCustomParamTypeParameterEncoder();
 
@@ -114,6 +118,8 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     String query,
                     MyCustomParamType query1,
                     Optional<MyCustomParamType> query2,
+                    String query3,
+                    Optional<String> query4,
                     UUID myPathParam,
                     MyCustomParamType myPathParam2,
                     int requestHeaderValue,
@@ -126,6 +132,10 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                 _request.putAllQueryParams("q1", paramsQuery1Encoder.toParamValues(query1));
                 if (query2.isPresent()) {
                     _request.putAllQueryParams("q2", paramsQuery2Encoder.toParamValues(query2.get()));
+                }
+                _request.putAllQueryParams("q3", paramsQuery3Encoder.toParamValues(query3));
+                if (query4.isPresent()) {
+                    _request.putAllQueryParams("q4", paramsQuery4Encoder.toParamValues(query4.get()));
                 }
                 _request.putPathParams("myPathParam", _parameterSerializer.serializeUuid(myPathParam));
                 _request.putPathParams("myPathParam2", paramsMyPathParam2Encoder.toParamValue(myPathParam2));


### PR DESCRIPTION
## Before this PR
Using a custom encoder with a primitive types fails with `NoSuchElementException`:
```
at java.base/java.util.Optional.orElseThrow(Optional.java:375)
  	at com.palantir.dialogue.annotations.processor.generate.ServiceImplementationGenerator.underlyingCustomType(ServiceImplementationGenerator.java:200)
  	at com.palantir.dialogue.annotations.processor.generate.ServiceImplementationGenerator.encoder(ServiceImplementationGenerator.java:188)
  	at com.palantir.dialogue.annotations.processor.generate.ServiceImplementationGenerator.lambda$generate$1(ServiceImplementationGenerator.java:78)
  	at java.base/java.util.Optional.map(Optional.java:258)
  	at com.palantir.dialogue.annotations.processor.generate.ServiceImplementationGenerator.lambda$generate$2(ServiceImplementationGenerator.java:78)
  	at com.palantir.dialogue.annotations.processor.data.ParameterTypes$LambdaCases.header(ParameterTypes.java:228)
  	at com.palantir.dialogue.annotations.processor.data.ParameterTypes$Header.match(ParameterTypes.java:280)
  	at com.palantir.dialogue.annotations.processor.data.ParameterTypes$CaseOfMatchers$PartialMatcher.otherwise(ParameterTypes.java:739)
  	at com.palantir.dialogue.annotations.processor.data.ParameterTypes$CaseOfMatchers$PartialMatcher.otherwise_(ParameterTypes.java:743)
  	at com.palantir.dialogue.annotations.processor.generate.ServiceImplementationGenerator.lambda$generate$7(ServiceImplementationGenerator.java:81)
  	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271)
  	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
  	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
  	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
  	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
  	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
  	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
  	at com.palantir.dialogue.annotations.processor.generate.ServiceImplementationGenerator.lambda$generate$8(ServiceImplementationGenerator.java:83)
  	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:406)
  	at com.palantir.dialogue.annotations.processor.generate.ServiceImplementationGenerator.generate(ServiceImplementationGenerator.java:73)
```

For context, I'm using Dialogue annotations to define a service interface for testing and want to define something like:
```java
@Request(method = HttpMethod.GET, path = "/foo")
void foo(
    @Header(value = "Cookie", encoder = CookieTokenEncoder.class) BearerToken token,
```
```java
final class CookieTokenEncoder implements ListParamEncoder<BearerToken> {
    @Override
    public List<String> toParamValues(BearerToken token) {
        return List.of("TOKEN=" + token);
    }
}
```

I could wrap it in a custom class, but there doesn't seem to be much benefit to forcing consumers to do that.

## After this PR
Custom encoders can be used with primitive types.

## Possible downsides?
Is there a reason we explicitly did not want to support this? Is there a benefit to only allowing one serialization format for primitive types, even when manually using the Dialogue annotations?