### PR TITLE
Opt into TLSv1.3 support for 10% of java 15+ clients

### DIFF
--- a/changelog/@unreleased/pr-1372.v2.yml
+++ b/changelog/@unreleased/pr-1372.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Opt into TLSv1.3 support for 10% of java 15+ clients
+  links:
+  - https://github.com/palantir/dialogue/pull/1372

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -473,7 +473,7 @@ public final class ApacheHttpClientChannels {
             SSLSocketFactory rawSocketFactory = conf.sslSocketFactory();
             SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(
                     MetricRegistries.instrument(conf.taggedMetricRegistry(), rawSocketFactory, name),
-                    new String[] {"TLSv1.2"},
+                    TlsProtocols.enabledFor(name),
                     supportedCipherSuites(
                             conf.enableGcmCipherSuites()
                                     ? CipherSuites.allCipherSuites()

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import com.google.common.primitives.Ints;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.random.SafeThreadLocalRandom;
+
+/** Internal utility functionality to slowly roll out new TLS protocol support. */
+final class TlsProtocols {
+
+    private static final SafeLogger log = SafeLoggerFactory.get(TlsProtocols.class);
+    private static final boolean JAVA_15_OR_LATER = isJava15OrLater();
+    private static final String TLS_V1_2 = "TLSv1.2";
+    private static final String TLS_V1_3 = "TLSv1.3";
+
+    static String[] enabledFor(String clientName) {
+        if (JAVA_15_OR_LATER && (assertsEnabled() || SafeThreadLocalRandom.get().nextInt(10) == 0)) {
+            log.info("Enabling TLSv1.3 support for client '{}'", SafeArg.of("client", clientName));
+            return new String[] {TLS_V1_3, TLS_V1_2};
+        } else {
+            return new String[] {TLS_V1_2};
+        }
+    }
+
+    private static boolean isJava15OrLater() {
+        Integer version = Ints.tryParse(System.getProperty("java.specification.version"));
+        return version != null && version >= 15;
+    }
+
+    @SuppressWarnings({"AssertWithSideEffects", "ConstantConditions", "InnerAssignment", "BadAssert"})
+    private static boolean assertsEnabled() {
+        boolean ret = false;
+        assert (ret = true);
+        return ret;
+    }
+
+    private TlsProtocols() {}
+}

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
@@ -31,7 +31,7 @@ final class TlsProtocols {
     private static final String TLS_V1_3 = "TLSv1.3";
 
     static String[] enabledFor(String clientName) {
-        if (JAVA_15_OR_LATER && (assertsEnabled() || SafeThreadLocalRandom.get().nextInt(10) == 0)) {
+        if (JAVA_15_OR_LATER && (assertsEnabled() || SafeThreadLocalRandom.get().nextDouble() < .1D)) {
             log.info("Enabling TLSv1.3 support for client '{}'", SafeArg.of("client", clientName));
             return new String[] {TLS_V1_3, TLS_V1_2};
         } else {


### PR DESCRIPTION
Based on initial rollout, we will ratchet up the value to
eventually enable TLSv1.3 across the java 15+ fleet.

In test code (determined based on whether or not asserts are
enabled) java 15+ runtimes will always enable TLSv1.3 in order
to tease out any potential issues before code hits production.

## Before this PR
Only TLSv1.2. We briefly tried 1.3 around the time we rolled out tlsv.13 on servers and had issues with buggy jdk 11/13 implementations. See  https://webtide.com/openjdk-11-and-tls-1-3-issues/ and https://bugs.openjdk.java.net/browse/JDK-8224997
We'd had issues with timeouts due to a dialogue bug which allowed connect timeouts to drop lower than expected for the handshake portion of connection initialization which has since been resolved.

## After this PR
==COMMIT_MSG==
Opt into TLSv1.3 support for 10% of java 15+ clients
==COMMIT_MSG==

## Possible downsides?
Opting into TLSv1.3 is not deterministic.

TLSv1.3 handshakes are individually more expensive than TLSv1.2, this makes little difference when connections are reused as expected, however in cases where connections are constantly recreated it can cause a dramatic increase in load.
