### PR TITLE
Response attachments.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -249,3 +249,8 @@ acceptedBreaks:
       new: "method <T> T com.palantir.dialogue.Clients::callBlocking(com.palantir.dialogue.EndpointChannel,\
         \ com.palantir.dialogue.Request, com.palantir.dialogue.Deserializer<T>)"
       justification: "New API for blocking calls."
+  "2.10.0":
+    com.palantir.dialogue:dialogue-target:
+    - code: "java.method.addedToInterface"
+      new: "method com.palantir.dialogue.ResponseAttachments com.palantir.dialogue.Response::attachments()"
+      justification: "New state in Response."

--- a/changelog/@unreleased/pr-1312.v2.yml
+++ b/changelog/@unreleased/pr-1312.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Responses can have attachments.
+  links:
+  - https://github.com/palantir/dialogue/pull/1312

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -24,6 +24,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachments;
 import com.palantir.dialogue.blocking.BlockingChannel;
 import com.palantir.dialogue.core.BaseUrl;
 import com.palantir.logsafe.Arg;
@@ -242,6 +243,9 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private static final class HttpClientResponse implements Response {
 
         private final CloseableHttpResponse response;
+
+        private final ResponseAttachments attachments = ResponseAttachments.create();
+
         // Client reference is used to prevent premature termination
         @Nullable
         private ApacheHttpClientChannels.CloseableClient client;
@@ -294,6 +298,11 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
         @Override
         public Optional<String> getFirstHeader(String header) {
             return Optional.ofNullable(response.getFirstHeader(header)).map(Header::getValue);
+        }
+
+        @Override
+        public ResponseAttachments attachments() {
+            return attachments;
         }
 
         @Override

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ResponseLeakDetector.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ResponseLeakDetector.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue.hc5;
 import com.google.common.collect.ListMultimap;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachments;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -180,6 +181,11 @@ final class ResponseLeakDetector {
         @Override
         public Optional<String> getFirstHeader(String header) {
             return delegate.getFirstHeader(header);
+        }
+
+        @Override
+        public ResponseAttachments attachments() {
+            return delegate.attachments();
         }
 
         @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -95,7 +95,6 @@ final class ContentDecodingChannel implements EndpointChannel {
         private final Response delegate;
         private final ListMultimap<String, String> headers;
         private final InputStream body;
-        private final ResponseAttachments attachments = ResponseAttachments.create();
 
         ContentDecodingResponse(Response delegate) {
             this.delegate = delegate;
@@ -141,7 +140,7 @@ final class ContentDecodingChannel implements EndpointChannel {
 
         @Override
         public ResponseAttachments attachments() {
-            return attachments;
+            return delegate.attachments();
         }
 
         @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachments;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -94,6 +95,7 @@ final class ContentDecodingChannel implements EndpointChannel {
         private final Response delegate;
         private final ListMultimap<String, String> headers;
         private final InputStream body;
+        private final ResponseAttachments attachments = ResponseAttachments.create();
 
         ContentDecodingResponse(Response delegate) {
             this.delegate = delegate;
@@ -135,6 +137,11 @@ final class ContentDecodingChannel implements EndpointChannel {
         @Override
         public String toString() {
             return "ContentDecodingResponse{delegate=" + delegate + '}';
+        }
+
+        @Override
+        public ResponseAttachments attachments() {
+            return attachments;
         }
 
         @Override

--- a/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionBlockingChannel.java
+++ b/dialogue-httpurlconnection-client/src/main/java/com/palantir/dialogue/httpurlconnection/HttpUrlConnectionBlockingChannel.java
@@ -25,6 +25,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachments;
 import com.palantir.dialogue.blocking.BlockingChannel;
 import com.palantir.dialogue.core.BaseUrl;
 import com.palantir.logsafe.Preconditions;
@@ -106,6 +107,7 @@ final class HttpUrlConnectionBlockingChannel implements BlockingChannel {
 
         private final HttpURLConnection connection;
         private final int code;
+        private final ResponseAttachments attachments = ResponseAttachments.create();
 
         HttpUrlConnectionResponse(HttpURLConnection connection) throws IOException {
             this.connection = connection;
@@ -146,6 +148,11 @@ final class HttpUrlConnectionBlockingChannel implements BlockingChannel {
         @Override
         public Optional<String> getFirstHeader(String header) {
             return Optional.ofNullable(connection.getHeaderField(header));
+        }
+
+        @Override
+        public ResponseAttachments attachments() {
+            return attachments;
         }
 
         @Override

--- a/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
+++ b/dialogue-java-client/src/main/java/com/palantir/dialogue/HttpChannel.java
@@ -97,6 +97,9 @@ public final class HttpChannel implements Channel {
 
     private Response toResponse(HttpResponse<InputStream> response) {
         return new Response() {
+
+            private final ResponseAttachments attachments = ResponseAttachments.create();
+
             @Override
             public InputStream body() {
                 return response.body();
@@ -114,6 +117,11 @@ public final class HttpChannel implements Channel {
                         .build();
                 response.headers().map().forEach(headers::putAll);
                 return headers;
+            }
+
+            @Override
+            public ResponseAttachments attachments() {
+                return attachments;
             }
 
             @Override

--- a/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
+++ b/dialogue-okhttp-client/src/main/java/com/palantir/dialogue/OkHttpResponse.java
@@ -25,6 +25,7 @@ import okhttp3.ResponseBody;
 public final class OkHttpResponse implements Response {
 
     private final okhttp3.Response delegate;
+    private final ResponseAttachments attachments = ResponseAttachments.create();
 
     private OkHttpResponse(okhttp3.Response delegate) {
         this.delegate = delegate;
@@ -56,6 +57,11 @@ public final class OkHttpResponse implements Response {
                 .build();
         delegate.headers().toMultimap().forEach(headers::putAll);
         return headers;
+    }
+
+    @Override
+    public ResponseAttachments attachments() {
+        return attachments;
     }
 
     @Override

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+
+final class Attachments {
+    private final Map<AttachmentKey<?>, Object> attachments = new ConcurrentHashMap<>(0);
+
+    private Attachments() {}
+
+    static Attachments create() {
+        return new Attachments();
+    }
+
+    @Nullable
+    public <V> V put(AttachmentKey<V> key, V value) {
+        Preconditions.checkNotNull(key, "key");
+        Preconditions.checkNotNull(value, "value");
+        key.checkIsInstance(value);
+        return (V) attachments.put(key, value);
+    }
+
+    @Nullable
+    public <V> V getOrDefault(AttachmentKey<V> key, @Nullable V defaultValue) {
+        Preconditions.checkNotNull(key, "key");
+        return (V) attachments.getOrDefault(key, defaultValue);
+    }
+
+    static final class AttachmentKey<V> {
+
+        private final Class<V> valueClazz;
+
+        private AttachmentKey(Class<V> valueClazz) {
+            this.valueClazz = valueClazz;
+        }
+
+        private void checkIsInstance(V value) {
+            if (!valueClazz.isInstance(value)) {
+                throw new SafeIllegalArgumentException(
+                        "Unexpected type",
+                        SafeArg.of("expected", valueClazz),
+                        SafeArg.of("actualType", value == null ? null : value.getClass()));
+            }
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "RawTypes"})
+    public static <T> AttachmentKey<T> createAttachmentKey(Class<? super T> valueClazz) {
+        Preconditions.checkNotNull(valueClazz, "valueClazz");
+        return new AttachmentKey(valueClazz);
+    }
+}

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
@@ -65,7 +65,7 @@ final class Attachments {
     }
 
     @SuppressWarnings({"unchecked", "RawTypes"})
-    public static <T> AttachmentKey<T> createAttachmentKey(Class<? super T> valueClazz) {
+    static <T> AttachmentKey<T> createAttachmentKey(Class<? super T> valueClazz) {
         Preconditions.checkNotNull(valueClazz, "valueClazz");
         return new AttachmentKey(valueClazz);
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
@@ -33,7 +33,7 @@ final class Attachments {
     }
 
     @Nullable
-    public <V> V put(AttachmentKey<V> key, V value) {
+    <V> V put(AttachmentKey<V> key, V value) {
         Preconditions.checkNotNull(key, "key");
         Preconditions.checkNotNull(value, "value");
         key.checkIsInstance(value);
@@ -41,7 +41,7 @@ final class Attachments {
     }
 
     @Nullable
-    public <V> V getOrDefault(AttachmentKey<V> key, @Nullable V defaultValue) {
+    <V> V getOrDefault(AttachmentKey<V> key, @Nullable V defaultValue) {
         Preconditions.checkNotNull(key, "key");
         return (V) attachments.getOrDefault(key, defaultValue);
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -16,7 +16,6 @@
 
 package com.palantir.dialogue;
 
-import com.google.common.annotations.Beta;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -90,7 +89,6 @@ public final class Request {
      * The mutable request attachments for this request. Attachments will be propagated when this request is mutated
      * through the builder
      */
-    @Beta
     public RequestAttachments attachments() {
         return attachments;
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RequestAttachments.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RequestAttachments.java
@@ -16,16 +16,11 @@
 
 package com.palantir.dialogue;
 
-import com.google.common.annotations.Beta;
-import com.palantir.logsafe.Preconditions;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
-@Beta
 public final class RequestAttachments {
 
-    private final Map<RequestAttachmentKey<?>, Object> attachments = new ConcurrentHashMap<>(0);
+    private final Attachments attachments = Attachments.create();
 
     private RequestAttachments() {}
 
@@ -35,15 +30,11 @@ public final class RequestAttachments {
 
     @Nullable
     public <V> V put(RequestAttachmentKey<V> key, V value) {
-        Preconditions.checkNotNull(key, "key");
-        Preconditions.checkNotNull(value, "value");
-        key.checkIsInstance(value);
-        return (V) attachments.put(key, value);
+        return attachments.put(key.attachment(), value);
     }
 
     @Nullable
     public <V> V getOrDefault(RequestAttachmentKey<V> key, @Nullable V defaultValue) {
-        Preconditions.checkNotNull(key, "key");
-        return (V) attachments.getOrDefault(key, defaultValue);
+        return attachments.getOrDefault(key.attachment(), defaultValue);
     }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Response.java
@@ -40,6 +40,11 @@ public interface Response extends Closeable {
     }
 
     /**
+     * The mutable response attachments.
+     */
+    ResponseAttachments attachments();
+
+    /**
      * Releases all resources associated with this response. If the {@link #body()} is still open, {@link #close()}
      * should {@link InputStream#close() close the stream}.
      * Implementations must not throw, preferring to catch and log internally.

--- a/dialogue-target/src/main/java/com/palantir/dialogue/ResponseAttachmentKey.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/ResponseAttachmentKey.java
@@ -18,11 +18,11 @@ package com.palantir.dialogue;
 
 import com.palantir.dialogue.Attachments.AttachmentKey;
 
-public final class RequestAttachmentKey<V> {
+public final class ResponseAttachmentKey<V> {
 
     private final AttachmentKey<V> attachment;
 
-    private RequestAttachmentKey(AttachmentKey<V> attachment) {
+    private ResponseAttachmentKey(AttachmentKey<V> attachment) {
         this.attachment = attachment;
     }
 
@@ -30,7 +30,7 @@ public final class RequestAttachmentKey<V> {
         return attachment;
     }
 
-    public static <T> RequestAttachmentKey<T> create(Class<? super T> valueClazz) {
-        return new RequestAttachmentKey<>(Attachments.createAttachmentKey(valueClazz));
+    public static <T> ResponseAttachmentKey<T> create(Class<? super T> valueClazz) {
+        return new ResponseAttachmentKey<>(Attachments.createAttachmentKey(valueClazz));
     }
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/ResponseAttachments.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/ResponseAttachments.java
@@ -16,21 +16,24 @@
 
 package com.palantir.dialogue;
 
-import com.palantir.dialogue.Attachments.AttachmentKey;
+import javax.annotation.Nullable;
 
-public final class RequestAttachmentKey<V> {
+public final class ResponseAttachments {
+    private final Attachments attachments = Attachments.create();
 
-    private final AttachmentKey<V> attachment;
+    private ResponseAttachments() {}
 
-    private RequestAttachmentKey(AttachmentKey<V> attachment) {
-        this.attachment = attachment;
+    public static ResponseAttachments create() {
+        return new ResponseAttachments();
     }
 
-    AttachmentKey<V> attachment() {
-        return attachment;
+    @Nullable
+    public <V> V put(RequestAttachmentKey<V> key, V value) {
+        return attachments.put(key.attachment(), value);
     }
 
-    public static <T> RequestAttachmentKey<T> create(Class<? super T> valueClazz) {
-        return new RequestAttachmentKey<>(Attachments.createAttachmentKey(valueClazz));
+    @Nullable
+    public <V> V getOrDefault(RequestAttachmentKey<V> key, @Nullable V defaultValue) {
+        return attachments.getOrDefault(key.attachment(), defaultValue);
     }
 }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/AttachmentsTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/AttachmentsTest.java
@@ -20,16 +20,17 @@ import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptio
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.dialogue.Attachments.AttachmentKey;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import org.assertj.core.api.AbstractLongAssert;
 import org.junit.jupiter.api.Test;
 
-public final class RequestAttachmentsTest {
+public final class AttachmentsTest {
 
-    private static final RequestAttachmentKey<Long> KEY1 = RequestAttachmentKey.create(Long.class);
-    private static final RequestAttachmentKey<Long> KEY2 = RequestAttachmentKey.create(Long.class);
-    private final RequestAttachments attachments = RequestAttachments.create();
+    private static final AttachmentKey<Long> KEY1 = Attachments.createAttachmentKey(Long.class);
+    private static final AttachmentKey<Long> KEY2 = Attachments.createAttachmentKey(Long.class);
+    private final Attachments attachments = Attachments.create();
 
     @Test
     public void testInitiallyEmpty() {
@@ -60,7 +61,7 @@ public final class RequestAttachmentsTest {
 
     @Test
     public void testCannotPutNullKey() {
-        RequestAttachmentKey<Long> key = null;
+        AttachmentKey<Long> key = null;
         assertThatLoggableExceptionThrownBy(() -> attachments.put(key, 1L))
                 .isExactlyInstanceOf(SafeNullPointerException.class)
                 .hasExactlyArgs()
@@ -78,12 +79,12 @@ public final class RequestAttachmentsTest {
     @Test
     @SuppressWarnings("RawTypes")
     public void testCannotAttachIncorrectType() {
-        assertThatThrownBy(() -> attachments.put((RequestAttachmentKey) KEY1, ""))
+        assertThatThrownBy(() -> attachments.put((AttachmentKey) KEY1, ""))
                 .isExactlyInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining("Unexpected type");
     }
 
-    private AbstractLongAssert<?> assertThatKey(RequestAttachmentKey<Long> key) {
+    private AbstractLongAssert<?> assertThatKey(AttachmentKey<Long> key) {
         return assertThat(attachments.getOrDefault(key, null));
     }
 }

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/TestResponse.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/TestResponse.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.HttpHeaders;
 public final class TestResponse implements Response {
 
     private final CloseRecordingInputStream inputStream;
+    private final ResponseAttachments attachments = ResponseAttachments.create();
 
     private boolean closeCalled = false;
     private int code = 0;
@@ -66,6 +67,11 @@ public final class TestResponse implements Response {
     @Override
     public ListMultimap<String, String> headers() {
         return headers;
+    }
+
+    @Override
+    public ResponseAttachments attachments() {
+        return attachments;
     }
 
     @Override

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -26,6 +26,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachments;
 import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.Preconditions;
@@ -281,6 +282,9 @@ final class SimulationServer implements Channel {
 
     private static Response wrapWithCloseInstrumentation(Response delegate, SimulationServer sim) {
         return new Response() {
+
+            private final ResponseAttachments attachments = ResponseAttachments.create();
+
             @Override
             public InputStream body() {
                 return delegate.body();
@@ -299,6 +303,11 @@ final class SimulationServer implements Channel {
             @Override
             public Optional<String> getFirstHeader(String header) {
                 return delegate.getFirstHeader(header);
+            }
+
+            @Override
+            public ResponseAttachments attachments() {
+                return attachments;
             }
 
             @Override

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -282,7 +282,6 @@ final class SimulationServer implements Channel {
 
     private static Response wrapWithCloseInstrumentation(Response delegate, SimulationServer sim) {
         return new Response() {
-
             @Override
             public InputStream body() {
                 return delegate.body();

--- a/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
+++ b/simulation/src/main/java/com/palantir/dialogue/core/SimulationServer.java
@@ -283,8 +283,6 @@ final class SimulationServer implements Channel {
     private static Response wrapWithCloseInstrumentation(Response delegate, SimulationServer sim) {
         return new Response() {
 
-            private final ResponseAttachments attachments = ResponseAttachments.create();
-
             @Override
             public InputStream body() {
                 return delegate.body();
@@ -307,7 +305,7 @@ final class SimulationServer implements Channel {
 
             @Override
             public ResponseAttachments attachments() {
-                return attachments;
+                return delegate.attachments();
             }
 
             @Override


### PR DESCRIPTION
## Before this PR

No way to attach mutable state to responses. As with requests, this turns out to be quite a nice and useful capability, so we'd like to extend this to responses.

## After this PR
==COMMIT_MSG==
Responses can have attachments.
==COMMIT_MSG==

## Possible downsides?

* Moar API.
* A lot of copy pasta: we could consider a nice AbstractResponse and shove some shared code there, but I didn't want to start with that because I know this is a contentious topic around here.
