### PR TITLE
ResponseAttachments should accept ResponseAttachmentKey.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -254,3 +254,17 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method com.palantir.dialogue.ResponseAttachments com.palantir.dialogue.Response::attachments()"
       justification: "New state in Response."
+  "3.0.0":
+    com.palantir.dialogue:dialogue-target:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <V> V com.palantir.dialogue.ResponseAttachments::getOrDefault(===com.palantir.dialogue.RequestAttachmentKey<V>===,\
+        \ V)"
+      new: "parameter <V> V com.palantir.dialogue.ResponseAttachments::getOrDefault(===com.palantir.dialogue.ResponseAttachmentKey<V>===,\
+        \ V)"
+      justification: "Incorrect parameter types"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <V> V com.palantir.dialogue.ResponseAttachments::put(===com.palantir.dialogue.RequestAttachmentKey<V>===,\
+        \ V)"
+      new: "parameter <V> V com.palantir.dialogue.ResponseAttachments::put(===com.palantir.dialogue.ResponseAttachmentKey<V>===,\
+        \ V)"
+      justification: "Incorrect parameter types"

--- a/changelog/@unreleased/pr-1317.v2.yml
+++ b/changelog/@unreleased/pr-1317.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: ResponseAttachments should accept ResponseAttachmentKey.
+  links:
+  - https://github.com/palantir/dialogue/pull/1317

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestAttachmentsTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestAttachmentsTest.java
@@ -16,24 +16,18 @@
 
 package com.palantir.dialogue;
 
-import javax.annotation.Nullable;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public final class ResponseAttachments {
-    private final Attachments attachments = Attachments.create();
+import org.junit.jupiter.api.Test;
 
-    private ResponseAttachments() {}
+public final class RequestAttachmentsTest {
 
-    public static ResponseAttachments create() {
-        return new ResponseAttachments();
-    }
+    private static final RequestAttachmentKey<Boolean> ATTACHMENT_KEY = RequestAttachmentKey.create(Boolean.class);
 
-    @Nullable
-    public <V> V put(ResponseAttachmentKey<V> key, V value) {
-        return attachments.put(key.attachment(), value);
-    }
-
-    @Nullable
-    public <V> V getOrDefault(ResponseAttachmentKey<V> key, @Nullable V defaultValue) {
-        return attachments.getOrDefault(key.attachment(), defaultValue);
+    @Test
+    public void testSanity() {
+        RequestAttachments requestAttachments = RequestAttachments.create();
+        requestAttachments.put(ATTACHMENT_KEY, true);
+        assertThat(requestAttachments.getOrDefault(ATTACHMENT_KEY, false)).isTrue();
     }
 }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/ResponseAttachmentsTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/ResponseAttachmentsTest.java
@@ -16,24 +16,18 @@
 
 package com.palantir.dialogue;
 
-import javax.annotation.Nullable;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public final class ResponseAttachments {
-    private final Attachments attachments = Attachments.create();
+import org.junit.jupiter.api.Test;
 
-    private ResponseAttachments() {}
+public final class ResponseAttachmentsTest {
 
-    public static ResponseAttachments create() {
-        return new ResponseAttachments();
-    }
+    private static final ResponseAttachmentKey<Integer> ATTACHMENT_KEY = ResponseAttachmentKey.create(Integer.class);
 
-    @Nullable
-    public <V> V put(ResponseAttachmentKey<V> key, V value) {
-        return attachments.put(key.attachment(), value);
-    }
-
-    @Nullable
-    public <V> V getOrDefault(ResponseAttachmentKey<V> key, @Nullable V defaultValue) {
-        return attachments.getOrDefault(key.attachment(), defaultValue);
+    @Test
+    public void testSanity() {
+        ResponseAttachments responseAttachments = ResponseAttachments.create();
+        responseAttachments.put(ATTACHMENT_KEY, 1);
+        assertThat(responseAttachments.getOrDefault(ATTACHMENT_KEY, 2)).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## Before this PR

Fatfinger/copy-pasta fail.

## After this PR
==COMMIT_MSG==
ResponseAttachments should accept ResponseAttachmentKey.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
