### PR TITLE
fix #1308: Reduce Dialogue client creation overhead

### DIFF
--- a/changelog/@unreleased/pr-1399.v2.yml
+++ b/changelog/@unreleased/pr-1399.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Reduce Dialogue client creation overhead by deferring per-endpoint
+    initialization work until the endpoint is first used.
+  links:
+  - https://github.com/palantir/dialogue/pull/1399


### PR DESCRIPTION
This bounds work to the number of endpoints that are actually
used. In most cases only a small subset of endpoints are
exercised, this is particularly true in many sticky-session
use-cases in which instances are created much more frequently.

Note that our serializers and deserializers can be relatively
expensive, however the expensive components are already
memoized. Per-endpoint channel binding attempts to do additional
work up-front, however it means each client instance we create
was doing _all_ of this work immediately. Now it occurs lazily
the first time an endpoint is used for a more predictable
performance profile.

==COMMIT_MSG==
Reduce Dialogue client creation overhead by deferring per-endpoint initialization work until the endpoint is first used.
==COMMIT_MSG==
