### PR TITLE
fix: remove Dialogue-request-scheduled trace

### DIFF
--- a/changelog/@unreleased/pr-1388.v2.yml
+++ b/changelog/@unreleased/pr-1388.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: remove Dialogue-request-scheduled trace
+  links:
+  - https://github.com/palantir/dialogue/pull/1388


### PR DESCRIPTION
## Before this PR
"Dialogue-request-scheduled" span was responsbile for an inordinate number of generated trace spans. In one example it was responsible for 4000/18000 spans within a trace for a service but less than 0.1% of execution time. The trace is providing very low value while still stressing our systems and our downstream dependencies. 

## After this PR
==COMMIT_MSG==
remove Dialogue-request-scheduled trace
==COMMIT_MSG==

## Possible downsides?
We could lose some visibility on the p9* levels of executing a request in dialogue.