### PR TITLE
Provide a static factory method replacement for JaxrsClient.create

### DIFF
--- a/changelog/@unreleased/pr-1400.v2.yml
+++ b/changelog/@unreleased/pr-1400.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide a static factory method replacement for JaxrsClient.create
+  links:
+  - https://github.com/palantir/dialogue/pull/1400

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -75,7 +75,7 @@ final class ChannelCache {
         LIVE_INSTANCES.add(newCache);
 
         int numLiveInstances = LIVE_INSTANCES.size();
-        if ((numLiveInstances > 1 && log.isInfoEnabled()) || log.isDebugEnabled()) {
+        if ((numLiveInstances > 5 && log.isInfoEnabled()) || log.isDebugEnabled()) {
             if (numLiveInstances >= 10) {
                 log.info(
                         "Created ChannelCache instance #{} ({} alive): {}",

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -50,6 +50,22 @@ public final class DialogueClients {
                 ImmutableReloadingParams.builder().scb(scb).build(), ChannelCache.createEmptyCache());
     }
 
+    /**
+     * Prefer {@link #create(Refreshable)}. Using a configured {@link ReloadingFactory} should always be preferred
+     * over this method, it only exists to ease migration.
+     *
+     * Construct an instance of the given {@code clientInterface} which can be used to make network calls to the
+     * single conceptual upstream identified by {@code clientConfiguration}.
+     *
+     * Behaviour is undefined if {@code clientConfiguration} contains no URIs.
+     *
+     * @param clientInterface Dialogue client interface annotated with {@link com.palantir.dialogue.DialogueService}
+     * @param clientConfiguration Configuration which <b>must</b> contain a user-agent
+     */
+    public static <T> T create(Class<T> clientInterface, ClientConfiguration clientConfiguration) {
+        return LegacyConstruction.getNonReloading(clientInterface, clientConfiguration);
+    }
+
     /** Parameters necessary for {@link DialogueChannel#builder()} and constructing an actual BlockingFoo instance. */
     @CheckReturnValue
     public interface WithDialogueOptions<T> {

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/LegacyConstruction.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/LegacyConstruction.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.client.config.NoOpHostEventsSink;
+import com.palantir.dialogue.clients.DialogueClients.ReloadingFactory;
+import com.palantir.refreshable.Refreshable;
+
+/** Utility functionality supporting client creation using the {@link ClientConfiguration} type. */
+final class LegacyConstruction {
+    private static final ReloadingFactory FACTORY = DialogueClients.create(
+                    Refreshable.only(ServicesConfigBlock.builder().build()))
+            .withHostEventsSink(NoOpHostEventsSink.INSTANCE);
+
+    @SuppressWarnings("deprecation")
+    static <T> T getNonReloading(Class<T> clientInterface, ClientConfiguration clientConfiguration) {
+        return FACTORY.getNonReloading(clientInterface, clientConfiguration);
+    }
+
+    private LegacyConstruction() {}
+}


### PR DESCRIPTION
This method takes fewer args, requiring the HostEventSink and
UserAgent to be included in the ClientConfiguration itself, however
we can handle this transformation in our automation.

==COMMIT_MSG==
Provide a static factory method replacement for JaxrsClient.create
==COMMIT_MSG==