### PR TITLE
Provide originating element for generated service factory

### DIFF
--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
@@ -113,7 +113,7 @@ public final class DialogueRequestAnnotationsProcessor extends AbstractProcessor
                     }
 
                     try {
-                        Goethe.formatAndEmit(javaFile, filer);
+                        Goethe.formatAndEmit(javaFile, filer, interfaceElement);
                     } catch (FilerException e) {
                         // Happens when same file is written twice. Dunno why this is a problem
                     } catch (IOException e) {

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/format/Goethe.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/format/Goethe.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 import javax.annotation.processing.Filer;
+import javax.lang.model.element.Element;
 import javax.tools.JavaFileObject;
 
 public final class Goethe {
@@ -38,12 +39,12 @@ public final class Goethe {
 
     private Goethe() {}
 
-    public static void formatAndEmit(JavaFile file, Filer filer) throws IOException {
+    public static void formatAndEmit(JavaFile file, Filer filer, Element element) throws IOException {
         StringBuilder unformattedSource = new StringBuilder();
         file.writeTo(unformattedSource);
         try {
             String formattedSource = JAVA_FORMATTER.formatSource(unformattedSource.toString());
-            writeTo(getFileName(file), formattedSource, filer);
+            writeTo(getFileName(file), formattedSource, filer, element);
         } catch (FormatterException e) {
             throw new IOException(generateMessage(file, unformattedSource.toString(), e.diagnostics()), e);
         }
@@ -82,8 +83,8 @@ public final class Goethe {
     }
 
     @SuppressWarnings({"EmptyCatch", "EmptyCatchBlock"})
-    private static void writeTo(String fileName, String sourceCode, Filer filer) throws IOException {
-        JavaFileObject filerSourceFile = filer.createSourceFile(fileName);
+    private static void writeTo(String fileName, String sourceCode, Filer filer, Element element) throws IOException {
+        JavaFileObject filerSourceFile = filer.createSourceFile(fileName, element);
         try (Writer writer = filerSourceFile.openWriter()) {
             writer.write(sourceCode);
         } catch (Exception e) {


### PR DESCRIPTION
https://github.com/palantir/dialogue/pull/1231 didn't quite work to enable incremental compilation because Gradle requires that each generated file has exactly one originating element.
https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_annotation_processing
```
> Task :compileJava
Full recompilation is required because the generated type 'com.palantir.foo.api.FooServiceDialogueServiceFactory' must have exactly one originating element, but had 0.
```
This PR updates the Dialogue annotation processor to provide the enclosing interface elements as the originating element to the `Filer` API.