### PR TITLE
Support Map<String, String> in queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ public interface MyService {
             // Path parameter variable name must match the request path component
             @Request.PathParam UUID myPathParam,
             @Request.PathParam(encoder = MyCustomParamTypeEncoder.class) MyCustomParamType myPathParam2,
+            // converts an custom type into a Multimap<String, String>
+            @Request.QueryMap(encoder = MyCustomTypeEncoder.class) MyCustomQueryParamType myCustomQueryParam,
             @Request.Header("Custom-Header") int requestHeaderValue,
             // Headers can be optional
             @Request.Header("Custom-Optional-Header") OptionalInt maybeRequestHeaderValue,
@@ -144,6 +146,9 @@ Features:
 * Custom parameter types: ```@Request.(Header|PathParam|QueryParam)(encoder=MyCustomParamTypeEncoder.class)```.
 * Custom serialization/deserialization: add ```@Request.Body(MySerializableTypeBodySerializer.class)```
   or ```@Request(accept=MyCustomResponseDeserializer.class)```.
+* Custom serialization from ```Map```, ```Multimap``` and custom types into query parameters. This functions
+  similarly to the Feign ```QueryMap``` feature, but with added control of customizing the serialization to
+  query parameters.
 * Authentication: builtin ```Authorization``` header handling if an annotated method has an ```AuthHeader``` parameter.
 
 See more examples [on how to define clients](dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java) and [use the generated code](dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java).

--- a/changelog/@unreleased/pr-1282.v2.yml
+++ b/changelog/@unreleased/pr-1282.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Support Map<String, String> in queries
+  links:
+  - https://github.com/palantir/dialogue/pull/1282

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomMultimapEncoder.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomMultimapEncoder.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.palantir.dialogue.annotations.MultimapParamEncoder;
 
-public class MyCustomMultimapEncoder implements MultimapParamEncoder<MyCustomParamType> {
+public final class MyCustomMultimapEncoder implements MultimapParamEncoder<MyCustomParamType> {
     @Override
     public Multimap<String, String> toParamValues(MyCustomParamType value) {
         return ImmutableMultimap.of("value-from-multimap", value.value());

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomMultimapEncoder.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomMultimapEncoder.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.example;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.palantir.dialogue.annotations.MultimapParamEncoder;
+
+public class MyCustomMultimapEncoder implements MultimapParamEncoder<MyCustomParamType> {
+    @Override
+    public Multimap<String, String> toParamValues(MyCustomParamType value) {
+        return ImmutableMultimap.of("value-from-multimap", value.value());
+    }
+}

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -16,6 +16,7 @@
 
 package com.palantir.myservice.example;
 
+import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.DialogueService;
 import com.palantir.dialogue.HttpMethod;
@@ -88,6 +89,13 @@ public interface MyService {
             // By changing this to MySpecialJson.class you can have
             // it's own object mapper; this is same as BodySerDe in dialogue
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);
+
+    @Request(method = HttpMethod.GET, path = "/multiparams")
+    void multiParams(
+            // or you can supply a multimap directly
+            @Request.QueryMap Multimap<String, String> multiQueryParams,
+            // or you can supply a custom converter
+            @Request.QueryMap(encoder = MyCustomMultimapEncoder.class) MyCustomParamType myParamToMultimap);
 
     @Request(method = HttpMethod.POST, path = "/multipart")
     void multipart(@Request.Body(PutFileRequestSerializer.class) PutFileRequest request);

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -22,6 +22,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.annotations.ErrorDecoder;
+import com.palantir.dialogue.annotations.MapToMultimapParamEncoder;
 import com.palantir.dialogue.annotations.Request;
 import com.palantir.myservice.example.PutFileRequest.PutFileRequestSerializer;
 import java.util.List;
@@ -81,7 +82,7 @@ public interface MyService {
             // Optional lists of primitives are supported too!
             @Request.Header("Custom-Optional-Header1") Optional<List<Integer>> maybeRequestHeaderValue1,
             // Can supply a map to fill in arbitrary query values
-            @Request.QueryMap Map<String, String> queryParams,
+            @Request.QueryMap(encoder = MapToMultimapParamEncoder.class) Map<String, String> queryParams,
             // Custom encoding classes may be provided for the request and response.
             // JSON should be easiest (default?).
             // By changing this to MySpecialJson.class you can have

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -25,6 +25,7 @@ import com.palantir.dialogue.annotations.ErrorDecoder;
 import com.palantir.dialogue.annotations.Request;
 import com.palantir.myservice.example.PutFileRequest.PutFileRequestSerializer;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
@@ -79,6 +80,8 @@ public interface MyService {
             @Request.Header("Custom-Optional-Header") OptionalInt maybeRequestHeaderValue,
             // Optional lists of primitives are supported too!
             @Request.Header("Custom-Optional-Header1") Optional<List<Integer>> maybeRequestHeaderValue1,
+            // Can supply a map to fill in arbitrary query values
+            @Request.QueryMap Map<String, String> queryParams,
             // Custom encoding classes may be provided for the request and response.
             // JSON should be easiest (default?).
             // By changing this to MySpecialJson.class you can have

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.Futures;
@@ -296,6 +297,23 @@ public final class MyServiceIntegrationTest {
         myServiceDialogue.multipart(ImmutablePutFileRequest.builder()
                 .contentBody(ContentBody.path(fileContentType, fileTxt))
                 .build());
+    }
+
+    @Test
+    void testMultiparams() {
+        undertowHandler = exchange -> {
+            exchange.assertMethod(HttpMethod.GET);
+
+            assertThat(exchange.exchange.getQueryParameters().get("q1")).containsExactly("var1", "var2");
+            assertThat(exchange.exchange.getQueryParameters().get("value-from-multimap"))
+                    .containsExactly("var3");
+        };
+
+        myServiceDialogue.multiParams(
+                ImmutableMultimap.<String, String>builder()
+                        .putAll("q1", "var1", "var2")
+                        .build(),
+                new MyCustomParamType("var3"));
     }
 
     private void testCustomResponse(int code) {

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -19,6 +19,7 @@ package com.palantir.myservice.example;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.Futures;
@@ -327,9 +328,10 @@ public final class MyServiceIntegrationTest {
         undertowHandler = exchange -> {
             exchange.assertMethod(HttpMethod.POST);
             exchange.assertPath("/params/90a8481a-2ef5-4c64-83fc-04a9b369e2b8/my-custom-param-value");
-            assertThat(exchange.exchange.getQueryParameters()).containsOnlyKeys("q", "q1");
+            assertThat(exchange.exchange.getQueryParameters()).containsOnlyKeys("q", "q1", "varq1");
             assertThat(exchange.exchange.getQueryParameters().get("q")).containsOnly("query");
             assertThat(exchange.exchange.getQueryParameters().get("q1")).containsOnly("Query", "Params");
+            assertThat(exchange.exchange.getQueryParameters().get("varq1")).containsOnly("varvar1");
             exchange.assertAccept().isNull();
             exchange.assertContentType().isEqualTo("application/json");
             exchange.assertSingleValueHeader(HttpString.tryFromString("Custom-Header"))
@@ -362,6 +364,7 @@ public final class MyServiceIntegrationTest {
                 2,
                 customHeaderOptionalValue,
                 Optional.of(Arrays.asList(1, 2)),
+                ImmutableMap.of("varq1", "varvar1"),
                 ImmutableMySerializableType.builder()
                         .value("my-serializable-type-value")
                         .build());

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
@@ -31,6 +31,8 @@ public interface ArgumentType {
 
         R optional(TypeName optionalJavaType, OptionalType optionalType);
 
+        R mapType(boolean isMultimap, TypeName javaTypeName);
+
         R customType(TypeName customTypeName);
     }
 

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
@@ -31,7 +31,7 @@ public interface ArgumentType {
 
         R optional(TypeName optionalJavaType, OptionalType optionalType);
 
-        R mapType(boolean isMultimap, TypeName javaTypeName);
+        R mapType(TypeName javaTypeName);
 
         R customType(TypeName customTypeName);
     }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentTypesResolver.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentTypesResolver.java
@@ -114,11 +114,11 @@ public final class ArgumentTypesResolver {
     private Optional<ArgumentType> getMapType(TypeMirror in, TypeName typeName) {
         return context.maybeAsDeclaredType(in).flatMap(declaredType -> {
             if (context.isAssignableWithErasure(declaredType, Multimap.class)) {
-                return Optional.of(ArgumentTypes.mapType(true, typeName));
+                return Optional.of(ArgumentTypes.mapType(typeName));
             } else if (context.isAssignableWithErasure(declaredType, Map.class)) {
-                return Optional.of(ArgumentTypes.mapType(false, typeName));
+                return Optional.of(ArgumentTypes.mapType(typeName));
             }
-            return Optional.empty();
+            return Optional.of(ArgumentTypes.customType(typeName));
         });
     }
 

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
@@ -41,7 +41,11 @@ import javax.lang.model.type.TypeMirror;
 public final class ParamTypesResolver {
 
     private static final ImmutableSet<Class<?>> PARAM_ANNOTATION_CLASSES = ImmutableSet.of(
-            Request.Body.class, Request.PathParam.class, Request.QueryParam.class, Request.Header.class);
+            Request.Body.class,
+            Request.PathParam.class,
+            Request.QueryParam.class,
+            Request.QueryMap.class,
+            Request.Header.class);
     private static final ImmutableSet<String> PARAM_ANNOTATIONS =
             PARAM_ANNOTATION_CLASSES.stream().map(Class::getCanonicalName).collect(ImmutableSet.toImmutableSet());
     private static final String paramEncoderMethod;
@@ -125,6 +129,8 @@ public final class ParamTypesResolver {
                     annotationReflector.getValueStrict(String.class),
                     getParameterEncoder(
                             endpointName, variableElement, annotationReflector, EncoderTypeAndMethod.LIST)));
+        } else if (annotationReflector.isAnnotation(Request.QueryMap.class)) {
+            return Optional.of(ParameterTypes.queryMap());
         }
 
         throw new SafeIllegalStateException("Not possible");

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
@@ -33,6 +33,8 @@ public interface ParameterType {
         R path(Optional<ParameterEncoderType> paramEncoderType);
 
         R query(String paramName, Optional<ParameterEncoderType> paramEncoderType);
+
+        R queryMap();
     }
 
     <R> R match(Cases<R> cases);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
@@ -34,7 +34,7 @@ public interface ParameterType {
 
         R query(String paramName, Optional<ParameterEncoderType> paramEncoderType);
 
-        R queryMap();
+        R queryMap(Optional<ParameterEncoderType> parameterEncoderType);
     }
 
     <R> R match(Cases<R> cases);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
@@ -34,7 +34,7 @@ public interface ParameterType {
 
         R query(String paramName, Optional<ParameterEncoderType> paramEncoderType);
 
-        R queryMap(Optional<ParameterEncoderType> parameterEncoderType);
+        R queryMap(ParameterEncoderType parameterEncoderType);
     }
 
     <R> R match(Cases<R> cases);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ResolverContext.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ResolverContext.java
@@ -50,6 +50,10 @@ public final class ResolverContext implements ErrorContext {
         return types.isAssignable(typeMirror, getTypeMirror(clazz));
     }
 
+    public boolean isAssignableWithErasure(TypeMirror typeMirror, Class<?> clazz) {
+        return types.isAssignable(types.erasure(typeMirror), getTypeMirror(clazz));
+    }
+
     public TypeName getTypeName(Class<?> clazz) {
         return TypeName.get(getTypeMirror(clazz));
     }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -81,7 +81,7 @@ public final class ServiceImplementationGenerator {
                             .header((_headerName, maybeEncoder) -> maybeEncoder.map(encoder -> encoder(arg, encoder)))
                             .path(maybeEncoder -> maybeEncoder.map(encoder -> encoder(arg, encoder)))
                             .query((_paramName, maybeEncoder) -> maybeEncoder.map(encoder -> encoder(arg, encoder)))
-                            .queryMap(maybeEncoder -> maybeEncoder.map(encoder -> encoder(arg, encoder)))
+                            .queryMap(encoder -> Optional.of(encoder(arg, encoder)))
                             .otherwise_(Optional.empty())
                             .stream())
                     .forEach(impl::addField);
@@ -254,7 +254,7 @@ public final class ServiceImplementationGenerator {
             }
 
             @Override
-            public CodeBlock queryMap(Optional<ParameterEncoderType> parameterEncoderType) {
+            public CodeBlock queryMap(ParameterEncoderType parameterEncoderType) {
                 return generateQueryMapParam(param, parameterEncoderType);
             }
         });
@@ -292,14 +292,14 @@ public final class ServiceImplementationGenerator {
                 paramEncoder);
     }
 
-    private CodeBlock generateQueryMapParam(ArgumentDefinition param, Optional<ParameterEncoderType> paramEncoder) {
+    private CodeBlock generateQueryMapParam(ArgumentDefinition param, ParameterEncoderType paramEncoder) {
         return generatePlainSerializer(
                 "nope",
                 "putAllQueryParams",
                 param.argName().get(),
                 CodeBlock.of("$L", param.argName().get()),
                 param.argType(),
-                paramEncoder);
+                Optional.of(paramEncoder));
     }
 
     private CodeBlock generatePlainSerializer(

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/DefaultMultimapParamEncoder.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/DefaultMultimapParamEncoder.java
@@ -14,34 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.dialogue.annotations.processor.data;
+package com.palantir.dialogue.annotations;
 
-import com.squareup.javapoet.TypeName;
-import org.derive4j.Data;
-import org.immutables.value.Value;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 
-@Value.Immutable
-@Value.Style(stagedBuilder = true)
-public interface ParameterEncoderType {
-
-    EncoderType type();
-
-    TypeName encoderJavaType();
-
-    String encoderFieldName();
-
-    String encoderMethodName();
-
-    @Data
-    interface EncoderType {
-        interface Cases<R> {
-            R param();
-
-            R listParam();
-
-            R multimapParam();
-        }
-
-        <R> R match(EncoderType.Cases<R> cases);
+public final class DefaultMultimapParamEncoder implements MultimapParamEncoder<Multimap<String, String>> {
+    @Override
+    public Multimap<String, String> toParamValues(Multimap<String, String> value) {
+        return ImmutableMultimap.copyOf(value);
     }
 }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/MapToMultimapParamEncoder.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/MapToMultimapParamEncoder.java
@@ -14,34 +14,15 @@
  * limitations under the License.
  */
 
-package com.palantir.dialogue.annotations.processor.data;
+package com.palantir.dialogue.annotations;
 
-import com.squareup.javapoet.TypeName;
-import org.derive4j.Data;
-import org.immutables.value.Value;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Map;
 
-@Value.Immutable
-@Value.Style(stagedBuilder = true)
-public interface ParameterEncoderType {
-
-    EncoderType type();
-
-    TypeName encoderJavaType();
-
-    String encoderFieldName();
-
-    String encoderMethodName();
-
-    @Data
-    interface EncoderType {
-        interface Cases<R> {
-            R param();
-
-            R listParam();
-
-            R multimapParam();
-        }
-
-        <R> R match(EncoderType.Cases<R> cases);
+public final class MapToMultimapParamEncoder implements MultimapParamEncoder<Map<String, String>> {
+    @Override
+    public Multimap<String, String> toParamValues(Map<String, String> value) {
+        return ImmutableMultimap.copyOf(value.entrySet());
     }
 }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/MultimapParamEncoder.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/MultimapParamEncoder.java
@@ -14,34 +14,10 @@
  * limitations under the License.
  */
 
-package com.palantir.dialogue.annotations.processor.data;
+package com.palantir.dialogue.annotations;
 
-import com.squareup.javapoet.TypeName;
-import org.derive4j.Data;
-import org.immutables.value.Value;
+import com.google.common.collect.Multimap;
 
-@Value.Immutable
-@Value.Style(stagedBuilder = true)
-public interface ParameterEncoderType {
-
-    EncoderType type();
-
-    TypeName encoderJavaType();
-
-    String encoderFieldName();
-
-    String encoderMethodName();
-
-    @Data
-    interface EncoderType {
-        interface Cases<R> {
-            R param();
-
-            R listParam();
-
-            R multimapParam();
-        }
-
-        <R> R match(EncoderType.Cases<R> cases);
-    }
+public interface MultimapParamEncoder<T> {
+    Multimap<String, String> toParamValues(T value);
 }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
@@ -101,5 +101,7 @@ public @interface Request {
      */
     @Retention(RetentionPolicy.SOURCE)
     @Target(ElementType.PARAMETER)
-    @interface QueryMap {}
+    @interface QueryMap {
+        Class<? extends MultimapParamEncoder<?>> encoder() default DefaultMultimapParamEncoder.class;
+    }
 }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
@@ -101,6 +101,5 @@ public @interface Request {
      */
     @Retention(RetentionPolicy.SOURCE)
     @Target(ElementType.PARAMETER)
-    @interface QueryMap {
-    }
+    @interface QueryMap {}
 }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
@@ -95,4 +95,12 @@ public @interface Request {
 
         Class<? extends ListParamEncoder<?>> encoder() default DefaultListParamEncoder.class;
     }
+
+    /**
+     * Similar to the Feign QueryMap serialization type. Only supports simple string -> string maps.
+     */
+    @Retention(RetentionPolicy.SOURCE)
+    @Target(ElementType.PARAMETER)
+    @interface QueryMap {
+    }
 }


### PR DESCRIPTION
I had a use case for supporting the Feign like QueryMap, where
I might have an indeterminate amount of potentially user supplied
query parameters which aren't known up front when calling a 3rd party
API.

This PR adds a very rudimentary QueryMap capability which supports
both Map and Multimap.

I still likely have to do a fair bit of cleanup here, by adding tests, documentation, etc. But wanted to ensure this wouldn't be flat out rejected before going forward.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Support Map<String, String> in queries
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
