### PR TITLE
Allow custom error handler for void endpoints.

### DIFF
--- a/changelog/@unreleased/pr-1278.v2.yml
+++ b/changelog/@unreleased/pr-1278.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow custom error handler for void endpoints.
+  links:
+  - https://github.com/palantir/dialogue/pull/1278

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/AlwaysThrowErrorDecoder.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/AlwaysThrowErrorDecoder.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.example;
+
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.annotations.ErrorDecoder;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+
+public final class AlwaysThrowErrorDecoder implements ErrorDecoder {
+    @Override
+    public boolean isError(Response _response) {
+        return true;
+    }
+
+    @Override
+    public RuntimeException decode(Response _response) {
+        return new SafeRuntimeException("There are only errors");
+    }
+}

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -63,6 +63,9 @@ public interface MyService {
             errorDecoder = ErrorDecoder.None.class)
     Response customResponse();
 
+    @Request(method = HttpMethod.PUT, path = "/custom/request2", errorDecoder = AlwaysThrowErrorDecoder.class)
+    void customVoidErrorDecoder();
+
     @Request(method = HttpMethod.POST, path = "/params/{myPathParam}/{myPathParam2}")
     void params(
             @Request.QueryParam("q") String query,

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -228,6 +228,23 @@ public final class MyServiceIntegrationTest {
     }
 
     @Test
+    public void testCustomVoidErrorDecoder() {
+        undertowHandler = exchange -> {
+            exchange.assertMethod(HttpMethod.PUT);
+            exchange.assertPath("/custom/request2");
+            exchange.assertAccept().isNull();
+            exchange.assertContentType().isNull();
+            exchange.assertBodyUtf8().isEmpty();
+
+            exchange.exchange.setStatusCode(204);
+        };
+
+        assertThatThrownBy(myServiceDialogue::customVoidErrorDecoder)
+                .isExactlyInstanceOf(SafeRuntimeException.class)
+                .hasMessage("There are only errors");
+    }
+
+    @Test
     public void testCustomResponse200() {
         testCustomResponse(200);
     }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -23,6 +23,7 @@ import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.dialogue.annotations.DefaultParameterSerializer;
 import com.palantir.dialogue.annotations.ErrorHandlingDeserializerFactory;
+import com.palantir.dialogue.annotations.ErrorHandlingVoidDeserializer;
 import com.palantir.dialogue.annotations.ListParamEncoder;
 import com.palantir.dialogue.annotations.ParamEncoder;
 import com.palantir.dialogue.annotations.ParameterSerializer;
@@ -172,8 +173,8 @@ public final class ServiceImplementationGenerator {
                 TypeMarker.class,
                 innerType);
         CodeBlock voidDeserializer = CodeBlock.of(
-                "$T.createVoidDeserializer($L.bodySerDe().emptyBodyDeserializer(), new $T())",
-                ErrorHandlingDeserializerFactory.class,
+                "new $T($L.bodySerDe().emptyBodyDeserializer(), new $T())",
+                ErrorHandlingVoidDeserializer.class,
                 serviceDefinition.conjureRuntimeArgName(),
                 errorDecoderType);
         return Optional.of(FieldSpec.builder(deserializerType, type.deserializerFieldName())

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -172,9 +172,10 @@ public final class ServiceImplementationGenerator {
                 TypeMarker.class,
                 innerType);
         CodeBlock voidDeserializer = CodeBlock.of(
-                "new $T($L.bodySerDe().emptyBodyDeserializer())",
+                "$T.createVoidDeserializer($L.bodySerDe().emptyBodyDeserializer(), new $T())",
                 ErrorHandlingDeserializerFactory.class,
-                serviceDefinition.conjureRuntimeArgName());
+                serviceDefinition.conjureRuntimeArgName(),
+                deserializerFactoryType);
         return Optional.of(FieldSpec.builder(deserializerType, type.deserializerFieldName())
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                 .initializer(type.isVoid() ? voidDeserializer : realDeserializer)

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -175,7 +175,7 @@ public final class ServiceImplementationGenerator {
                 "$T.createVoidDeserializer($L.bodySerDe().emptyBodyDeserializer(), new $T())",
                 ErrorHandlingDeserializerFactory.class,
                 serviceDefinition.conjureRuntimeArgName(),
-                deserializerFactoryType);
+                errorDecoderType);
         return Optional.of(FieldSpec.builder(deserializerType, type.deserializerFieldName())
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                 .initializer(type.isVoid() ? voidDeserializer : realDeserializer)

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -171,9 +171,10 @@ public final class ServiceImplementationGenerator {
                 errorDecoderType,
                 TypeMarker.class,
                 innerType);
-        CodeBlock voidDeserializer =
-                CodeBlock.of("$L.bodySerDe().emptyBodyDeserializer()", serviceDefinition.conjureRuntimeArgName());
-
+        CodeBlock voidDeserializer = CodeBlock.of(
+                "new $T($L.bodySerDe().emptyBodyDeserializer())",
+                ErrorHandlingDeserializerFactory.class,
+                serviceDefinition.conjureRuntimeArgName());
         return Optional.of(FieldSpec.builder(deserializerType, type.deserializerFieldName())
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                 .initializer(type.isVoid() ? voidDeserializer : realDeserializer)

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -97,6 +97,8 @@ public final class DialogueRequestAnnotationsProcessorTest {
                 clazz.getSimpleName() + ".java"));
         try {
             return Compiler.javac()
+                    // This is required because this tool does not know about our gradle setting.
+                    .withOptions("-source", "11")
                     .withProcessors(new DialogueRequestAnnotationsProcessor())
                     .compile(JavaFileObjects.forResource(clazzPath.toUri().toURL()));
         } catch (MalformedURLException e) {

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -17,6 +17,7 @@ import com.palantir.dialogue.UrlBuilder;
 import com.palantir.dialogue.annotations.ConjureErrorDecoder;
 import com.palantir.dialogue.annotations.DefaultParameterSerializer;
 import com.palantir.dialogue.annotations.ErrorHandlingDeserializerFactory;
+import com.palantir.dialogue.annotations.ErrorHandlingVoidDeserializer;
 import com.palantir.dialogue.annotations.Json;
 import com.palantir.dialogue.annotations.ListParamEncoder;
 import com.palantir.dialogue.annotations.ParamEncoder;
@@ -58,8 +59,8 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             private final EndpointChannel customRequestChannel =
                     endpointChannelFactory.endpoint(Endpoints.customRequest);
 
-            private final Deserializer<Void> customRequestDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+            private final Deserializer<Void> customRequestDeserializer = new ErrorHandlingVoidDeserializer(
+                    runtime.bodySerDe().emptyBodyDeserializer(), new ConjureErrorDecoder());
 
             private final EndpointChannel customResponseChannel =
                     endpointChannelFactory.endpoint(Endpoints.customResponse);
@@ -89,8 +90,8 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
 
             private final EndpointChannel paramsChannel = endpointChannelFactory.endpoint(Endpoints.params);
 
-            private final Deserializer<Void> paramsDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+            private final Deserializer<Void> paramsDeserializer = new ErrorHandlingVoidDeserializer(
+                    runtime.bodySerDe().emptyBodyDeserializer(), new ConjureErrorDecoder());
 
             @Override
             public String greet(AuthHeader authHeader, String greeting) {

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ErrorHandlingDeserializerFactory.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ErrorHandlingDeserializerFactory.java
@@ -38,7 +38,7 @@ public final class ErrorHandlingDeserializerFactory<T> implements DeserializerFa
     public <T1 extends T> Deserializer<T1> deserializerFor(TypeMarker<T1> type) {
         Deserializer<T1> delegateDeserializer = delegate.deserializerFor(type);
         boolean isCloseable = TypeToken.of(type.getType()).isSubtypeOf(Closeable.class);
-        return new Deserializer<T1>() {
+        return new Deserializer<>() {
             @Override
             public T1 deserialize(Response response) {
                 boolean closeResponse = true;
@@ -60,26 +60,6 @@ public final class ErrorHandlingDeserializerFactory<T> implements DeserializerFa
             @Override
             public Optional<String> accepts() {
                 return delegateDeserializer.accepts();
-            }
-        };
-    }
-
-    public static Deserializer<Void> createVoidDeserializer(Deserializer<Void> delegate, ErrorDecoder errorDecoder) {
-        return new Deserializer<>() {
-            @Override
-            public Void deserialize(Response response) {
-                try (response) {
-                    if (errorDecoder.isError(response)) {
-                        throw errorDecoder.decode(response);
-                    } else {
-                        return delegate.deserialize(response);
-                    }
-                }
-            }
-
-            @Override
-            public Optional<String> accepts() {
-                return delegate.accepts();
             }
         };
     }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ErrorHandlingDeserializerFactory.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ErrorHandlingDeserializerFactory.java
@@ -63,4 +63,24 @@ public final class ErrorHandlingDeserializerFactory<T> implements DeserializerFa
             }
         };
     }
+
+    public static Deserializer<Void> createVoidDeserializer(Deserializer<Void> delegate, ErrorDecoder errorDecoder) {
+        return new Deserializer<>() {
+            @Override
+            public Void deserialize(Response response) {
+                try (response) {
+                    if (errorDecoder.isError(response)) {
+                        throw errorDecoder.decode(response);
+                    } else {
+                        return delegate.deserialize(response);
+                    }
+                }
+            }
+
+            @Override
+            public Optional<String> accepts() {
+                return delegate.accepts();
+            }
+        };
+    }
 }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ErrorHandlingVoidDeserializer.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ErrorHandlingVoidDeserializer.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.annotations;
+
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.Response;
+import com.palantir.logsafe.Preconditions;
+import java.util.Optional;
+
+public final class ErrorHandlingVoidDeserializer implements Deserializer<Void> {
+
+    private final Deserializer<Void> delegate;
+    private final ErrorDecoder errorDecoder;
+
+    public ErrorHandlingVoidDeserializer(Deserializer<Void> delegate, ErrorDecoder errorDecoder) {
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+        this.errorDecoder = Preconditions.checkNotNull(errorDecoder, "errorDecoder");
+    }
+
+    @Override
+    public Void deserialize(Response response) {
+        try (response) {
+            if (errorDecoder.isError(response)) {
+                throw errorDecoder.decode(response);
+            } else {
+                return delegate.deserialize(response);
+            }
+        }
+    }
+
+    @Override
+    public Optional<String> accepts() {
+        return delegate.accepts();
+    }
+}

--- a/dialogue-annotations/src/test/java/com/palantir/dialogue/annotations/ErrorHandlingDeserializerFactoryTest.java
+++ b/dialogue-annotations/src/test/java/com/palantir/dialogue/annotations/ErrorHandlingDeserializerFactoryTest.java
@@ -51,7 +51,7 @@ public final class ErrorHandlingDeserializerFactoryTest {
     private Response response;
 
     private ErrorHandlingDeserializerFactory<Object> errorHandlingDeserializerFactory;
-    private final TypeMarker<Integer> integerTypeMarker = new TypeMarker<Integer>() {};
+    private final TypeMarker<Integer> integerTypeMarker = new TypeMarker<>() {};
 
     @BeforeEach
     public void beforeEach() {
@@ -61,7 +61,7 @@ public final class ErrorHandlingDeserializerFactoryTest {
 
     @AfterEach
     public void afterEach() {
-        verifyNoMoreInteractions(integerDelegateDeserializer, errorDecoder, response);
+        verifyNoMoreInteractions(integerDelegateDeserializer, delegateDeserializerFactory, errorDecoder, response);
     }
 
     @Test

--- a/dialogue-annotations/src/test/java/com/palantir/dialogue/annotations/ErrorHandlingVoidDeserializerTest.java
+++ b/dialogue-annotations/src/test/java/com/palantir/dialogue/annotations/ErrorHandlingVoidDeserializerTest.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.annotations;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public final class ErrorHandlingVoidDeserializerTest {
+
+    @Mock
+    private ErrorDecoder errorDecoder;
+
+    @Mock
+    private Deserializer<Void> delegateDeserializer;
+
+    @Mock
+    private Response response;
+
+    private ErrorHandlingVoidDeserializer errorHandlingVoidDeserializer;
+
+    @BeforeEach
+    public void beforeEach() {
+        errorHandlingVoidDeserializer = new ErrorHandlingVoidDeserializer(delegateDeserializer, errorDecoder);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        verifyNoMoreInteractions(errorDecoder, delegateDeserializer, response);
+    }
+
+    @Test
+    public void testOnErrorCallsErrorDecoder() {
+        RuntimeException runtimeException = new RuntimeException();
+        when(errorDecoder.isError(response)).thenReturn(true);
+        when(errorDecoder.decode(response)).thenReturn(runtimeException);
+
+        assertThatThrownBy(() -> errorHandlingVoidDeserializer.deserialize(response))
+                .isEqualTo(runtimeException);
+        verify(response).close();
+    }
+
+    @Test
+    public void testOnSuccessCallsDeserializer() {
+        when(errorDecoder.isError(response)).thenReturn(false);
+
+        errorHandlingVoidDeserializer.deserialize(response);
+
+        verify(delegateDeserializer).deserialize(response);
+        verify(response).close();
+    }
+}


### PR DESCRIPTION
## Before this PR
Original ErrorDecoder PR missed void endpoints, thanks @gmaretic for reporting.

## After this PR
==COMMIT_MSG==
Allow custom error handler for void endpoints.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
