### PR TITLE
Reword the DialogueException message

### DIFF
--- a/changelog/@unreleased/pr-1304.v2.yml
+++ b/changelog/@unreleased/pr-1304.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reword the DialogueException message
+  links:
+  - https://github.com/palantir/dialogue/pull/1304

--- a/dialogue-target/src/main/java/com/palantir/dialogue/DialogueException.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/DialogueException.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /** Internal marker type for Dialogue network layer failures where no response is returned. */
 public final class DialogueException extends RuntimeException implements SafeLoggable {
-    private static final String MESSAGE = "Dialogue transport failure";
+    private static final String MESSAGE = "Network transport failure";
 
     public DialogueException(Throwable cause) {
         super(MESSAGE, cause);


### PR DESCRIPTION
Objective is to make it more obvious that failures are likely
the result of a network level failures, not necessarily a dialogue
deficiency.
In retrospect I wish I'd named `DialogueException` differently,
however this may alleviate some of the pressure.

## After this PR
==COMMIT_MSG==
Reword the DialogueException message
==COMMIT_MSG==

## Possible downsides?
possible someone depended on the exception message value? Unlikely given DialogueException is public, although that wasn't always the case.
