### PR TITLE
Quick prototype of sticky handling mechanisms with minimal code-change

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -56,7 +56,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
     private static final int UNHEALTHY_SCORE_MULTIPLIER = 2;
 
     private final BalancedScoreTracker tracker;
-    private final ImmutableList<LimitedChannel> channels;
+    private final ImmutableList<BalancedChannel> channels;
 
     BalancedNodeSelectionStrategyChannel(
             ImmutableList<LimitedChannel> channels,
@@ -66,7 +66,10 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             String channelName) {
         Preconditions.checkState(channels.size() >= 2, "At least two channels required");
         this.tracker = new BalancedScoreTracker(channels.size(), random, ticker, taggedMetrics, channelName);
-        this.channels = channels;
+        this.channels = IntStream.range(0, channels.size())
+                .mapToObj(index -> new BalancedChannel(
+                        channels.get(index), tracker.channelStats().get(index)))
+                .collect(ImmutableList.toImmutableList());
         log.debug("Initialized", SafeArg.of("count", channels.size()), UnsafeArg.of("channels", channels));
     }
 
@@ -113,11 +116,32 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
                 giveUpThreshold = newThreshold;
             }
 
-            ChannelScoreInfo channelInfo = snapshot.getDelegate();
+            BalancedChannel channel = channels.get(snapshot.getDelegate().channelIndex());
+            Optional<ListenableFuture<Response>> maybe =
+                    StickyAttachments.maybeExecute(channel, endpoint, request, limitEnforcement);
+            if (maybe.isPresent()) {
+                return maybe;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static final class BalancedChannel implements LimitedChannel {
+        private final LimitedChannel delegate;
+        private final ChannelScoreInfo channelInfo;
+
+        BalancedChannel(LimitedChannel delegate, ChannelScoreInfo channelInfo) {
+            this.delegate = delegate;
+            this.channelInfo = channelInfo;
+        }
+
+        @Override
+        public Optional<ListenableFuture<Response>> maybeExecute(
+                Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
             channelInfo.startRequest();
 
-            Optional<ListenableFuture<Response>> maybe =
-                    channels.get(channelInfo.channelIndex()).maybeExecute(endpoint, request, limitEnforcement);
+            Optional<ListenableFuture<Response>> maybe = delegate.maybeExecute(endpoint, request, limitEnforcement);
 
             if (maybe.isPresent()) {
                 channelInfo.observability().markRequestMade();
@@ -126,9 +150,13 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             } else {
                 channelInfo.undoStartRequest();
             }
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        @Override
+        public String toString() {
+            return "BalancedChannel{delegate=" + delegate + ", channelInfo=" + channelInfo + '}';
+        }
     }
 
     @VisibleForTesting

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
@@ -103,6 +103,10 @@ final class BalancedScoreTracker {
         return channelStats.stream().mapToInt(c -> c.computeScoreSnapshot().score);
     }
 
+    ImmutableList<ChannelScoreInfo> channelStats() {
+        return channelStats;
+    }
+
     /** Returns a new shuffled list, without mutating the input list (which may be immutable). */
     private static <T> List<T> shuffleImmutableList(ImmutableList<T> sourceList, Random random) {
         List<T> mutableList = new ArrayList<>(sourceList);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
@@ -133,7 +133,10 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
         int pin = currentPin.get();
         PinChannel channel = nodeList.get(pin);
 
-        Optional<ListenableFuture<Response>> maybeResponse = channel.maybeExecute(endpoint, request, limitEnforcement);
+        // n.b. StickyAttachments.maybeExecute uses the delegate PinChannel, which bypasses the FutureCallback
+        // instrumentation below on subsequent "sticky" requests.
+        Optional<ListenableFuture<Response>> maybeResponse =
+                StickyAttachments.maybeExecute(channel, endpoint, request, limitEnforcement);
         if (!maybeResponse.isPresent()) {
             return Optional.empty();
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestAttachmentKey;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachmentKey;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
+import com.palantir.dialogue.futures.DialogueFutures;
+import java.util.Optional;
+import javax.annotation.CheckReturnValue;
+
+public final class StickyAttachments {
+
+    /**
+     * Added to {@link com.palantir.dialogue.RequestAttachments} to opt into a {@link #STICKY_TOKEN} on the response.
+     */
+    public static final RequestAttachmentKey<Boolean> REQUEST_STICKY_TOKEN = RequestAttachmentKey.create(Boolean.class);
+
+    /**
+     * Maybe transferred from {@link com.palantir.dialogue.RequestAttachments} to
+     * {@link com.palantir.dialogue.ResponseAttachments} as {@link #STICKY} to stick to the same channel.
+     */
+    public static final ResponseAttachmentKey<StickyTarget> STICKY_TOKEN =
+            ResponseAttachmentKey.create(StickyTarget.class);
+
+    /**
+     * Used to execute requests against the same host.
+     */
+    public static final RequestAttachmentKey<StickyTarget> STICKY = RequestAttachmentKey.create(StickyTarget.class);
+
+    private StickyAttachments() {}
+
+    // package private, used exclusively
+    interface StickyTarget {
+        Optional<ListenableFuture<Response>> maybeExecute(
+                Endpoint endpoint, Request request, LimitEnforcement limitEnforcement);
+    }
+
+    @CheckReturnValue
+    static Optional<ListenableFuture<Response>> maybeExecute(
+            LimitedChannel channel, Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
+        if (request != null
+                && Boolean.TRUE.equals(request.attachments().getOrDefault(REQUEST_STICKY_TOKEN, Boolean.FALSE))) {
+            return channel.maybeExecute(endpoint, request, limitEnforcement)
+                    .map(future -> DialogueFutures.transform(future, response -> {
+                        response.attachments().put(STICKY_TOKEN, channel::maybeExecute);
+                        return response;
+                    }));
+        } else {
+            return channel.maybeExecute(endpoint, request, limitEnforcement);
+        }
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
@@ -56,8 +56,7 @@ class BalancedNodeSelectionStrategyChannelTest {
     @Mock
     LimitedChannel chan2;
 
-    @Mock
-    Request request;
+    private final Request request = Request.builder().build();
 
     private Endpoint endpoint = TestEndpoint.GET;
     private BalancedNodeSelectionStrategyChannel channel;

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
+import com.palantir.dialogue.Request;
 import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -83,7 +84,7 @@ class NodeSelectionStrategyChannelTest {
                 .thenReturn(Optional.of(Futures.immediateFuture(
                         new TestResponse().code(200).withHeader("Node-Selection-Strategy", "BALANCED,FOO"))));
 
-        assertThat(channel.maybeExecute(null, null, LimitEnforcement.DEFAULT_ENABLED))
+        assertThat(channel.maybeExecute(null, Request.builder().build(), LimitEnforcement.DEFAULT_ENABLED))
                 .isPresent();
         verify(strategySelector, times(1))
                 .updateAndGet(eq(ImmutableList.of(


### PR DESCRIPTION
==COMMIT_MSG==
Quick prototype of sticky handling mechanisms with minimal code-change
==COMMIT_MSG==

The exposed/public API is:

https://github.com/palantir/dialogue/blob/558edccae45b7326780330ba6f9dcf2bf2d55cf2/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java#L32-L47

## Possible downsides?
has no test coverage, I have not verified any of this.

This doesn't give us the tools to expose a `list<channel>` to
improve `PerHostClientFactory`, however that should be feasible
with a little bit of plumbing if we choose to do so.
