### PR TITLE
[WIP] Unregister metrics on close.

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -461,15 +461,16 @@ public final class ApacheHttpClientChannels {
         }
 
         public CloseableClient build() {
-            Preconditions.checkNotNull(clientConfiguration, "ClientConfiguration is required");
+            ClientConfiguration conf =
+                    Preconditions.checkNotNull(clientConfiguration, "ClientConfiguration is required");
 
             String tagName = "dialogue";
             String tagValue = "true";
-            TaggedMetricRegistry parentTaggedMetricRegistry = clientConfiguration.taggedMetricRegistry();
+            TaggedMetricRegistry parentTaggedMetricRegistry = conf.taggedMetricRegistry();
             TaggedMetricRegistry scopedTaggedMetricRegistry = new DefaultTaggedMetricRegistry();
             parentTaggedMetricRegistry.addMetrics(tagName, tagValue, parentTaggedMetricRegistry);
-            ClientConfiguration conf = ClientConfiguration.builder()
-                    .from(clientConfiguration)
+            conf = ClientConfiguration.builder()
+                    .from(conf)
                     .taggedMetricRegistry(scopedTaggedMetricRegistry)
                     .build();
             String name = Preconditions.checkNotNull(clientName, "Client name is required");


### PR DESCRIPTION
## Before this PR

Each unique channel registers metrics that stick around after the channel is closed. This usually is not much of a problem (they cost a little bit of memory), but it created frequently enough they might leak?

We have things like DialogueInternalWeakReducingGauge which make sure we don't keep a reference to the heavy objects, but this should clean it up completely.

## After this PR
==COMMIT_MSG==
Dialogue metrics are unregistered on close.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
