### PR TITLE
fix #1346: ReloadingFactory.getNonReloading doesn't require a UserAgent

### DIFF
--- a/changelog/@unreleased/pr-1358.v2.yml
+++ b/changelog/@unreleased/pr-1358.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: ReloadingFactory.getNonReloading correctly uses the factory user-agent
+    when one isn't present on an input ClientConfiguration instance.
+  links:
+  - https://github.com/palantir/dialogue/pull/1358


### PR DESCRIPTION
## Before this PR
#1346
## After this PR
==COMMIT_MSG==
ReloadingFactory.getNonReloading correctly uses the factory user-agent when one isn't present on an input ClientConfiguration instance.
==COMMIT_MSG==
