### PR TITLE
Dialogue Annotation Processor Encoders may reference supertypes

### DIFF
--- a/changelog/@unreleased/pr-1383.v2.yml
+++ b/changelog/@unreleased/pr-1383.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue Annotation Processor Encoders may reference supertypes, for
+    example an `Object` encoder may be applied to a `BigInteger` parameter.
+  links:
+  - https://github.com/palantir/dialogue/pull/1383

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
@@ -20,7 +20,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.annotations.Request;
+import com.palantir.dialogue.annotations.ToStringParamEncoder;
 import com.palantir.tokens.auth.AuthHeader;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -81,6 +83,8 @@ public interface MyService {
                     Optional<MyCustomParamType> maybeCustomOptionalHeader3Value,
             @Request.Header("Custom-Header1") List<String> customListHeader,
             @Request.Header("Custom-Optional-Header3") Optional<List<String>> customOptionalListHeader,
+            @Request.Header(value = "Custom-To-String-Header", encoder = ToStringParamEncoder.class)
+                    BigInteger bigInteger,
             // Custom encoding classes may be provided for the request and response.
             // JSON should be easiest (default?).
             // By changing this to MySpecialJson.class you can have

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -19,13 +19,13 @@ import com.palantir.dialogue.annotations.DefaultParameterSerializer;
 import com.palantir.dialogue.annotations.ErrorHandlingDeserializerFactory;
 import com.palantir.dialogue.annotations.ErrorHandlingVoidDeserializer;
 import com.palantir.dialogue.annotations.Json;
-import com.palantir.dialogue.annotations.ListParamEncoder;
-import com.palantir.dialogue.annotations.ParamEncoder;
 import com.palantir.dialogue.annotations.ParameterSerializer;
+import com.palantir.dialogue.annotations.ToStringParamEncoder;
 import com.palantir.tokens.auth.AuthHeader;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.Void;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,21 +69,23 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                             new MyResponseDeserializer(), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<Response>() {});
 
-            private final ListParamEncoder<MyCustomParamType> paramsQuery1Encoder =
+            private final MyCustomParamTypeParameterEncoder paramsQuery1Encoder =
                     new MyCustomParamTypeParameterEncoder();
 
-            private final ListParamEncoder<MyCustomParamType> paramsQuery2Encoder =
+            private final MyCustomParamTypeParameterEncoder paramsQuery2Encoder =
                     new MyCustomParamTypeParameterEncoder();
 
-            private final ListParamEncoder<String> paramsQuery3Encoder = new MyCustomStringParameterEncoder();
+            private final MyCustomStringParameterEncoder paramsQuery3Encoder = new MyCustomStringParameterEncoder();
 
-            private final ListParamEncoder<String> paramsQuery4Encoder = new MyCustomStringParameterEncoder();
+            private final MyCustomStringParameterEncoder paramsQuery4Encoder = new MyCustomStringParameterEncoder();
 
-            private final ParamEncoder<MyCustomParamType> paramsMyPathParam2Encoder =
+            private final MyCustomParamTypeParameterEncoder paramsMyPathParam2Encoder =
                     new MyCustomParamTypeParameterEncoder();
 
-            private final ListParamEncoder<MyCustomParamType> paramsMaybeCustomOptionalHeader3ValueEncoder =
+            private final MyCustomParamTypeParameterEncoder paramsMaybeCustomOptionalHeader3ValueEncoder =
                     new MyCustomParamTypeParameterEncoder();
+
+            private final ToStringParamEncoder paramsBigIntegerEncoder = new ToStringParamEncoder();
 
             private final Serializer<MySerializableType> paramsSerializer =
                     new MySerializableTypeBodySerializer().serializerFor(new TypeMarker<MySerializableType>() {});
@@ -138,6 +140,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     Optional<MyCustomParamType> maybeCustomOptionalHeader3Value,
                     List<String> customListHeader,
                     Optional<List<String>> customOptionalListHeader,
+                    BigInteger bigInteger,
                     MySerializableType body) {
                 Request.Builder _request = Request.builder();
                 _request.putQueryParams("q", _parameterSerializer.serializeString(query));
@@ -192,6 +195,8 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                                     .map(_parameterSerializer::serializeString)
                                     .collect(Collectors.toList()));
                 }
+                _request.putAllHeaderParams(
+                        "Custom-To-String-Header", paramsBigIntegerEncoder.toParamValues(bigInteger));
                 _request.body(paramsSerializer.serialize(body));
                 runtime.clients().callBlocking(paramsChannel, _request.build(), paramsDeserializer);
             }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ToStringParamEncoder.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/ToStringParamEncoder.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.annotations;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Simple Encoder implementation which always uses the {@link Object#toString()} value.
+ * This is not used by <i>default</i> because it should be a conscious decision to rely on
+ * {@link Object#toString()} over the wire.
+ */
+public final class ToStringParamEncoder implements ListParamEncoder<Object>, ParamEncoder<Object> {
+
+    public ToStringParamEncoder() {}
+
+    @Override
+    public List<String> toParamValues(Object value) {
+        return value == null ? List.of() : List.of(toParamValue(value));
+    }
+
+    @Override
+    public String toParamValue(Object value) {
+        return Objects.toString(value);
+    }
+}


### PR DESCRIPTION
For example, the new implementation allows an encoder for type
Object to be used for a String parameter, for instance to implement
a toString encoder.

==COMMIT_MSG==
Dialogue Annotation Processor Encoders may reference supertypes, for example an `Object` encoder may be applied to a `BigInteger` parameter.
==COMMIT_MSG==
