### PR TITLE
Sticky host routing.

### DIFF
--- a/changelog/@unreleased/pr-1336.v2.yml
+++ b/changelog/@unreleased/pr-1336.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: DialogueChannels can route to a particular host.
+  links:
+  - https://github.com/palantir/dialogue/pull/1336

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -56,7 +56,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
     private static final int UNHEALTHY_SCORE_MULTIPLIER = 2;
 
     private final BalancedScoreTracker tracker;
-    private final ImmutableList<LimitedChannel> channels;
+    private final ImmutableList<BalancedChannel> channels;
 
     BalancedNodeSelectionStrategyChannel(
             ImmutableList<LimitedChannel> channels,
@@ -66,7 +66,10 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             String channelName) {
         Preconditions.checkState(channels.size() >= 2, "At least two channels required");
         this.tracker = new BalancedScoreTracker(channels.size(), random, ticker, taggedMetrics, channelName);
-        this.channels = channels;
+        this.channels = IntStream.range(0, channels.size())
+                .mapToObj(index -> new BalancedChannel(
+                        channels.get(index), tracker.channelStats().get(index)))
+                .collect(ImmutableList.toImmutableList());
         log.debug("Initialized", SafeArg.of("count", channels.size()), UnsafeArg.of("channels", channels));
     }
 
@@ -113,11 +116,32 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
                 giveUpThreshold = newThreshold;
             }
 
-            ChannelScoreInfo channelInfo = snapshot.getDelegate();
+            BalancedChannel channel = channels.get(snapshot.getDelegate().channelIndex());
+            Optional<ListenableFuture<Response>> maybe =
+                    StickyAttachments.maybeExecute(channel, endpoint, request, limitEnforcement);
+            if (maybe.isPresent()) {
+                return maybe;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static final class BalancedChannel implements LimitedChannel {
+        private final LimitedChannel delegate;
+        private final ChannelScoreInfo channelInfo;
+
+        BalancedChannel(LimitedChannel delegate, ChannelScoreInfo channelInfo) {
+            this.delegate = delegate;
+            this.channelInfo = channelInfo;
+        }
+
+        @Override
+        public Optional<ListenableFuture<Response>> maybeExecute(
+                Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
             channelInfo.startRequest();
 
-            Optional<ListenableFuture<Response>> maybe =
-                    channels.get(channelInfo.channelIndex()).maybeExecute(endpoint, request, limitEnforcement);
+            Optional<ListenableFuture<Response>> maybe = delegate.maybeExecute(endpoint, request, limitEnforcement);
 
             if (maybe.isPresent()) {
                 channelInfo.observability().markRequestMade();
@@ -126,9 +150,13 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
             } else {
                 channelInfo.undoStartRequest();
             }
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        @Override
+        public String toString() {
+            return "BalancedChannel{delegate=" + delegate + ", channelInfo=" + channelInfo + '}';
+        }
     }
 
     @VisibleForTesting

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java
@@ -118,7 +118,7 @@ final class BalancedNodeSelectionStrategyChannel implements LimitedChannel {
 
             BalancedChannel channel = channels.get(snapshot.getDelegate().channelIndex());
             Optional<ListenableFuture<Response>> maybe =
-                    StickyAttachments.maybeExecute(channel, endpoint, request, limitEnforcement);
+                    StickyAttachments.maybeAddStickyToken(channel, endpoint, request, limitEnforcement);
             if (maybe.isPresent()) {
                 return maybe;
             }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
@@ -103,6 +103,10 @@ final class BalancedScoreTracker {
         return channelStats.stream().mapToInt(c -> c.computeScoreSnapshot().score);
     }
 
+    ImmutableList<ChannelScoreInfo> channelStats() {
+        return channelStats;
+    }
+
     /** Returns a new shuffled list, without mutating the input list (which may be immutable). */
     private static <T> List<T> shuffleImmutableList(ImmutableList<T> sourceList, Random random) {
         List<T> mutableList = new ArrayList<>(sourceList);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -78,7 +78,7 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
         }
 
         if (channels.size() == 1) {
-            return new StickyChannelHandler(new StuckRequestHandler(channels.get(0)));
+            return new StickyChannelHandler(new StickyTokenHandler(channels.get(0)));
         }
 
         return new NodeSelectionStrategyChannel(
@@ -233,11 +233,11 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
         }
     }
 
-    private static final class StuckRequestHandler implements LimitedChannel {
+    private static final class StickyTokenHandler implements LimitedChannel {
 
         private final LimitedChannel delegate;
 
-        StuckRequestHandler(LimitedChannel delegate) {
+        StickyTokenHandler(LimitedChannel delegate) {
             this.delegate = delegate;
         }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
-import com.palantir.dialogue.core.StickyAttachments.StickyTarget;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -224,11 +223,7 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
 
         static Optional<ListenableFuture<Response>> maybeExecute(
                 LimitedChannel channel, Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
-            StickyTarget target = request.attachments().getOrDefault(StickyAttachments.STICKY, null);
-            if (target != null) {
-                return target.maybeExecute(endpoint, request, limitEnforcement);
-            }
-            return channel.maybeExecute(endpoint, request, limitEnforcement);
+            return StickyAttachments.maybeExecuteOnSticky(channel, endpoint, request, limitEnforcement);
         }
 
         @Override
@@ -249,7 +244,7 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
         @Override
         public Optional<ListenableFuture<Response>> maybeExecute(
                 Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
-            return StickyAttachments.maybeExecute(delegate, endpoint, request, limitEnforcement);
+            return StickyAttachments.maybeAddStickyToken(delegate, endpoint, request, limitEnforcement);
         }
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
@@ -133,7 +133,10 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
         int pin = currentPin.get();
         PinChannel channel = nodeList.get(pin);
 
-        Optional<ListenableFuture<Response>> maybeResponse = channel.maybeExecute(endpoint, request, limitEnforcement);
+        // n.b. StickyAttachments.maybeExecute uses the delegate PinChannel, which bypasses the FutureCallback
+        // instrumentation below on subsequent "sticky" requests.
+        Optional<ListenableFuture<Response>> maybeResponse =
+                StickyAttachments.maybeExecute(channel, endpoint, request, limitEnforcement);
         if (!maybeResponse.isPresent()) {
             return Optional.empty();
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannel.java
@@ -136,7 +136,7 @@ final class PinUntilErrorNodeSelectionStrategyChannel implements LimitedChannel 
         // n.b. StickyAttachments.maybeExecute uses the delegate PinChannel, which bypasses the FutureCallback
         // instrumentation below on subsequent "sticky" requests.
         Optional<ListenableFuture<Response>> maybeResponse =
-                StickyAttachments.maybeExecute(channel, endpoint, request, limitEnforcement);
+                StickyAttachments.maybeAddStickyToken(channel, endpoint, request, limitEnforcement);
         if (!maybeResponse.isPresent()) {
             return Optional.empty();
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestAttachmentKey;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachmentKey;
+import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
+import com.palantir.dialogue.futures.DialogueFutures;
+import java.util.Optional;
+import javax.annotation.CheckReturnValue;
+
+public final class StickyAttachments {
+
+    /**
+     * Added to {@link com.palantir.dialogue.RequestAttachments} to opt into a {@link #STICKY_TOKEN} on the response.
+     */
+    public static final RequestAttachmentKey<Boolean> REQUEST_STICKY_TOKEN = RequestAttachmentKey.create(Boolean.class);
+
+    /**
+     * Maybe transferred from {@link com.palantir.dialogue.RequestAttachments} to
+     * {@link com.palantir.dialogue.ResponseAttachments} as {@link #STICKY} to stick to the same channel.
+     */
+    public static final ResponseAttachmentKey<StickyTarget> STICKY_TOKEN =
+            ResponseAttachmentKey.create(StickyTarget.class);
+
+    /**
+     * Used to execute requests against the same host.
+     */
+    public static final RequestAttachmentKey<StickyTarget> STICKY = RequestAttachmentKey.create(StickyTarget.class);
+
+    private StickyAttachments() {}
+
+    // package private, used exclusively
+    interface StickyTarget {
+        Optional<ListenableFuture<Response>> maybeExecute(
+                Endpoint endpoint, Request request, LimitEnforcement limitEnforcement);
+    }
+
+    @CheckReturnValue
+    static Optional<ListenableFuture<Response>> maybeExecute(
+            LimitedChannel channel, Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
+        if (request != null
+                && Boolean.TRUE.equals(request.attachments().getOrDefault(REQUEST_STICKY_TOKEN, Boolean.FALSE))) {
+            return channel.maybeExecute(endpoint, request, limitEnforcement)
+                    .map(future -> DialogueFutures.transform(future, response -> {
+                        response.attachments().put(STICKY_TOKEN, channel::maybeExecute);
+                        return response;
+                    }));
+        } else {
+            return channel.maybeExecute(endpoint, request, limitEnforcement);
+        }
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
@@ -27,28 +27,29 @@ import com.palantir.dialogue.futures.DialogueFutures;
 import java.util.Optional;
 import javax.annotation.CheckReturnValue;
 
-public final class StickyAttachments {
+final class StickyAttachments {
 
     /**
      * Added to {@link com.palantir.dialogue.RequestAttachments} to opt into a {@link #STICKY_TOKEN} on the response.
      */
-    public static final RequestAttachmentKey<Boolean> REQUEST_STICKY_TOKEN = RequestAttachmentKey.create(Boolean.class);
+    private static final RequestAttachmentKey<Boolean> REQUEST_STICKY_TOKEN =
+            RequestAttachmentKey.create(Boolean.class);
 
     /**
      * Maybe transferred from {@link com.palantir.dialogue.RequestAttachments} to
      * {@link com.palantir.dialogue.ResponseAttachments} as {@link #STICKY} to stick to the same channel.
      */
-    public static final ResponseAttachmentKey<StickyTarget> STICKY_TOKEN =
+    private static final ResponseAttachmentKey<StickyTarget> STICKY_TOKEN =
             ResponseAttachmentKey.create(StickyTarget.class);
 
     /**
      * Used to execute requests against the same host.
      */
-    public static final RequestAttachmentKey<StickyTarget> STICKY = RequestAttachmentKey.create(StickyTarget.class);
+    private static final RequestAttachmentKey<StickyTarget> STICKY = RequestAttachmentKey.create(StickyTarget.class);
 
     private StickyAttachments() {}
 
-    // package private, used exclusively
+    // package private, used exclusively around the borders of the node selection channel.
     interface StickyTarget {
         Optional<ListenableFuture<Response>> maybeExecute(
                 Endpoint endpoint, Request request, LimitEnforcement limitEnforcement);
@@ -57,8 +58,7 @@ public final class StickyAttachments {
     @CheckReturnValue
     static Optional<ListenableFuture<Response>> maybeExecute(
             LimitedChannel channel, Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
-        if (request != null
-                && Boolean.TRUE.equals(request.attachments().getOrDefault(REQUEST_STICKY_TOKEN, Boolean.FALSE))) {
+        if (Boolean.TRUE.equals(request.attachments().getOrDefault(REQUEST_STICKY_TOKEN, Boolean.FALSE))) {
             return channel.maybeExecute(endpoint, request, limitEnforcement)
                     .map(future -> DialogueFutures.transform(future, response -> {
                         response.attachments().put(STICKY_TOKEN, channel::maybeExecute);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
@@ -86,8 +86,6 @@ final class StickyAttachments {
     static Consumer<Request> copyStickyTarget(Response response) {
         StickyTarget stickyTarget =
                 Preconditions.checkNotNull(response.attachments().getOrDefault(STICKY_TOKEN, null), "stickyToken");
-        return request -> {
-            request.attachments().put(STICKY, stickyTarget);
-        };
+        return request -> request.attachments().put(STICKY, stickyTarget);
     }
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyAttachments.java
@@ -51,8 +51,7 @@ final class StickyAttachments {
 
     private StickyAttachments() {}
 
-    // package private, used exclusively around the borders of the node selection channel.
-    interface StickyTarget {
+    private interface StickyTarget {
         Optional<ListenableFuture<Response>> maybeExecute(
                 Endpoint endpoint, Request request, LimitEnforcement limitEnforcement);
     }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
@@ -38,6 +38,8 @@ import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,8 +58,7 @@ class BalancedNodeSelectionStrategyChannelTest {
     @Mock
     LimitedChannel chan2;
 
-    private final Request request = Request.builder().build();
-
+    private Request request = Request.builder().build();
     private Endpoint endpoint = TestEndpoint.GET;
     private BalancedNodeSelectionStrategyChannel channel;
     private BalancedNodeSelectionStrategyChannel rttChannel;
@@ -166,6 +167,45 @@ class BalancedNodeSelectionStrategyChannelTest {
     public void skiplimits_passthrough(LimitEnforcement limitEnforcement) {
         when(chan1.maybeExecute(any(), any(), eq(limitEnforcement))).thenReturn(http(200));
         assertThat(channel.maybeExecute(endpoint, request, limitEnforcement)).isPresent();
+    }
+
+    @Test
+    public void stickyToken_requests_maintain_scores() throws ExecutionException {
+        SettableFuture<Response> initialRequestFuture = SettableFuture.create();
+        SettableFuture<Response> stickyRequestFuture = SettableFuture.create();
+        when(chan2.maybeExecute(any(), any(), eq(LimitEnforcement.DEFAULT_ENABLED)))
+                .thenReturn(Optional.of(initialRequestFuture))
+                .thenReturn(Optional.of(stickyRequestFuture));
+
+        request = Request.builder().build();
+        StickyAttachments.requestStickyToken(request);
+        ListenableFuture<Response> responseFuture = channel.maybeExecute(
+                        endpoint, request, LimitEnforcement.DEFAULT_ENABLED)
+                .get();
+
+        assertThat(channel.getScoresForTesting())
+                .describedAs("initial request maintains scores")
+                .containsExactly(0, 1);
+
+        initialRequestFuture.set(TestResponse.withBody(null));
+        Consumer<Request> requestConsumer = StickyAttachments.copyStickyTarget(Futures.getDone(responseFuture));
+
+        assertThat(channel.getScoresForTesting())
+                .describedAs("complete initial request updates scores")
+                .containsExactly(0, 0);
+
+        request = Request.builder().build();
+        requestConsumer.accept(request);
+        assertThat(StickyAttachments.maybeExecuteOnSticky(null, endpoint, request, LimitEnforcement.DEFAULT_ENABLED))
+                .isPresent();
+
+        assertThat(channel.getScoresForTesting())
+                .describedAs("Follow on request maintains scores")
+                .containsExactly(0, 1);
+        stickyRequestFuture.set(TestResponse.withBody(null));
+        assertThat(channel.getScoresForTesting())
+                .describedAs("Complete follow on request updates scores")
+                .containsExactly(0, 0);
     }
 
     private static void set200(LimitedChannel chan) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannelTest.java
@@ -56,8 +56,7 @@ class BalancedNodeSelectionStrategyChannelTest {
     @Mock
     LimitedChannel chan2;
 
-    @Mock
-    Request request;
+    private final Request request = Request.builder().build();
 
     private Endpoint endpoint = TestEndpoint.GET;
     private BalancedNodeSelectionStrategyChannel channel;

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
@@ -308,7 +308,22 @@ public final class DialogueChannelTest {
 
     @ParameterizedTest
     @EnumSource(NodeSelectionStrategy.class)
-    public void test_can_use_sticky_attachments(NodeSelectionStrategy nodeSelectionStrategy) throws ExecutionException {
+    public void test_can_request_sticky_token_with_single_uri(NodeSelectionStrategy nodeSelectionStrategy)
+            throws ExecutionException {
+        test_can_use_sticky_attachments_impl(nodeSelectionStrategy, ImmutableList.of("http://localhost"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(NodeSelectionStrategy.class)
+    public void test_can_request_sticky_token_with_many_uris(NodeSelectionStrategy nodeSelectionStrategy)
+            throws ExecutionException {
+        test_can_use_sticky_attachments_impl(
+                nodeSelectionStrategy,
+                ImmutableList.of("http://localhost", "http" + "://localhost2", "http" + "://localhost3"));
+    }
+
+    private void test_can_use_sticky_attachments_impl(
+            NodeSelectionStrategy nodeSelectionStrategy, ImmutableList<String> uris) throws ExecutionException {
         String uriHeader = "uri";
         DialogueChannelFactory factory = args -> {
             mockChannel = Mockito.mock(Channel.class);
@@ -320,7 +335,7 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(ClientConfiguration.builder()
-                        .uris(ImmutableList.of("http://localhost", "http://localhost2", "http://localhost3"))
+                        .uris(uris)
                         .from(stubConfig)
                         .nodeSelectionStrategy(nodeSelectionStrategy)
                         .build())

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -59,6 +60,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,7 +84,10 @@ public final class DialogueChannelTest {
             .build();
 
     @Mock
-    private Channel mockChannel;
+    private Channel mockChannel1;
+
+    @Mock
+    private Channel mockChannel2;
 
     private Endpoint endpoint = TestEndpoint.POST;
 
@@ -97,11 +102,11 @@ public final class DialogueChannelTest {
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .factory(_args -> mockChannel)
+                .factory(_args -> mockChannel1)
                 .build();
 
         ListenableFuture<Response> expectedResponse = Futures.immediateFuture(response);
-        lenient().when(mockChannel.execute(eq(endpoint), any())).thenReturn(expectedResponse);
+        lenient().when(mockChannel1.execute(eq(endpoint), any())).thenReturn(expectedResponse);
     }
 
     @Test
@@ -173,11 +178,11 @@ public final class DialogueChannelTest {
 
     @Test
     void test_queue_rejection_is_not_retried() {
-        when(mockChannel.execute(any(), any())).thenReturn(SettableFuture.create());
+        when(mockChannel1.execute(any(), any())).thenReturn(SettableFuture.create());
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
-                .factory(_args -> mockChannel)
+                .factory(_args -> mockChannel1)
                 .random(new Random(123456L))
                 .maxQueueSize(1)
                 .build();
@@ -276,7 +281,7 @@ public final class DialogueChannelTest {
                         .from(stubConfig)
                         .uris(Collections.emptyList())
                         .build())
-                .factory(_args -> mockChannel)
+                .factory(_args -> mockChannel1)
                 .build();
         ListenableFuture<Response> future = channel.execute(endpoint, request);
         assertThatThrownBy(future::get).hasRootCauseInstanceOf(SafeIllegalStateException.class);
@@ -284,7 +289,7 @@ public final class DialogueChannelTest {
 
     @Test
     void nice_tostring() {
-        DialogueChannelFactory factory = _args -> mockChannel;
+        DialogueChannelFactory factory = _args -> mockChannel1;
         channel = DialogueChannel.builder()
                 .channelName("my-channel")
                 .clientConfiguration(stubConfig)
@@ -299,6 +304,73 @@ public final class DialogueChannelTest {
         assertThat(channel.toString())
                 .describedAs("It's important we can differentiate two instances built from the same config!")
                 .isNotEqualTo(channel2.toString());
+    }
+
+    @Test
+    public void test_can_route_to_specific_host() throws ExecutionException {
+        String host1 = "http://localhost1";
+        String host2 = "http://localhost2";
+        ImmutableMap<String, Channel> channels = ImmutableMap.of(host1, mockChannel1, host2, mockChannel2);
+        ClientConfiguration twoNodeConfig = ClientConfiguration.builder()
+                .from(ClientConfigurations.of(ServiceConfiguration.builder()
+                        .addUris(host1)
+                        .addUris(host2)
+                        .security(SSL_CONFIG)
+                        .build()))
+                .nodeSelectionStrategy(NodeSelectionStrategy.ROUND_ROBIN)
+                .userAgent(USER_AGENT)
+                .build();
+
+        DialogueChannelFactory factory = channelArgs -> channels.get(channelArgs.uri());
+        channel = DialogueChannel.builder()
+                .channelName("my-channel")
+                .clientConfiguration(twoNodeConfig)
+                .factory(factory)
+                .random(new Random(1L))
+                .build();
+
+        SettableFuture<Response> channel1ResponseFuture = SettableFuture.create();
+        SettableFuture<Response> channel2ResponseFuture = SettableFuture.create();
+
+        when(mockChannel1.execute(any(), any())).thenReturn(channel1ResponseFuture);
+        when(mockChannel2.execute(any(), any())).thenReturn(channel2ResponseFuture);
+
+        Request request1 = createRequestWithAddExecutedOnAttachment();
+        ListenableFuture<Response> response1 = channel.execute(endpoint, request1);
+
+        Request request2 = createRequestWithAddExecutedOnAttachment();
+        ListenableFuture<Response> response2 = channel.execute(endpoint, request2);
+
+        Response channel1Response = TestResponse.withBody(null);
+        channel1ResponseFuture.set(channel1Response);
+
+        Response channel2Response = TestResponse.withBody(null);
+        channel2ResponseFuture.set(channel2Response);
+
+        assertThat(Futures.getDone(response1)).isEqualTo(channel1Response);
+        assertThat(Futures.getDone(response2)).isEqualTo(channel2Response);
+
+        Consumer<Request> channel1StickyTarget = StickyAttachments.copyStickyTarget(channel1Response);
+        Consumer<Request> channel2StickyTarget = StickyAttachments.copyStickyTarget(channel2Response);
+
+        channel1Response = TestResponse.withBody(null);
+        channel2Response = TestResponse.withBody(null);
+        when(mockChannel1.execute(any(), any())).thenReturn(Futures.immediateFuture(channel1Response));
+        when(mockChannel2.execute(any(), any())).thenReturn(Futures.immediateFuture(channel2Response));
+
+        request1 = Request.builder().build();
+        channel1StickyTarget.accept(request1);
+        assertThat(Futures.getDone(channel.execute(endpoint, request1))).isEqualTo(channel1Response);
+
+        request2 = Request.builder().build();
+        channel2StickyTarget.accept(request2);
+        assertThat(Futures.getDone(channel.execute(endpoint, request2))).isEqualTo(channel2Response);
+    }
+
+    private Request createRequestWithAddExecutedOnAttachment() {
+        Request newRequest = Request.builder().build();
+        StickyAttachments.requestStickyToken(newRequest);
+        return newRequest;
     }
 
     @Test

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/NodeSelectionStrategyChannelTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
+import com.palantir.dialogue.Request;
 import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -83,7 +84,7 @@ class NodeSelectionStrategyChannelTest {
                 .thenReturn(Optional.of(Futures.immediateFuture(
                         new TestResponse().code(200).withHeader("Node-Selection-Strategy", "BALANCED,FOO"))));
 
-        assertThat(channel.maybeExecute(null, null, LimitEnforcement.DEFAULT_ENABLED))
+        assertThat(channel.maybeExecute(null, Request.builder().build(), LimitEnforcement.DEFAULT_ENABLED))
                 .isPresent();
         verify(strategySelector, times(1))
                 .updateAndGet(eq(ImmutableList.of(

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -63,6 +64,7 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
     private DialoguePinuntilerrorMetrics metrics = DialoguePinuntilerrorMetrics.of(new DefaultTaggedMetricRegistry());
     private String channelName = "channelName";
     private Random pseudo = new Random(12893712L);
+    private Request request = Request.builder().build();
 
     @BeforeEach
     public void before() {
@@ -171,9 +173,9 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
                 .thenReturn(Optional.of(future2));
 
         // kick off two requests
-        assertThat(pinUntilError.maybeExecute(null, null, LimitEnforcement.DEFAULT_ENABLED))
+        assertThat(pinUntilError.maybeExecute(null, request, LimitEnforcement.DEFAULT_ENABLED))
                 .isPresent();
-        assertThat(pinUntilError.maybeExecute(null, null, LimitEnforcement.DEFAULT_ENABLED))
+        assertThat(pinUntilError.maybeExecute(null, request, LimitEnforcement.DEFAULT_ENABLED))
                 .isPresent();
 
         // second request completes before the first (i.e. out of order), but they both signify the host wass broken
@@ -195,7 +197,7 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
         when(channel1.maybeExecute(any(), any(), eq(LimitEnforcement.DEFAULT_ENABLED)))
                 .thenReturn(Optional.empty());
         setResponse(channel2, 204);
-        assertThat(pinUntilError.maybeExecute(null, null, LimitEnforcement.DEFAULT_ENABLED))
+        assertThat(pinUntilError.maybeExecute(null, request, LimitEnforcement.DEFAULT_ENABLED))
                 .isPresent();
     }
 
@@ -211,9 +213,9 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
                 channelName);
     }
 
-    private static int getCode(PinUntilErrorNodeSelectionStrategyChannel channel) {
+    private int getCode(PinUntilErrorNodeSelectionStrategyChannel channel) {
         try {
-            ListenableFuture<Response> future = channel.maybeExecute(null, null, LimitEnforcement.DEFAULT_ENABLED)
+            ListenableFuture<Response> future = channel.maybeExecute(null, request, LimitEnforcement.DEFAULT_ENABLED)
                     .get();
             Response response = future.get(1, TimeUnit.MILLISECONDS);
             return response.code();


### PR DESCRIPTION
## Before this PR

DialogueChannels cannot route to a particular host.

## After this PR

*StickyAttachments* can be used to request that special Response attachment be added that, when copied to subsequent requests, pins them to the same node as initial request.

==COMMIT_MSG==
DialogueChannels can route to a particular host.
==COMMIT_MSG==

## Possible downsides?

As discussed in the prototype PR, pin until error pinned requests to not update the pin on failures. This is absolutely possible to do, but quite a bit of extra work so we decided to forego. Initial requests still switch the pins which should be good enough.
