### PR TITLE
Plumb through hostIndex to individual channels for debugging

### DIFF
--- a/changelog/@unreleased/pr-1293.v2.yml
+++ b/changelog/@unreleased/pr-1293.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Plumb through hostIndex to individual channels for debugging
+  links:
+  - https://github.com/palantir/dialogue/pull/1293

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -65,12 +66,17 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private final ApacheHttpClientChannels.CloseableClient client;
     private final BaseUrl baseUrl;
     private final ResponseLeakDetector responseLeakDetector;
+    private final OptionalInt uriIndexForInstrumentation;
 
     ApacheHttpClientBlockingChannel(
-            ApacheHttpClientChannels.CloseableClient client, URL baseUrl, ResponseLeakDetector responseLeakDetector) {
+            ApacheHttpClientChannels.CloseableClient client,
+            URL baseUrl,
+            ResponseLeakDetector responseLeakDetector,
+            OptionalInt uriIndexForInstrumentation) {
         this.client = client;
         this.baseUrl = BaseUrl.of(baseUrl);
         this.responseLeakDetector = responseLeakDetector;
+        this.uriIndexForInstrumentation = uriIndexForInstrumentation;
     }
 
     @Override
@@ -154,6 +160,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             SafeArg.of("requestTraceId", request.headerParams().get(TraceHttpHeaders.TRACE_ID)),
             // Request span ID can be used to associate a failed request with a request log line on the server.
             SafeArg.of("requestSpanId", request.headerParams().get(TraceHttpHeaders.SPAN_ID)),
+            SafeArg.of("hostIndex", uriIndexForInstrumentation)
         };
     }
 

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
@@ -82,7 +82,8 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
                                                 "serviceName",
                                                 "endpointName",
                                                 "requestTraceId",
-                                                "requestSpanId");
+                                                "requestSpanId",
+                                                "hostIndex");
                             }));
         }
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -129,7 +129,7 @@ final class ChannelCache {
                         .from(apacheClient.conf())
                         .uris(channelCacheRequest.serviceConf().uris()) // restore uris
                         .build())
-                .channelFactory(uri -> ApacheHttpClientChannels.createSingleUri(uri, apacheClient.client()))
+                .factory(args -> ApacheHttpClientChannels.createSingleUri(args, apacheClient.client()))
                 .overrideHostIndex(channelCacheRequest.overrideHostIndex())
                 .build();
     }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -78,7 +78,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         return DialogueChannel.builder()
                 .channelName(channelName)
                 .clientConfiguration(clientConf)
-                .channelFactory(uri -> ApacheHttpClientChannels.createSingleUri(uri, apacheClient))
+                .factory(args -> ApacheHttpClientChannels.createSingleUri(args, apacheClient))
                 .build();
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
@@ -34,7 +34,7 @@ interface Config {
 
     String channelName();
 
-    ChannelFactory channelFactory();
+    DialogueChannelFactory channelFactory();
 
     ClientConfiguration rawConfig();
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannelFactory.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannelFactory.java
@@ -17,13 +17,30 @@
 package com.palantir.dialogue.core;
 
 import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.DialogueImmutablesStyle;
+import java.util.OptionalInt;
+import org.immutables.value.Value;
 
-/**
- * Prefer using {@link DialogueChannelFactory} to support additional debugging metadata.
- * @deprecated in favor of {@link DialogueChannelFactory}.
- */
-@Deprecated
-public interface ChannelFactory {
+public interface DialogueChannelFactory {
 
-    Channel create(String uri);
+    Channel create(ChannelArgs args);
+
+    @Value.Immutable
+    @DialogueImmutablesStyle
+    interface ChannelArgs {
+        String uri();
+
+        OptionalInt uriIndexForInstrumentation();
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        class Builder extends ImmutableChannelArgs.Builder {}
+    }
+
+    @SuppressWarnings("deprecation")
+    static DialogueChannelFactory from(ChannelFactory legacy) {
+        return args -> legacy.create(args.uri());
+    }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueTracing.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueTracing.java
@@ -51,6 +51,13 @@ final class DialogueTracing {
                 "channel", cf.channelName(), "mesh", Boolean.toString(cf.mesh() == MeshMode.USE_EXTERNAL_MESH));
     }
 
+    static ImmutableMap<String, String> tracingTags(Config cf, int hostIndex) {
+        return ImmutableMap.<String, String>builder()
+                .putAll(tracingTags(cf))
+                .put("hostIndex", Integer.toString(hostIndex))
+                .build();
+    }
+
     static TagTranslator<Response> responseTranslator(ImmutableMap<String, String> tags) {
         return new TagTranslator<Response>() {
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
@@ -97,7 +97,7 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(_uri -> mockChannel)
+                .factory(_args -> mockChannel)
                 .build();
 
         ListenableFuture<Response> expectedResponse = Futures.immediateFuture(response);
@@ -121,7 +121,7 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(_uri -> badUserImplementation)
+                .factory(_args -> badUserImplementation)
                 .build();
 
         // this should never throw
@@ -143,7 +143,7 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(_uri -> badUserImplementation)
+                .factory(_args -> badUserImplementation)
                 .build();
 
         // this should never throw
@@ -160,7 +160,7 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(_uri -> delegate)
+                .factory(_args -> delegate)
                 .build();
 
         Thread.currentThread().interrupt();
@@ -177,7 +177,7 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(_uri -> mockChannel)
+                .factory(_args -> mockChannel)
                 .random(new Random(123456L))
                 .maxQueueSize(1)
                 .build();
@@ -221,7 +221,7 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(_uri -> (_endpoint, currentRequest) -> {
+                .factory(_args -> (_endpoint, currentRequest) -> {
                     int interactions = channelInteractions.incrementAndGet();
                     if (interactions > 1) {
                         return Futures.immediateFuture(new TestResponse()
@@ -276,7 +276,7 @@ public final class DialogueChannelTest {
                         .from(stubConfig)
                         .uris(Collections.emptyList())
                         .build())
-                .channelFactory(_uri -> mockChannel)
+                .factory(_args -> mockChannel)
                 .build();
         ListenableFuture<Response> future = channel.execute(endpoint, request);
         assertThatThrownBy(future::get).hasRootCauseInstanceOf(SafeIllegalStateException.class);
@@ -284,16 +284,16 @@ public final class DialogueChannelTest {
 
     @Test
     void nice_tostring() {
-        ChannelFactory factory = _uri -> mockChannel;
+        DialogueChannelFactory factory = _args -> mockChannel;
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(factory)
+                .factory(factory)
                 .build();
         DialogueChannel channel2 = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .channelFactory(factory)
+                .factory(factory)
                 .build();
         System.out.println(channel);
         assertThat(channel.toString())

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/HostMetricsChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/HostMetricsChannelTest.java
@@ -47,7 +47,7 @@ class HostMetricsChannelTest {
     Channel mockChannel;
 
     @Mock
-    ChannelFactory factory;
+    DialogueChannelFactory factory;
 
     @Mock
     Ticker ticker;

--- a/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionChannels.java
+++ b/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionChannels.java
@@ -32,7 +32,7 @@ public final class HttpUrlConnectionChannels {
         return DialogueChannel.builder()
                 .channelName("http-url-channel")
                 .clientConfiguration(conf)
-                .channelFactory(uri -> BlockingChannelAdapter.of(new HttpUrlConnectionBlockingChannel(conf, url(uri))))
+                .factory(args -> BlockingChannelAdapter.of(new HttpUrlConnectionBlockingChannel(conf, url(args.uri()))))
                 .build();
     }
 

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/JavaChannels.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/JavaChannels.java
@@ -55,7 +55,7 @@ public final class JavaChannels {
         return DialogueChannel.builder()
                 .channelName("java-channel")
                 .clientConfiguration(conf)
-                .channelFactory(uri -> HttpChannel.of(client, url(uri)))
+                .factory(args -> HttpChannel.of(client, url(args.uri())))
                 .build();
     }
 

--- a/dialogue-jmh/src/main/java/com/palantir/dialogue/core/EndToEndBenchmark.java
+++ b/dialogue-jmh/src/main/java/com/palantir/dialogue/core/EndToEndBenchmark.java
@@ -131,7 +131,7 @@ public class EndToEndBenchmark {
         Channel zeroNetworkChannel = DialogueChannel.builder()
                 .channelName("goFast")
                 .clientConfiguration(clientConf)
-                .channelFactory(_uri -> InstantChannel.INSTANCE)
+                .factory(_uri -> InstantChannel.INSTANCE)
                 .buildNonLiveReloading();
         zeroNetworkDialogue = SampleServiceBlocking.of(
                 zeroNetworkChannel, DefaultConjureRuntime.builder().build());

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannels.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpChannels.java
@@ -133,7 +133,7 @@ public final class OkHttpChannels {
         return DialogueChannel.builder()
                 .channelName("okhtpp-channel")
                 .clientConfiguration(config)
-                .channelFactory(uri -> OkHttpChannel.of(client, url(uri)))
+                .factory(args -> OkHttpChannel.of(client, url(args.uri())))
                 .build();
     }
 

--- a/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
+++ b/simulation/src/test/java/com/palantir/dialogue/core/Strategy.java
@@ -83,7 +83,7 @@ public enum Strategy {
                                             .from(STUB_CONFIG)
                                             .taggedMetricRegistry(sim.taggedMetrics()))
                                     .build())
-                            .channelFactory(uri -> channelSupplier.get().get(uri))
+                            .factory(args -> channelSupplier.get().get(args.uri()))
                             .random(sim.pseudoRandom())
                             .scheduler(sim.scheduler())
                             .ticker(sim.clock())


### PR DESCRIPTION
This was an initial attempt to surface per-host information for individual failures. #1292 should give us the data we want for the specific case we're investigating, but this may be more helpful in the general case (outside of pin-until-error) because we can track which node each retry was executed on.

It hits a lot of code. Worth the churn? ¯\_(ツ)_/¯

## After this PR
==COMMIT_MSG==
Plumb through hostIndex to individual channels for debugging
==COMMIT_MSG==
