### PR TITLE
Increase TLSv1.3 probability on java 15+ to 50% (up from 10%)

### DIFF
--- a/changelog/@unreleased/pr-1380.v2.yml
+++ b/changelog/@unreleased/pr-1380.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Broaden TLSv1.3 rollout by increasing TLSv1.3 probability on java 15+
+    to 50% (up from 10%)
+  links:
+  - https://github.com/palantir/dialogue/pull/1380

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
@@ -31,7 +31,7 @@ final class TlsProtocols {
     private static final String TLS_V1_3 = "TLSv1.3";
 
     static String[] enabledFor(String clientName) {
-        if (JAVA_15_OR_LATER && (assertsEnabled() || SafeThreadLocalRandom.get().nextDouble() < .1D)) {
+        if (JAVA_15_OR_LATER && (assertsEnabled() || SafeThreadLocalRandom.get().nextDouble() < .5D)) {
             log.info("Enabling TLSv1.3 support for client '{}'", SafeArg.of("client", clientName));
             return new String[] {TLS_V1_3, TLS_V1_2};
         } else {


### PR DESCRIPTION
## Before this PR
10%

## After this PR
==COMMIT_MSG==
Broaden TLSv1.3 rollout by increasing TLSv1.3 probability on java 15+ to 50% (up from 10%)
==COMMIT_MSG==

## Possible downsides?
Might break/overload things, that's why we started with with 10%.
