### PR TITLE
Fix DialogueRequestAnnotationsProcessor warnings on JDK15

### DIFF
--- a/changelog/@unreleased/pr-1288.v2.yml
+++ b/changelog/@unreleased/pr-1288.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix DialogueRequestAnnotationsProcessor warnings on JDK15
+  links:
+  - https://github.com/palantir/dialogue/pull/1288

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
@@ -50,7 +50,6 @@ import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -59,7 +58,6 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public final class DialogueRequestAnnotationsProcessor extends AbstractProcessor {
 
     private Messager messager;
@@ -83,7 +81,7 @@ public final class DialogueRequestAnnotationsProcessor extends AbstractProcessor
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_11;
+        return SourceVersion.latestSupported();
     }
 
     @Override


### PR DESCRIPTION
The `SourceVersion getSupportedSourceVersion()` annotation processor
method returns the highest supported source version, not the
minimum requirement. Now we use `SourceVersion.latestSupported()`
to use the latest version available at runtime to describe
'no limit'.

==COMMIT_MSG==
Fix DialogueRequestAnnotationsProcessor warnings on JDK15
==COMMIT_MSG==
