### PR TITLE
All Dialogue users on Java 15+ may use TLSv1.3

### DIFF
--- a/changelog/@unreleased/pr-1387.v2.yml
+++ b/changelog/@unreleased/pr-1387.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: All Dialogue users on Java 15+ may use TLSv1.3
+  links:
+  - https://github.com/palantir/dialogue/pull/1387

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
@@ -20,7 +20,6 @@ import com.google.common.primitives.Ints;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import com.palantir.random.SafeThreadLocalRandom;
 
 /** Internal utility functionality to slowly roll out new TLS protocol support. */
 final class TlsProtocols {
@@ -31,7 +30,7 @@ final class TlsProtocols {
     private static final String TLS_V1_3 = "TLSv1.3";
 
     static String[] enabledFor(String clientName) {
-        if (JAVA_15_OR_LATER && (assertsEnabled() || SafeThreadLocalRandom.get().nextDouble() < .5D)) {
+        if (JAVA_15_OR_LATER) {
             log.info("Enabling TLSv1.3 support for client '{}'", SafeArg.of("client", clientName));
             return new String[] {TLS_V1_3, TLS_V1_2};
         } else {
@@ -42,13 +41,6 @@ final class TlsProtocols {
     private static boolean isJava15OrLater() {
         Integer version = Ints.tryParse(System.getProperty("java.specification.version"));
         return version != null && version >= 15;
-    }
-
-    @SuppressWarnings({"AssertWithSideEffects", "ConstantConditions", "InnerAssignment", "BadAssert"})
-    private static boolean assertsEnabled() {
-        boolean ret = false;
-        assert (ret = true);
-        return ret;
     }
 
     private TlsProtocols() {}


### PR DESCRIPTION
Previously this option was enabled 50% of the time, however we've
not encountered issues, so we're rolling it out at 100%.

## After this PR
==COMMIT_MSG==
All Dialogue users on Java 15+ may use TLSv1.3
==COMMIT_MSG==

## Possible downsides?
Might hit edge cases we haven't considered?
