### PR TITLE
pin-until-error logs at info when the pinned node changes

### DIFF
--- a/changelog/@unreleased/pr-1292.v2.yml
+++ b/changelog/@unreleased/pr-1292.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: pin-until-error logs at info when the pinned node changes
+  links:
+  - https://github.com/palantir/dialogue/pull/1292

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
@@ -376,6 +376,9 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
             if (next.isPresent()) {
                 nextNodeBecauseThrowable.mark();
                 if (log.isInfoEnabled()) {
+                    // throwable is not shown unless debug logging is
+                    // enabled to avoid duplicate stack traces.
+                    Throwable throwableToLog = log.isDebugEnabled() ? throwable : null;
                     log.info(
                             "Received throwable, switching to next channel",
                             SafeArg.of("stableIndex", channel.stableIndex()),
@@ -384,9 +387,7 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
                             SafeArg.of("nextIndex", next.getAsInt()),
                             SafeArg.of("channelName", channelName),
                             SafeArg.of("numChannels", numChannels),
-                            // throwable is not shown unless debug logging is
-                            // enabled to avoid duplicate stack traces.
-                            log.isDebugEnabled() ? throwable : null);
+                            throwableToLog);
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug(


### PR DESCRIPTION
==COMMIT_MSG==
pin-until-error logs at info when the pinned node changes
==COMMIT_MSG==

## Possible downsides?
Potential noise.
