### PR TITLE
LimitedChannel supports disabling limit enforcement.

### DIFF
--- a/changelog/@unreleased/pr-1316.v2.yml
+++ b/changelog/@unreleased/pr-1316.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: LimitedChannel supports skipping limits.
+  description: LimitedChannel supports disabling limit enforcement.
   links:
   - https://github.com/palantir/dialogue/pull/1316

--- a/changelog/@unreleased/pr-1316.v2.yml
+++ b/changelog/@unreleased/pr-1316.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: LimitedChannel supports skipping limits.
+  links:
+  - https://github.com/palantir/dialogue/pull/1316

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -72,7 +72,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request request, SkipLimits skipLimits) {
+            Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
         ScoreSnapshot[] snapshotsByScore = tracker.getSnapshotsInOrderOfIncreasingScore();
 
         int giveUpThreshold = Integer.MAX_VALUE;
@@ -117,7 +117,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             channelInfo.startRequest();
 
             Optional<ListenableFuture<Response>> maybe =
-                    channels.get(channelInfo.channelIndex()).maybeExecute(endpoint, request, skipLimits);
+                    channels.get(channelInfo.channelIndex()).maybeExecute(endpoint, request, limitEnforcement);
 
             if (maybe.isPresent()) {
                 channelInfo.observability().markRequestMade();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -71,7 +71,8 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
     }
 
     @Override
-    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
+    public Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request request, SkipLimits skipLimits) {
         ScoreSnapshot[] snapshotsByScore = tracker.getSnapshotsInOrderOfIncreasingScore();
 
         int giveUpThreshold = Integer.MAX_VALUE;
@@ -116,7 +117,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             channelInfo.startRequest();
 
             Optional<ListenableFuture<Response>> maybe =
-                    channels.get(channelInfo.channelIndex()).maybeExecute(endpoint, request);
+                    channels.get(channelInfo.channelIndex()).maybeExecute(endpoint, request, skipLimits);
 
             if (maybe.isPresent()) {
                 channelInfo.observability().markRequestMade();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
@@ -69,7 +69,7 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
      * {@link Permit#onFailure} which delegate to
      * ignore/dropped/success depending on the success or failure state of the response.
      * */
-    Optional<Permit> acquire() {
+    Optional<Permit> acquire(boolean force) {
 
         // Capture the limit field reference once to avoid work in a tight loop. The JIT cannot
         // reliably optimize out references to final fields due to the potential for reflective
@@ -83,7 +83,7 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
         int currentLimit = (int) getLimit();
         while (true) {
             int currentInFlight = localInFlight.get();
-            if (currentInFlight >= currentLimit) {
+            if (!force && currentInFlight >= currentLimit) {
                 return Optional.empty();
             }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.google.common.util.concurrent.FutureCallback;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.logsafe.SafeArg;
 import java.io.IOException;
 import java.util.Optional;
@@ -69,7 +70,7 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
      * {@link Permit#onFailure} which delegate to
      * ignore/dropped/success depending on the success or failure state of the response.
      * */
-    Optional<Permit> acquire(boolean force) {
+    Optional<Permit> acquire(LimitEnforcement limitEnforcement) {
 
         // Capture the limit field reference once to avoid work in a tight loop. The JIT cannot
         // reliably optimize out references to final fields due to the potential for reflective
@@ -83,7 +84,7 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
         int currentLimit = (int) getLimit();
         while (true) {
             int currentInFlight = localInFlight.get();
-            if (!force && currentInFlight >= currentLimit) {
+            if (limitEnforcement.enforceLimits() && currentInFlight >= currentLimit) {
                 return Optional.empty();
             }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToLimitedChannelAdapter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToLimitedChannelAdapter.java
@@ -33,7 +33,8 @@ final class ChannelToLimitedChannelAdapter implements LimitedChannel {
     }
 
     @Override
-    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
+    public Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request request, SkipLimits _skipLimits) {
         return Optional.of(delegate.execute(endpoint, request));
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToLimitedChannelAdapter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToLimitedChannelAdapter.java
@@ -34,7 +34,7 @@ final class ChannelToLimitedChannelAdapter implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request request, SkipLimits _skipLimits) {
+            Endpoint endpoint, Request request, LimitEnforcement _limitEnforcement) {
         return Optional.of(delegate.execute(endpoint, request));
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -77,9 +77,9 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request request, SkipLimits skipLimits) {
+            Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
         Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> maybePermit =
-                limiter.acquire(skipLimits == SkipLimits.Yes);
+                limiter.acquire(limitEnforcement);
         if (maybePermit.isPresent()) {
             CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit permit = maybePermit.get();
             logPermitAcquired();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue.core;
 
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.client.config.ClientConfiguration.ClientQoS;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
@@ -51,6 +52,11 @@ interface Config {
     @Value.Derived
     default MeshMode mesh() {
         return MeshMode.fromUris(rawConfig().uris(), SafeArg.of("channelName", channelName()));
+    }
+
+    @Value.Derived
+    default boolean isConcurrencyLimitingEnabled() {
+        return clientConf().clientQoS() == ClientQoS.ENABLED && mesh() != MeshMode.USE_EXTERNAL_MESH;
     }
 
     @Value.Default

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannel.java
@@ -29,13 +29,18 @@ import java.util.Optional;
  * Limited channels must limit exclusively based on the state of the {@link com.palantir.dialogue.Channel}, not
  * the {@link Endpoint} or {@link Request} arguments, otherwise the caller (generally a {@link QueuedChannel})
  * may prevent <i>all</i> requests from proceeding.
- * Implementations should support skipping the limit checks, while still tracking usage appropriately.
+ * Implementations should support disabling limit enforcement, while still tracking usage appropriately.
  */
 interface LimitedChannel {
-    Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request, SkipLimits skipLimits);
+    Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request request, LimitEnforcement limitEnforcement);
 
-    enum SkipLimits {
-        Yes,
-        No
+    enum LimitEnforcement {
+        DANGEROUS_BYPASS_LIMITS,
+        DEFAULT_ENABLED;
+
+        boolean enforceLimits() {
+            return this == DEFAULT_ENABLED;
+        }
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/LimitedChannel.java
@@ -29,7 +29,13 @@ import java.util.Optional;
  * Limited channels must limit exclusively based on the state of the {@link com.palantir.dialogue.Channel}, not
  * the {@link Endpoint} or {@link Request} arguments, otherwise the caller (generally a {@link QueuedChannel})
  * may prevent <i>all</i> requests from proceeding.
+ * Implementations should support skipping the limit checks, while still tracking usage appropriately.
  */
 interface LimitedChannel {
-    Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request);
+    Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request, SkipLimits skipLimits);
+
+    enum SkipLimits {
+        Yes,
+        No
+    }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowLimitedChannel.java
@@ -39,9 +39,10 @@ final class NeverThrowLimitedChannel implements LimitedChannel {
     }
 
     @Override
-    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
+    public Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request request, SkipLimits skipLimits) {
         try {
-            return delegate.maybeExecute(endpoint, request);
+            return delegate.maybeExecute(endpoint, request, skipLimits);
         } catch (RuntimeException | Error e) {
             log.error("Dialogue channels should never throw. This may be a bug in the channel implementation", e);
             return Optional.of(Futures.immediateFailedFuture(e));

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NeverThrowLimitedChannel.java
@@ -40,9 +40,9 @@ final class NeverThrowLimitedChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request request, SkipLimits skipLimits) {
+            Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
         try {
-            return delegate.maybeExecute(endpoint, request, skipLimits);
+            return delegate.maybeExecute(endpoint, request, limitEnforcement);
         } catch (RuntimeException | Error e) {
             log.error("Dialogue channels should never throw. This may be a bug in the channel implementation", e);
             return Optional.of(Futures.immediateFailedFuture(e));

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -93,8 +93,8 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request request, SkipLimits skipLimits) {
-        Optional<ListenableFuture<Response>> maybe = delegate.maybeExecute(endpoint, request, skipLimits);
+            Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
+        Optional<ListenableFuture<Response>> maybe = delegate.maybeExecute(endpoint, request, limitEnforcement);
         if (!maybe.isPresent()) {
             return Optional.empty();
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -92,8 +92,9 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
     }
 
     @Override
-    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
-        Optional<ListenableFuture<Response>> maybe = delegate.maybeExecute(endpoint, request);
+    public Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request request, SkipLimits skipLimits) {
+        Optional<ListenableFuture<Response>> maybe = delegate.maybeExecute(endpoint, request, skipLimits);
         if (!maybe.isPresent()) {
             return Optional.empty();
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
@@ -129,11 +129,11 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request request, SkipLimits skipLimits) {
+            Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
         int pin = currentPin.get();
         PinChannel channel = nodeList.get(pin);
 
-        Optional<ListenableFuture<Response>> maybeResponse = channel.maybeExecute(endpoint, request, skipLimits);
+        Optional<ListenableFuture<Response>> maybeResponse = channel.maybeExecute(endpoint, request, limitEnforcement);
         if (!maybeResponse.isPresent()) {
             return Optional.empty();
         }
@@ -188,8 +188,8 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
 
         @Override
         default Optional<ListenableFuture<Response>> maybeExecute(
-                Endpoint endpoint, Request request, SkipLimits skipLimits) {
-            return delegate().maybeExecute(endpoint, request, skipLimits);
+                Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
+            return delegate().maybeExecute(endpoint, request, limitEnforcement);
         }
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
@@ -128,16 +128,17 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
     }
 
     @Override
-    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
+    public Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request request, SkipLimits skipLimits) {
         int pin = currentPin.get();
         PinChannel channel = nodeList.get(pin);
 
-        Optional<ListenableFuture<Response>> maybeResponse = channel.maybeExecute(endpoint, request);
+        Optional<ListenableFuture<Response>> maybeResponse = channel.maybeExecute(endpoint, request, skipLimits);
         if (!maybeResponse.isPresent()) {
             return Optional.empty();
         }
 
-        DialogueFutures.addDirectCallback(maybeResponse.get(), new FutureCallback<Response>() {
+        DialogueFutures.addDirectCallback(maybeResponse.get(), new FutureCallback<>() {
             @Override
             public void onSuccess(Response response) {
                 // We specifically don't switch  429 responses to support transactional
@@ -186,8 +187,9 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
         int stableIndex();
 
         @Override
-        default Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
-            return delegate().maybeExecute(endpoint, request);
+        default Optional<ListenableFuture<Response>> maybeExecute(
+                Endpoint endpoint, Request request, SkipLimits skipLimits) {
+            return delegate().maybeExecute(endpoint, request, skipLimits);
         }
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -28,7 +28,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
-import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 final class QueuedChannel implements Channel {
     private static final Logger log = LoggerFactory.getLogger(QueuedChannel.class);
-    private static final SkipLimits DO_NOT_SKIP_LIMITS = SkipLimits.No;
+    private static final LimitEnforcement DO_NOT_SKIP_LIMITS = LimitEnforcement.DEFAULT_ENABLED;
 
     private final Deque<DeferredCall> queuedCalls;
     private final NeverThrowLimitedChannel delegate;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/SupplierChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/SupplierChannel.java
@@ -31,8 +31,9 @@ final class SupplierChannel implements LimitedChannel {
     }
 
     @Override
-    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request request) {
+    public Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request request, SkipLimits skipLimits) {
         LimitedChannel delegate = channelSupplier.get();
-        return delegate.maybeExecute(endpoint, request);
+        return delegate.maybeExecute(endpoint, request, skipLimits);
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/SupplierChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/SupplierChannel.java
@@ -32,8 +32,8 @@ final class SupplierChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request request, SkipLimits skipLimits) {
+            Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
         LimitedChannel delegate = channelSupplier.get();
-        return delegate.maybeExecute(endpoint, request, skipLimits);
+        return delegate.maybeExecute(endpoint, request, limitEnforcement);
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ZeroUriNodeSelectionChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ZeroUriNodeSelectionChannel.java
@@ -36,7 +36,7 @@ final class ZeroUriNodeSelectionChannel implements LimitedChannel {
 
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
-            Endpoint endpoint, Request _request, SkipLimits _skipLimits) {
+            Endpoint endpoint, Request _request, LimitEnforcement _limitEnforcement) {
         return Optional.of(Futures.immediateFailedFuture(new SafeIllegalStateException(
                 "There are no URIs configured to handle requests",
                 SafeArg.of("channel", channelName),

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ZeroUriNodeSelectionChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ZeroUriNodeSelectionChannel.java
@@ -35,7 +35,8 @@ final class ZeroUriNodeSelectionChannel implements LimitedChannel {
     }
 
     @Override
-    public Optional<ListenableFuture<Response>> maybeExecute(Endpoint endpoint, Request _request) {
+    public Optional<ListenableFuture<Response>> maybeExecute(
+            Endpoint endpoint, Request _request, SkipLimits _skipLimits) {
         return Optional.of(Futures.immediateFailedFuture(new SafeIllegalStateException(
                 "There are no URIs configured to handle requests",
                 SafeArg.of("channel", channelName),

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
@@ -33,6 +33,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestEndpoint;
 import com.palantir.dialogue.TestResponse;
+import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.time.Duration;
 import java.util.Optional;
@@ -75,13 +76,13 @@ class BalancedNodeSelectionStrategyChannelTest {
     void when_one_channel_is_in_use_prefer_the_other() {
         set200(chan1);
         SettableFuture<Response> settableFuture = SettableFuture.create();
-        when(chan2.maybeExecute(any(), any())).thenReturn(Optional.of(settableFuture));
+        when(chan2.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(Optional.of(settableFuture));
 
         for (int i = 0; i < 200; i++) {
-            channel.maybeExecute(endpoint, request);
+            channel.maybeExecute(endpoint, request, SkipLimits.No);
         }
-        verify(chan1, times(199)).maybeExecute(eq(endpoint), any());
-        verify(chan2, times(1)).maybeExecute(eq(endpoint), any());
+        verify(chan1, times(199)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
+        verify(chan2, times(1)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
     }
 
     @Test
@@ -90,53 +91,55 @@ class BalancedNodeSelectionStrategyChannelTest {
         set200(chan2);
 
         for (int i = 0; i < 200; i++) {
-            channel.maybeExecute(endpoint, request);
+            channel.maybeExecute(endpoint, request, SkipLimits.No);
         }
-        verify(chan1, times(99)).maybeExecute(eq(endpoint), any());
-        verify(chan2, times(101)).maybeExecute(eq(endpoint), any());
+        verify(chan1, times(99)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
+        verify(chan2, times(101)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
     }
 
     @Test
     void when_channels_refuse_try_all_then_give_up() {
-        when(chan1.maybeExecute(any(), any())).thenReturn(Optional.empty());
-        when(chan2.maybeExecute(any(), any())).thenReturn(Optional.empty());
+        when(chan1.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(Optional.empty());
+        when(chan2.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(Optional.empty());
 
-        assertThat(channel.maybeExecute(endpoint, request)).isNotPresent();
-        verify(chan1, times(1)).maybeExecute(eq(endpoint), any());
-        verify(chan2, times(1)).maybeExecute(eq(endpoint), any());
+        assertThat(channel.maybeExecute(endpoint, request, SkipLimits.No)).isNotPresent();
+        verify(chan1, times(1)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
+        verify(chan2, times(1)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
     }
 
     @Test
     void a_single_4xx_doesnt_move_the_needle() {
-        when(chan1.maybeExecute(any(), any())).thenReturn(http(400)).thenReturn(http(200));
-        when(chan2.maybeExecute(any(), any())).thenReturn(http(200));
+        when(chan1.maybeExecute(any(), any(), eq(SkipLimits.No)))
+                .thenReturn(http(400))
+                .thenReturn(http(200));
+        when(chan2.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(http(200));
 
         for (long start = clock.read();
                 clock.read() < start + Duration.ofSeconds(10).toNanos();
                 incrementClockBy(Duration.ofMillis(50))) {
-            channel.maybeExecute(endpoint, request);
+            channel.maybeExecute(endpoint, request, SkipLimits.No);
             assertThat(channel.getScoresForTesting())
                     .describedAs("A single 400 at the beginning isn't enough to impact scores", channel)
                     .containsExactly(0, 0);
         }
 
-        verify(chan1, times(99)).maybeExecute(eq(endpoint), any());
-        verify(chan2, times(101)).maybeExecute(eq(endpoint), any());
+        verify(chan1, times(99)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
+        verify(chan2, times(101)).maybeExecute(eq(endpoint), any(), eq(SkipLimits.No));
     }
 
     @Test
     void constant_4xxs_do_eventually_move_the_needle_but_we_go_back_to_fair_distribution() {
-        when(chan1.maybeExecute(any(), any())).thenReturn(http(400));
-        when(chan2.maybeExecute(any(), any())).thenReturn(http(200));
+        when(chan1.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(http(400));
+        when(chan2.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(http(200));
 
         for (int i = 0; i < 11; i++) {
-            rttChannel.maybeExecute(endpoint, request);
+            rttChannel.maybeExecute(endpoint, request, SkipLimits.No);
             assertThat(rttChannel.getScoresForTesting())
                     .describedAs("%s %s: Scores not affected yet %s", i, Duration.ofNanos(clock.read()), rttChannel)
                     .containsExactly(0, 0);
             incrementClockBy(Duration.ofMillis(50));
         }
-        rttChannel.maybeExecute(endpoint, request);
+        rttChannel.maybeExecute(endpoint, request, SkipLimits.No);
         assertThat(rttChannel.getScoresForTesting())
                 .describedAs("%s: Constant 4xxs did move the needle %s", Duration.ofNanos(clock.read()), rttChannel)
                 .containsExactly(1, 0);
@@ -151,7 +154,7 @@ class BalancedNodeSelectionStrategyChannelTest {
     }
 
     private static void set200(LimitedChannel chan) {
-        when(chan.maybeExecute(any(), any())).thenReturn(http(200));
+        when(chan.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(http(200));
     }
 
     private static Optional<ListenableFuture<Response>> http(int value) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
@@ -41,6 +41,8 @@ import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -151,6 +153,13 @@ class BalancedNodeSelectionStrategyChannelTest {
                         "%s: We quickly forget about 4xxs and go back to fair shuffling %s",
                         Duration.ofNanos(clock.read()), rttChannel)
                 .containsExactly(0, 0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(SkipLimits.class)
+    public void skiplimits_passthrough(SkipLimits skipLimits) {
+        when(chan1.maybeExecute(any(), any(), eq(skipLimits))).thenReturn(http(200));
+        assertThat(channel.maybeExecute(endpoint, request, skipLimits)).isPresent();
     }
 
     private static void set200(LimitedChannel chan) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.core.CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Behavior;
 import com.palantir.dialogue.core.CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -55,17 +56,17 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         double max = limiter.getLimit();
         Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> latestPermit = null;
         for (int i = 0; i < max; ++i) {
-            latestPermit = limiter.acquire(false);
+            latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
             assertThat(latestPermit).isPresent();
         }
 
         // Limit reached, cannot acquire permit
         assertThat(limiter.getInflight()).isEqualTo((int) max);
-        assertThat(limiter.acquire(false)).isEmpty();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
 
         // Release one permit, can acquire new permit.
         latestPermit.get().ignore();
-        assertThat(limiter.acquire(false)).isPresent();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
     }
 
     @ParameterizedTest
@@ -76,7 +77,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         double max = limiter.getLimit();
         Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> latestPermit = null;
         for (int i = 0; i < max; ++i) {
-            latestPermit = limiter.acquire(false);
+            latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
             assertThat(latestPermit).isPresent();
         }
 
@@ -84,8 +85,23 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         assertThat(limiter.getLimit()).isEqualTo(20.05);
 
         // Now we can only acquire one extra permit, not 2
-        assertThat(limiter.acquire(false)).isPresent();
-        assertThat(limiter.acquire(false)).isEmpty();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
+    }
+
+    @ParameterizedTest
+    @EnumSource(Behavior.class)
+    public void acquire_canTurnOffLimits(Behavior behavior) {
+        CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
+
+        double max = limiter.getLimit();
+        for (int i = 0; i < max; ++i) {
+            assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
+        }
+
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
+        assertThat(limiter.acquire(LimitEnforcement.DANGEROUS_BYPASS_LIMITS)).isPresent();
+        assertThat(limiter.getInflight()).isEqualTo((int) (max + 1));
     }
 
     @ParameterizedTest
@@ -93,7 +109,8 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void ignore_releasesPermit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         assertThat(limiter.getInflight()).isEqualTo(0);
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit = limiter.acquire(false);
+        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit =
+                limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
         assertThat(limiter.getInflight()).isEqualTo(1);
         permit.get().ignore();
         assertThat(limiter.getInflight()).isEqualTo(0);
@@ -104,7 +121,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void ignore_doesNotChangeLimits(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         double max = limiter.getLimit();
-        limiter.acquire(false).get().ignore();
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().ignore();
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -113,7 +130,8 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void dropped_releasesPermit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         assertThat(limiter.getInflight()).isEqualTo(0);
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit = limiter.acquire(false);
+        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit =
+                limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
         assertThat(limiter.getInflight()).isEqualTo(1);
         permit.get().dropped();
         assertThat(limiter.getInflight()).isEqualTo(0);
@@ -124,7 +142,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void dropped_reducesLimit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         double max = limiter.getLimit();
-        limiter.acquire(false).get().dropped();
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().dropped();
         assertThat(limiter.getLimit()).isEqualTo((int) (max * 0.9));
     }
 
@@ -133,7 +151,8 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void success_releasesPermit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         assertThat(limiter.getInflight()).isEqualTo(0);
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit = limiter.acquire(false);
+        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit =
+                limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
         assertThat(limiter.getInflight()).isEqualTo(1);
         permit.get().success();
         assertThat(limiter.getInflight()).isEqualTo(0);
@@ -145,11 +164,11 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         double max = limiter.getLimit();
         for (int i = 0; i < max * .9; ++i) {
-            assertThat(limiter.acquire(false)).isPresent();
+            assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
             assertThat(limiter.getLimit()).isEqualTo(max);
         }
 
-        limiter.acquire(false).get().success();
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().success();
         assertThat(limiter.getLimit()).isGreaterThan(max).isLessThanOrEqualTo(max + 1);
     }
 
@@ -161,7 +180,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         when(response.code()).thenReturn(200);
 
         double max = limiter.getLimit();
-        limiter.acquire(false).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -173,7 +192,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
             when(response.code()).thenReturn(code);
 
             double max = limiter.getLimit();
-            limiter.acquire(false).get().onSuccess(response);
+            limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
             assertThat(limiter.getLimit()).as("For status %d", code).isCloseTo(max * 0.9, Percentage.withPercentage(5));
         }
     }
@@ -186,7 +205,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         when(response.code()).thenReturn(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(false).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
         assertThat(limiter.getLimit()).as("For status %d", code).isCloseTo(max * 0.9, Percentage.withPercentage(5));
     }
 
@@ -198,7 +217,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         when(response.code()).thenReturn(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(false).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -210,7 +229,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         when(response.code()).thenReturn(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(false).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
         assertThat(limiter.getLimit()).as("For status %d", code).isCloseTo(max * 0.9, Percentage.withPercentage(5));
     }
 
@@ -220,7 +239,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         IOException exception = new IOException();
 
         double max = limiter.getLimit();
-        limiter.acquire(false).get().onFailure(exception);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onFailure(exception);
         assertThat(limiter.getLimit()).isEqualTo((int) (max * 0.9));
     }
 
@@ -230,7 +249,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         IOException exception = new IOException();
 
         double max = limiter.getLimit();
-        limiter.acquire(false).get().onFailure(exception);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onFailure(exception);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -241,7 +260,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         RuntimeException exception = new RuntimeException();
 
         double max = limiter.getLimit();
-        limiter.acquire(false).get().onFailure(exception);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onFailure(exception);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -252,13 +271,13 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         int max = (int) limiter.getLimit();
         Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> latestPermit;
         for (int i = 0; i < max - 1; ++i) {
-            latestPermit = limiter.acquire(false);
+            latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
             assertThat(latestPermit).isPresent();
         }
 
-        latestPermit = limiter.acquire(false);
+        latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
         assertThat(latestPermit).isPresent();
-        assertThat(limiter.acquire(false)).isEmpty();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
         latestPermit.get().ignore();
 
         // Now let's have some threads fight for that last remaining permit.
@@ -274,7 +293,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
                     Uninterruptibles.awaitUninterruptibly(latch);
 
                     for (int i = 0; i < numIterations; i++) {
-                        Optional<Permit> acquire = limiter.acquire(false);
+                        Optional<Permit> acquire = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
                         if (acquire.isPresent()) {
                             assertThat(acquire.get().inFlightSnapshot()).isLessThanOrEqualTo(max);
                             acquire.get().ignore();

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
@@ -27,7 +27,7 @@ import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.dialogue.TestResponse;
-import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.util.List;
 import java.util.Optional;
@@ -79,11 +79,12 @@ class NodeSelectionStrategyChannelTest {
                 new DefaultTaggedMetricRegistry(),
                 channels);
 
-        when(channel1.maybeExecute(any(), any(), eq(SkipLimits.No)))
+        when(channel1.maybeExecute(any(), any(), eq(LimitEnforcement.DEFAULT_ENABLED)))
                 .thenReturn(Optional.of(Futures.immediateFuture(
                         new TestResponse().code(200).withHeader("Node-Selection-Strategy", "BALANCED,FOO"))));
 
-        assertThat(channel.maybeExecute(null, null, SkipLimits.No)).isPresent();
+        assertThat(channel.maybeExecute(null, null, LimitEnforcement.DEFAULT_ENABLED))
+                .isPresent();
         verify(strategySelector, times(1))
                 .updateAndGet(eq(ImmutableList.of(
                         DialogueNodeSelectionStrategy.BALANCED, DialogueNodeSelectionStrategy.UNKNOWN)));

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
@@ -27,6 +27,7 @@ import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.dialogue.TestResponse;
+import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.util.List;
 import java.util.Optional;
@@ -78,11 +79,11 @@ class NodeSelectionStrategyChannelTest {
                 new DefaultTaggedMetricRegistry(),
                 channels);
 
-        when(channel1.maybeExecute(any(), any()))
+        when(channel1.maybeExecute(any(), any(), eq(SkipLimits.No)))
                 .thenReturn(Optional.of(Futures.immediateFuture(
                         new TestResponse().code(200).withHeader("Node-Selection-Strategy", "BALANCED,FOO"))));
 
-        assertThat(channel.maybeExecute(null, null)).isPresent();
+        assertThat(channel.maybeExecute(null, null, SkipLimits.No)).isPresent();
         verify(strategySelector, times(1))
                 .updateAndGet(eq(ImmutableList.of(
                         DialogueNodeSelectionStrategy.BALANCED, DialogueNodeSelectionStrategy.UNKNOWN)));

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,6 +29,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.time.Duration;
 import java.util.Optional;
@@ -164,13 +166,13 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
 
         SettableFuture<Response> future1 = SettableFuture.create();
         SettableFuture<Response> future2 = SettableFuture.create();
-        when(channel2.maybeExecute(any(), any()))
+        when(channel2.maybeExecute(any(), any(), eq(SkipLimits.No)))
                 .thenReturn(Optional.of(future1))
                 .thenReturn(Optional.of(future2));
 
         // kick off two requests
-        assertThat(pinUntilError.maybeExecute(null, null)).isPresent();
-        assertThat(pinUntilError.maybeExecute(null, null)).isPresent();
+        assertThat(pinUntilError.maybeExecute(null, null, SkipLimits.No)).isPresent();
+        assertThat(pinUntilError.maybeExecute(null, null, SkipLimits.No)).isPresent();
 
         // second request completes before the first (i.e. out of order), but they both signify the host wass broken
         future2.set(response(500));
@@ -188,9 +190,9 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
 
     @Test
     public void finds_first_non_limited_channel() {
-        when(channel1.maybeExecute(any(), any())).thenReturn(Optional.empty());
+        when(channel1.maybeExecute(any(), any(), eq(SkipLimits.No))).thenReturn(Optional.empty());
         setResponse(channel2, 204);
-        assertThat(pinUntilError.maybeExecute(null, null)).isPresent();
+        assertThat(pinUntilError.maybeExecute(null, null, SkipLimits.No)).isPresent();
     }
 
     @Test
@@ -207,7 +209,8 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
 
     private static int getCode(PinUntilErrorNodeSelectionStrategyChannel channel) {
         try {
-            ListenableFuture<Response> future = channel.maybeExecute(null, null).get();
+            ListenableFuture<Response> future =
+                    channel.maybeExecute(null, null, SkipLimits.No).get();
             Response response = future.get(1, TimeUnit.MILLISECONDS);
             return response.code();
         } catch (Exception e) {
@@ -219,7 +222,9 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
         Mockito.clearInvocations(mockChannel);
         Mockito.reset(mockChannel);
         Response resp = response(status);
-        lenient().when(mockChannel.maybeExecute(any(), any())).thenReturn(Optional.of(Futures.immediateFuture(resp)));
+        lenient()
+                .when(mockChannel.maybeExecute(any(), any(), eq(SkipLimits.No)))
+                .thenReturn(Optional.of(Futures.immediateFuture(resp)));
     }
 
     private static Response response(int status) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -48,6 +48,8 @@ import org.mockito.stubbing.OngoingStubbing;
 @SuppressWarnings("FutureReturnValueIgnored")
 public class QueuedChannelTest {
 
+    private static final SkipLimits DO_NOT_SKIP_LIMITS = SkipLimits.No;
+
     @Mock
     private LimitedChannel delegate;
 
@@ -108,27 +110,27 @@ public class QueuedChannelTest {
     public void testQueuedRequestExecutedOnNextSubmission() {
         mockNoCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(2)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(2)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
 
         mockHasCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(4)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(4)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
     }
 
     @Test
     public void testQueuedRequestExecutedOnNextSubmission_throws() throws ExecutionException, InterruptedException {
         // First request is limited by the channel and queued
         Request queuedRequest = Mockito.mock(Request.class);
-        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queuedRequest, DO_NOT_SKIP_LIMITS)).thenReturn(Optional.empty());
         ListenableFuture<Response> queuedFuture =
                 queuedChannel.maybeExecute(endpoint, queuedRequest).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest, SkipLimits.No);
+        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest, DO_NOT_SKIP_LIMITS);
         assertThat(queuedFuture).isNotDone();
 
         // Second request succeeds and the queued request is attempted, but throws an exception
         futureResponse.set(mockResponse);
-        when(delegate.maybeExecute(endpoint, request, SkipLimits.No)).thenReturn(maybeResponse);
-        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No))
+        when(delegate.maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS)).thenReturn(maybeResponse);
+        when(delegate.maybeExecute(endpoint, queuedRequest, DO_NOT_SKIP_LIMITS))
                 .thenThrow(new NullPointerException("expected"));
         ListenableFuture<Response> completed =
                 queuedChannel.maybeExecute(endpoint, request).get();
@@ -138,22 +140,22 @@ public class QueuedChannelTest {
         assertThat(queuedFuture).isDone();
         assertThat(completed.get()).isEqualTo(mockResponse);
         assertThatThrownBy(queuedFuture::get).hasRootCauseMessage("expected");
-        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
-        verify(delegate, times(3)).maybeExecute(endpoint, queuedRequest, SkipLimits.No);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
+        verify(delegate, times(3)).maybeExecute(endpoint, queuedRequest, DO_NOT_SKIP_LIMITS);
     }
 
     @Test
     public void testQueuedRequestExecutedWhenRunningRequestCompletes() {
         mockHasCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
 
         mockNoCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(3)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(3)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
         futureResponse.set(mockResponse);
 
-        verify(delegate, times(4)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(4)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
     }
 
     @Test
@@ -163,15 +165,15 @@ public class QueuedChannelTest {
         mockNoCapacity();
         queuedChannel.maybeExecute(endpoint, request);
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(3)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(3)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
 
         // flush queue by completing a request
         mockHasCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(6)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(6)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
         futureResponse.set(mockResponse);
 
-        verify(delegate, times(6)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(6)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
     }
 
     @Test
@@ -247,14 +249,14 @@ public class QueuedChannelTest {
     public void testQueuedResponseClosedOnCancel() {
         Request queuedRequest =
                 Request.builder().pathParams(ImmutableMap.of("foo", "bar")).build();
-        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queuedRequest, DO_NOT_SKIP_LIMITS)).thenReturn(Optional.empty());
         ListenableFuture<Response> result =
                 queuedChannel.maybeExecute(endpoint, queuedRequest).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest, SkipLimits.No);
+        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest, DO_NOT_SKIP_LIMITS);
 
-        when(delegate.maybeExecute(endpoint, request, SkipLimits.No))
+        when(delegate.maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS))
                 .thenReturn(Optional.of(Futures.immediateFuture(Mockito.mock(Response.class))));
-        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No))
+        when(delegate.maybeExecute(endpoint, queuedRequest, DO_NOT_SKIP_LIMITS))
                 .thenAnswer((Answer<Optional<ListenableFuture<Response>>>) _invocation -> {
                     // cancel from this invocation to simulate the race between cancellation and execution
                     assertThat(result.cancel(true)).isTrue();
@@ -263,50 +265,52 @@ public class QueuedChannelTest {
         // Force scheduling
         queuedChannel.maybeExecute(endpoint, request);
         assertThat(result).isCancelled();
-        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
         verify(mockResponse, times(1)).close();
     }
 
     @Test
     public void testQueuedResponsePropagatesCancel() {
         Request queued = Request.builder().putHeaderParams("key", "val").build();
-        when(delegate.maybeExecute(endpoint, queued, SkipLimits.No)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queued, DO_NOT_SKIP_LIMITS)).thenReturn(Optional.empty());
         ListenableFuture<Response> result =
                 queuedChannel.maybeExecute(endpoint, queued).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queued, SkipLimits.No);
+        verify(delegate, times(2)).maybeExecute(endpoint, queued, DO_NOT_SKIP_LIMITS);
 
-        when(delegate.maybeExecute(endpoint, request, SkipLimits.No))
+        when(delegate.maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS))
                 .thenReturn(Optional.of(Futures.immediateFuture(Mockito.mock(Response.class))));
-        when(delegate.maybeExecute(endpoint, queued, SkipLimits.No)).thenReturn(maybeResponse);
+        when(delegate.maybeExecute(endpoint, queued, DO_NOT_SKIP_LIMITS)).thenReturn(maybeResponse);
         queuedChannel.maybeExecute(endpoint, request);
         result.cancel(true);
         assertThat(futureResponse).isCancelled();
-        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
-        verify(delegate, times(3)).maybeExecute(endpoint, queued, SkipLimits.No);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
+        verify(delegate, times(3)).maybeExecute(endpoint, queued, DO_NOT_SKIP_LIMITS);
     }
 
     @Test
     public void testQueuedResponseAvoidsExecutingCancelled() {
         Request queued = Request.builder().putHeaderParams("key", "val").build();
-        when(delegate.maybeExecute(endpoint, queued, SkipLimits.No)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queued, DO_NOT_SKIP_LIMITS)).thenReturn(Optional.empty());
         ListenableFuture<Response> result =
                 queuedChannel.maybeExecute(endpoint, queued).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queued, SkipLimits.No);
+        verify(delegate, times(2)).maybeExecute(endpoint, queued, DO_NOT_SKIP_LIMITS);
 
         assertThat(result.cancel(true)).isTrue();
-        when(delegate.maybeExecute(endpoint, request, SkipLimits.No))
+        when(delegate.maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS))
                 .thenReturn(Optional.of(Futures.immediateFuture(Mockito.mock(Response.class))));
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS);
         // Should not have been invoked any more.
-        verify(delegate, times(2)).maybeExecute(endpoint, queued, SkipLimits.No);
+        verify(delegate, times(2)).maybeExecute(endpoint, queued, DO_NOT_SKIP_LIMITS);
     }
 
     private OngoingStubbing<Optional<ListenableFuture<Response>>> mockHasCapacity() {
-        return when(delegate.maybeExecute(endpoint, request, SkipLimits.No)).thenReturn(maybeResponse);
+        return when(delegate.maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS))
+                .thenReturn(maybeResponse);
     }
 
     private OngoingStubbing<Optional<ListenableFuture<Response>>> mockNoCapacity() {
-        return when(delegate.maybeExecute(endpoint, request, SkipLimits.No)).thenReturn(Optional.empty());
+        return when(delegate.maybeExecute(endpoint, request, DO_NOT_SKIP_LIMITS))
+                .thenReturn(Optional.empty());
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -30,6 +30,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
 import com.palantir.tracing.TestTracing;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.util.Optional;
@@ -107,27 +108,28 @@ public class QueuedChannelTest {
     public void testQueuedRequestExecutedOnNextSubmission() {
         mockNoCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(2)).maybeExecute(endpoint, request);
+        verify(delegate, times(2)).maybeExecute(endpoint, request, SkipLimits.No);
 
         mockHasCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(4)).maybeExecute(endpoint, request);
+        verify(delegate, times(4)).maybeExecute(endpoint, request, SkipLimits.No);
     }
 
     @Test
     public void testQueuedRequestExecutedOnNextSubmission_throws() throws ExecutionException, InterruptedException {
         // First request is limited by the channel and queued
         Request queuedRequest = Mockito.mock(Request.class);
-        when(delegate.maybeExecute(endpoint, queuedRequest)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No)).thenReturn(Optional.empty());
         ListenableFuture<Response> queuedFuture =
                 queuedChannel.maybeExecute(endpoint, queuedRequest).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest);
+        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest, SkipLimits.No);
         assertThat(queuedFuture).isNotDone();
 
         // Second request succeeds and the queued request is attempted, but throws an exception
         futureResponse.set(mockResponse);
-        when(delegate.maybeExecute(endpoint, request)).thenReturn(maybeResponse);
-        when(delegate.maybeExecute(endpoint, queuedRequest)).thenThrow(new NullPointerException("expected"));
+        when(delegate.maybeExecute(endpoint, request, SkipLimits.No)).thenReturn(maybeResponse);
+        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No))
+                .thenThrow(new NullPointerException("expected"));
         ListenableFuture<Response> completed =
                 queuedChannel.maybeExecute(endpoint, request).get();
         // Both results should be completed. The thrown exception should
@@ -136,22 +138,22 @@ public class QueuedChannelTest {
         assertThat(queuedFuture).isDone();
         assertThat(completed.get()).isEqualTo(mockResponse);
         assertThatThrownBy(queuedFuture::get).hasRootCauseMessage("expected");
-        verify(delegate, times(1)).maybeExecute(endpoint, request);
-        verify(delegate, times(3)).maybeExecute(endpoint, queuedRequest);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(3)).maybeExecute(endpoint, queuedRequest, SkipLimits.No);
     }
 
     @Test
     public void testQueuedRequestExecutedWhenRunningRequestCompletes() {
         mockHasCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(1)).maybeExecute(endpoint, request);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
 
         mockNoCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(3)).maybeExecute(endpoint, request);
+        verify(delegate, times(3)).maybeExecute(endpoint, request, SkipLimits.No);
         futureResponse.set(mockResponse);
 
-        verify(delegate, times(4)).maybeExecute(endpoint, request);
+        verify(delegate, times(4)).maybeExecute(endpoint, request, SkipLimits.No);
     }
 
     @Test
@@ -161,15 +163,15 @@ public class QueuedChannelTest {
         mockNoCapacity();
         queuedChannel.maybeExecute(endpoint, request);
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(3)).maybeExecute(endpoint, request);
+        verify(delegate, times(3)).maybeExecute(endpoint, request, SkipLimits.No);
 
         // flush queue by completing a request
         mockHasCapacity();
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(6)).maybeExecute(endpoint, request);
+        verify(delegate, times(6)).maybeExecute(endpoint, request, SkipLimits.No);
         futureResponse.set(mockResponse);
 
-        verify(delegate, times(6)).maybeExecute(endpoint, request);
+        verify(delegate, times(6)).maybeExecute(endpoint, request, SkipLimits.No);
     }
 
     @Test
@@ -245,14 +247,14 @@ public class QueuedChannelTest {
     public void testQueuedResponseClosedOnCancel() {
         Request queuedRequest =
                 Request.builder().pathParams(ImmutableMap.of("foo", "bar")).build();
-        when(delegate.maybeExecute(endpoint, queuedRequest)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No)).thenReturn(Optional.empty());
         ListenableFuture<Response> result =
                 queuedChannel.maybeExecute(endpoint, queuedRequest).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest);
+        verify(delegate, times(2)).maybeExecute(endpoint, queuedRequest, SkipLimits.No);
 
-        when(delegate.maybeExecute(endpoint, request))
+        when(delegate.maybeExecute(endpoint, request, SkipLimits.No))
                 .thenReturn(Optional.of(Futures.immediateFuture(Mockito.mock(Response.class))));
-        when(delegate.maybeExecute(endpoint, queuedRequest))
+        when(delegate.maybeExecute(endpoint, queuedRequest, SkipLimits.No))
                 .thenAnswer((Answer<Optional<ListenableFuture<Response>>>) _invocation -> {
                     // cancel from this invocation to simulate the race between cancellation and execution
                     assertThat(result.cancel(true)).isTrue();
@@ -261,50 +263,50 @@ public class QueuedChannelTest {
         // Force scheduling
         queuedChannel.maybeExecute(endpoint, request);
         assertThat(result).isCancelled();
-        verify(delegate, times(1)).maybeExecute(endpoint, request);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
         verify(mockResponse, times(1)).close();
     }
 
     @Test
     public void testQueuedResponsePropagatesCancel() {
         Request queued = Request.builder().putHeaderParams("key", "val").build();
-        when(delegate.maybeExecute(endpoint, queued)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queued, SkipLimits.No)).thenReturn(Optional.empty());
         ListenableFuture<Response> result =
                 queuedChannel.maybeExecute(endpoint, queued).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queued);
+        verify(delegate, times(2)).maybeExecute(endpoint, queued, SkipLimits.No);
 
-        when(delegate.maybeExecute(endpoint, request))
+        when(delegate.maybeExecute(endpoint, request, SkipLimits.No))
                 .thenReturn(Optional.of(Futures.immediateFuture(Mockito.mock(Response.class))));
-        when(delegate.maybeExecute(endpoint, queued)).thenReturn(maybeResponse);
+        when(delegate.maybeExecute(endpoint, queued, SkipLimits.No)).thenReturn(maybeResponse);
         queuedChannel.maybeExecute(endpoint, request);
         result.cancel(true);
         assertThat(futureResponse).isCancelled();
-        verify(delegate, times(1)).maybeExecute(endpoint, request);
-        verify(delegate, times(3)).maybeExecute(endpoint, queued);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
+        verify(delegate, times(3)).maybeExecute(endpoint, queued, SkipLimits.No);
     }
 
     @Test
     public void testQueuedResponseAvoidsExecutingCancelled() {
         Request queued = Request.builder().putHeaderParams("key", "val").build();
-        when(delegate.maybeExecute(endpoint, queued)).thenReturn(Optional.empty());
+        when(delegate.maybeExecute(endpoint, queued, SkipLimits.No)).thenReturn(Optional.empty());
         ListenableFuture<Response> result =
                 queuedChannel.maybeExecute(endpoint, queued).get();
-        verify(delegate, times(2)).maybeExecute(endpoint, queued);
+        verify(delegate, times(2)).maybeExecute(endpoint, queued, SkipLimits.No);
 
         assertThat(result.cancel(true)).isTrue();
-        when(delegate.maybeExecute(endpoint, request))
+        when(delegate.maybeExecute(endpoint, request, SkipLimits.No))
                 .thenReturn(Optional.of(Futures.immediateFuture(Mockito.mock(Response.class))));
         queuedChannel.maybeExecute(endpoint, request);
-        verify(delegate, times(1)).maybeExecute(endpoint, request);
+        verify(delegate, times(1)).maybeExecute(endpoint, request, SkipLimits.No);
         // Should not have been invoked any more.
-        verify(delegate, times(2)).maybeExecute(endpoint, queued);
+        verify(delegate, times(2)).maybeExecute(endpoint, queued, SkipLimits.No);
     }
 
     private OngoingStubbing<Optional<ListenableFuture<Response>>> mockHasCapacity() {
-        return when(delegate.maybeExecute(endpoint, request)).thenReturn(maybeResponse);
+        return when(delegate.maybeExecute(endpoint, request, SkipLimits.No)).thenReturn(maybeResponse);
     }
 
     private OngoingStubbing<Optional<ListenableFuture<Response>>> mockNoCapacity() {
-        return when(delegate.maybeExecute(endpoint, request)).thenReturn(Optional.empty());
+        return when(delegate.maybeExecute(endpoint, request, SkipLimits.No)).thenReturn(Optional.empty());
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -30,7 +30,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
-import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.tracing.TestTracing;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.util.Optional;
@@ -48,7 +48,7 @@ import org.mockito.stubbing.OngoingStubbing;
 @SuppressWarnings("FutureReturnValueIgnored")
 public class QueuedChannelTest {
 
-    private static final SkipLimits DO_NOT_SKIP_LIMITS = SkipLimits.No;
+    private static final LimitEnforcement DO_NOT_SKIP_LIMITS = LimitEnforcement.DEFAULT_ENABLED;
 
     @Mock
     private LimitedChannel delegate;

--- a/dialogue-jmh/src/main/java/com/palantir/dialogue/core/NodeSelectionBenchmark.java
+++ b/dialogue-jmh/src/main/java/com/palantir/dialogue/core/NodeSelectionBenchmark.java
@@ -26,7 +26,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestEndpoint;
 import com.palantir.dialogue.TestResponse;
-import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.random.SafeThreadLocalRandom;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -136,7 +136,7 @@ public class NodeSelectionBenchmark {
     @Threads(4)
     @Benchmark
     public Optional<ListenableFuture<Response>> postRequest() {
-        return channel.maybeExecute(TestEndpoint.POST, request, SkipLimits.No);
+        return channel.maybeExecute(TestEndpoint.POST, request, LimitEnforcement.DEFAULT_ENABLED);
     }
 
     public static void main(String[] _args) throws Exception {
@@ -154,7 +154,7 @@ public class NodeSelectionBenchmark {
 
         @Override
         public Optional<ListenableFuture<Response>> maybeExecute(
-                Endpoint _endpoint, Request _request, SkipLimits _skipLimits) {
+                Endpoint _endpoint, Request _request, LimitEnforcement _limitEnforcement) {
             return Optional.of(future);
         }
     }

--- a/dialogue-jmh/src/main/java/com/palantir/dialogue/core/NodeSelectionBenchmark.java
+++ b/dialogue-jmh/src/main/java/com/palantir/dialogue/core/NodeSelectionBenchmark.java
@@ -26,6 +26,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestEndpoint;
 import com.palantir.dialogue.TestResponse;
+import com.palantir.dialogue.core.LimitedChannel.SkipLimits;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.random.SafeThreadLocalRandom;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -135,7 +136,7 @@ public class NodeSelectionBenchmark {
     @Threads(4)
     @Benchmark
     public Optional<ListenableFuture<Response>> postRequest() {
-        return channel.maybeExecute(TestEndpoint.POST, request);
+        return channel.maybeExecute(TestEndpoint.POST, request, SkipLimits.No);
     }
 
     public static void main(String[] _args) throws Exception {
@@ -152,7 +153,8 @@ public class NodeSelectionBenchmark {
         INSTANCE;
 
         @Override
-        public Optional<ListenableFuture<Response>> maybeExecute(Endpoint _endpoint, Request _request) {
+        public Optional<ListenableFuture<Response>> maybeExecute(
+                Endpoint _endpoint, Request _request, SkipLimits _skipLimits) {
             return Optional.of(future);
         }
     }


### PR DESCRIPTION
## Before this PR

In order to support fair queues, we need the ability to skip limits for certain (small number) of requests.

## After this PR
==COMMIT_MSG==
LimitedChannel supports skipping limits.
==COMMIT_MSG==

## Possible downsides?

Need to add tests still.
