### PR TITLE
Dialogue path parameters support multi-segment values

### DIFF
--- a/changelog/@unreleased/pr-1401.v2.yml
+++ b/changelog/@unreleased/pr-1401.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue path parameters support multi-segment values
+  links:
+  - https://github.com/palantir/dialogue/pull/1401

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -102,4 +102,7 @@ public interface MyService {
 
     @Request(method = HttpMethod.GET, path = "/multipath/{pathSegments}")
     void multiplePathSegments(@Request.PathParam List<UUID> pathSegments);
+
+    @Request(method = HttpMethod.GET, path = "/multipath-strings/{pathSegments}")
+    void multipleStringPathSegments(@Request.PathParam List<String> pathSegments);
 }

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -99,4 +99,7 @@ public interface MyService {
 
     @Request(method = HttpMethod.POST, path = "/multipart")
     void multipart(@Request.Body(PutFileRequestSerializer.class) PutFileRequest request);
+
+    @Request(method = HttpMethod.GET, path = "/multipath/{pathSegments}")
+    void multiplePathSegments(@Request.PathParam List<UUID> pathSegments);
 }

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -19,6 +19,7 @@ package com.palantir.myservice.example;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterables;
@@ -314,6 +315,17 @@ public final class MyServiceIntegrationTest {
                         .putAll("q1", "var1", "var2")
                         .build(),
                 new MyCustomParamType("var3"));
+    }
+
+    @Test
+    void testMultiplePathParams() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        undertowHandler = exchange -> {
+            exchange.assertMethod(HttpMethod.GET);
+            exchange.assertPath("/multipath/" + first + '/' + second);
+        };
+        myServiceDialogue.multiplePathSegments(ImmutableList.of(first, second));
     }
 
     private void testCustomResponse(int code) {

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -328,6 +328,29 @@ public final class MyServiceIntegrationTest {
         myServiceDialogue.multiplePathSegments(ImmutableList.of(first, second));
     }
 
+    @Test
+    void testMultiplePathParams_empty() {
+        undertowHandler = exchange -> {
+            exchange.assertMethod(HttpMethod.GET);
+            exchange.assertPath("/multipath");
+        };
+        myServiceDialogue.multiplePathSegments(ImmutableList.of());
+    }
+
+    @Test
+    void testMultiplePathParams_escaped() {
+        String first = "a/b";
+        String second = "c/d";
+        undertowHandler = exchange -> {
+            exchange.assertMethod(HttpMethod.GET);
+            // The server should receive uri-encoded slashes as '%2F' as opposed to
+            // splitting the input segment string values into sub-segments. This allows
+            // the server to recreate the original data.
+            exchange.assertPath("/multipath-strings/a%2Fb/c%2Fd");
+        };
+        myServiceDialogue.multipleStringPathSegments(ImmutableList.of(first, second));
+    }
+
     private void testCustomResponse(int code) {
         undertowHandler = exchange -> {
             exchange.assertMethod(HttpMethod.PUT);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/EndpointsEnumGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/EndpointsEnumGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.dialogue.annotations.processor.generate;
 
+import com.google.common.collect.ListMultimap;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.PathTemplate;
@@ -32,7 +33,6 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import java.util.Map;
 import java.util.Optional;
 import javax.lang.model.element.Modifier;
 
@@ -76,7 +76,8 @@ public final class EndpointsEnumGenerator {
                 .addMethod(MethodSpec.methodBuilder("renderPath")
                         .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
-                        .addParameter(ParameterizedTypeName.get(Map.class, String.class, String.class), "params")
+                        .addParameter(
+                                ParameterizedTypeName.get(ListMultimap.class, String.class, String.class), "params")
                         .addParameter(UrlBuilder.class, "url")
                         .addCode("pathTemplate.fill(params, url);")
                         .build())

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -242,7 +242,7 @@ public final class ServiceImplementationGenerator {
     private CodeBlock generatePathParam(ArgumentDefinition param, Optional<ParameterEncoderType> paramEncoder) {
         return generatePlainSerializer(
                 "putPathParams",
-                "nope",
+                "putAllPathParams",
                 param.argName().get(),
                 CodeBlock.of("$L", param.argName().get()),
                 param.argType(),

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -1,5 +1,6 @@
 package com.palantir.myservice.service;
 
+import com.google.common.collect.ListMultimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
@@ -27,7 +28,6 @@ import java.lang.String;
 import java.lang.Void;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
@@ -209,7 +209,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     PathTemplate.builder().fixed("greet").build();
 
             @Override
-            public void renderPath(Map<String, String> params, UrlBuilder url) {
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
                 pathTemplate.fill(params, url);
             }
 
@@ -239,7 +239,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     PathTemplate.builder().fixed("greeting").build();
 
             @Override
-            public void renderPath(Map<String, String> params, UrlBuilder url) {
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
                 pathTemplate.fill(params, url);
             }
 
@@ -269,7 +269,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     PathTemplate.builder().fixed("custom").fixed("request").build();
 
             @Override
-            public void renderPath(Map<String, String> params, UrlBuilder url) {
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
                 pathTemplate.fill(params, url);
             }
 
@@ -299,7 +299,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     PathTemplate.builder().fixed("custom").fixed("request1").build();
 
             @Override
-            public void renderPath(Map<String, String> params, UrlBuilder url) {
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
                 pathTemplate.fill(params, url);
             }
 
@@ -332,7 +332,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     .build();
 
             @Override
-            public void renderPath(Map<String, String> params, UrlBuilder url) {
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
                 pathTemplate.fill(params, url);
             }
 

--- a/dialogue-annotations/src/test/java/com/palantir/dialogue/MultimapAsMapTest.java
+++ b/dialogue-annotations/src/test/java/com/palantir/dialogue/MultimapAsMapTest.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MultimapAsMapTest {
+
+    @Test
+    public void testSimpleConversion() {
+        ImmutableListMultimap<String, String> multimap = ImmutableListMultimap.<String, String>builder()
+                .put("a", "b")
+                .put("c", "d")
+                .build();
+        assertThat(MultimapAsMap.of(multimap))
+                .hasSize(2)
+                .containsExactlyEntriesOf(ImmutableMap.of("a", "b", "c", "d"))
+                .containsOnlyKeys("a", "c");
+    }
+
+    @Test
+    public void testMultipleValues() {
+        ImmutableListMultimap<String, String> multimap = ImmutableListMultimap.<String, String>builder()
+                .put("a", "b")
+                .putAll("c", "d", "e")
+                .build();
+        Map<String, String> map = MultimapAsMap.of(multimap);
+        assertThat(map).hasSize(2);
+        assertThat(map.keySet()).isEqualTo(ImmutableSet.of("a", "c"));
+        assertThat(map.get("a")).isEqualTo("b");
+        assertThatThrownBy(() -> map.get("c")).isInstanceOf(SafeIllegalStateException.class);
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -52,7 +52,7 @@ public final class BaseUrl {
 
     public URL render(Endpoint endpoint, Request request) {
         DefaultUrlBuilder url = builder.newBuilder();
-        endpoint.renderPath(request.pathParams(), url);
+        endpoint.renderPath(request.pathParameters(), url);
         request.queryParams().forEach(url::queryParam);
         return url.build();
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Endpoint.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Endpoint.java
@@ -16,6 +16,9 @@
 
 package com.palantir.dialogue;
 
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -25,7 +28,23 @@ import java.util.Set;
  * as well as the types of the request and response body.
  */
 public interface Endpoint {
-    void renderPath(Map<String, String> params, UrlBuilder url);
+    /**
+     * {@link #renderPath(ListMultimap, UrlBuilder)} is preferred, however at least one {@code renderPath} must be
+     * implemented to avoid infinite recursion.
+     */
+    default void renderPath(Map<String, String> params, UrlBuilder url) {
+        renderPath(
+                params.isEmpty()
+                        ? ImmutableListMultimap.of()
+                        : ImmutableListMultimap.<String, String>builder()
+                                .putAll(params.entrySet())
+                                .build(),
+                url);
+    }
+
+    default void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+        renderPath(params.isEmpty() ? ImmutableMap.of() : new MultimapAsMap<>(params), url);
+    }
 
     HttpMethod httpMethod();
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Endpoint.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Endpoint.java
@@ -43,7 +43,7 @@ public interface Endpoint {
     }
 
     default void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
-        renderPath(params.isEmpty() ? ImmutableMap.of() : new MultimapAsMap<>(params), url);
+        renderPath(params.isEmpty() ? ImmutableMap.of() : MultimapAsMap.of(params), url);
     }
 
     HttpMethod httpMethod();

--- a/dialogue-target/src/main/java/com/palantir/dialogue/MultimapAsMap.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/MultimapAsMap.java
@@ -17,95 +17,34 @@
 package com.palantir.dialogue;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Collection;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
-/** Map implementation wrapping a Multimap which uses the first value for any given key. */
-final class MultimapAsMap<K, V> implements Map<K, V> {
-    private final Multimap<K, V> multimap;
+/**
+ * Utility functionality to transform a multimap into a standard map assuming all keys have at most one value.
+ */
+final class MultimapAsMap {
 
-    MultimapAsMap(Multimap<K, V> multimap) {
-        this.multimap = multimap;
-    }
-
-    @Override
-    public int size() {
-        return multimap.keySet().size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return multimap.isEmpty();
-    }
-
-    @Override
-    public boolean containsKey(Object key) {
-        return multimap.containsKey(key);
-    }
-
-    @Override
-    public boolean containsValue(Object value) {
-        for (Entry<K, V> entry : entrySet()) {
-            if (Objects.equals(entry.getValue(), value)) {
-                return true;
+    static <K, V> Map<K, V> of(Multimap<K, V> multimap) {
+        return Maps.transformValues(multimap.asMap(), values -> {
+            int size = values.size();
+            if (size <= 1) {
+                return Iterables.getOnlyElement(values, null);
             }
-        }
-        return false;
+            // It's important that we fail in this case to avoid building malformed requests.
+            // Older clients cannot produce this kind of data, so the most likely scenario is
+            // a client is attempting to add multiple path parameters but has implemented the
+            // wrong Endpoint.renderPath method.
+            throw new SafeIllegalStateException(
+                    "Multiple values are not allowed, use the multimap accessor instead",
+                    SafeArg.of("size", size),
+                    UnsafeArg.of("values", values));
+        });
     }
 
-    @Override
-    @Nullable
-    @SuppressWarnings("unchecked")
-    public V get(Object key) {
-        return Iterables.getFirst(multimap.get((K) key), null);
-    }
-
-    @Override
-    public V put(K _key, V _value) {
-        throw new UnsupportedOperationException("unmodifiable");
-    }
-
-    @Override
-    public V remove(Object _key) {
-        throw new UnsupportedOperationException("unmodifiable");
-    }
-
-    @Override
-    public void putAll(Map<? extends K, ? extends V> _map) {
-        throw new UnsupportedOperationException("unmodifiable");
-    }
-
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException("unmodifiable");
-    }
-
-    @Override
-    public Set<K> keySet() {
-        return multimap.keySet();
-    }
-
-    @Override
-    @SuppressWarnings("SimplifyStreamApiCallChains") // Thanks intellij, but that would be recursive...
-    public Collection<V> values() {
-        return entrySet().stream().map(Entry::getValue).collect(Collectors.toUnmodifiableList());
-    }
-
-    @Override
-    public Set<Entry<K, V>> entrySet() {
-        return multimap.keySet().stream()
-                .map(key -> new SimpleImmutableEntry<>(key, get(key)))
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
-    @Override
-    public String toString() {
-        return "MultimapAsMap{multimap=" + multimap + '}';
-    }
+    private MultimapAsMap() {}
 }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/MultimapAsMap.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/MultimapAsMap.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/** Map implementation wrapping a Multimap which uses the first value for any given key. */
+final class MultimapAsMap<K, V> implements Map<K, V> {
+    private final Multimap<K, V> multimap;
+
+    MultimapAsMap(Multimap<K, V> multimap) {
+        this.multimap = multimap;
+    }
+
+    @Override
+    public int size() {
+        return multimap.keySet().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return multimap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return multimap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        for (Entry<K, V> entry : entrySet()) {
+            if (Objects.equals(entry.getValue(), value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public V get(Object key) {
+        return Iterables.getFirst(multimap.get((K) key), null);
+    }
+
+    @Override
+    public V put(K _key, V _value) {
+        throw new UnsupportedOperationException("unmodifiable");
+    }
+
+    @Override
+    public V remove(Object _key) {
+        throw new UnsupportedOperationException("unmodifiable");
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> _map) {
+        throw new UnsupportedOperationException("unmodifiable");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("unmodifiable");
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return multimap.keySet();
+    }
+
+    @Override
+    @SuppressWarnings("SimplifyStreamApiCallChains") // Thanks intellij, but that would be recursive...
+    public Collection<V> values() {
+        return entrySet().stream().map(Entry::getValue).collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return multimap.keySet().stream()
+                .map(key -> new SimpleImmutableEntry<>(key, get(key)))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public String toString() {
+        return "MultimapAsMap{multimap=" + multimap + '}';
+    }
+}

--- a/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue;
 
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
@@ -68,6 +69,17 @@ public final class PathTemplate {
             }
         }
         Verify.verify(numVariableSegments == parameters.size(), "Too many parameters supplied, this is a bug");
+    }
+
+    /** Populates this template with the given named parameters. */
+    public void fill(ListMultimap<String, String> parameters, UrlBuilder url) {
+        for (Segment segment : segments) {
+            if (segment.fixed != null) {
+                url.pathSegment(segment.fixed);
+            } else {
+                parameters.get(segment.variable).forEach(url::pathSegment);
+            }
+        }
     }
 
     public static final class PathTemplateBuilder {

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -73,11 +73,11 @@ public final class Request {
      * one-to-one correspondence between variable {@link PathTemplate.Segment path segments} of a {@link PathTemplate}
      * and the request's {@link #pathParams}.
      *
-     * {@link #pathParameters()} is preferred, however we have not marked this deprecated in order to avoid
-     * adding warnings to existing generated code.
+     * @deprecated in favor of {@link #pathParameters()} which returns a multimap
      */
+    @Deprecated
     public Map<String, String> pathParams() {
-        return new MultimapAsMap<>(pathParams);
+        return MultimapAsMap.of(pathParams);
     }
 
     /**

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -18,15 +18,12 @@ package com.palantir.dialogue;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.palantir.logsafe.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,7 +39,7 @@ public final class Request {
 
     private final ListMultimap<String, String> headerParams;
     private final ListMultimap<String, String> queryParams;
-    private final Map<String, String> pathParams;
+    private final ListMultimap<String, String> pathParams;
     private final Optional<RequestBody> body;
     private final RequestAttachments attachments;
 
@@ -75,8 +72,20 @@ public final class Request {
      * The HTTP path parameters for this request, encoded as a map of {@code param-name: param-value}. There is a
      * one-to-one correspondence between variable {@link PathTemplate.Segment path segments} of a {@link PathTemplate}
      * and the request's {@link #pathParams}.
+     *
+     * {@link #pathParameters()} is preferred, however we have not marked this deprecated in order to avoid
+     * adding warnings to existing generated code.
      */
     public Map<String, String> pathParams() {
+        return new MultimapAsMap<>(pathParams);
+    }
+
+    /**
+     * The HTTP path parameters for this request, encoded as a multimap of {@code param-name: param-value}. There is a
+     * one-to-many correspondence between variable {@link PathTemplate.Segment path segments} of a {@link PathTemplate}
+     * and the request's {@link #pathParams}.
+     */
+    public ListMultimap<String, String> pathParameters() {
         return pathParams;
     }
 
@@ -146,7 +155,7 @@ public final class Request {
 
         private ListMultimap<String, String> queryParams = ImmutableListMultimap.of();
 
-        private Map<String, String> pathParams = ImmutableMap.of();
+        private ListMultimap<String, String> pathParams = ImmutableListMultimap.of();
 
         private Optional<RequestBody> body = Optional.empty();
 
@@ -241,7 +250,17 @@ public final class Request {
             return putAllPathParams(entries);
         }
 
+        public Request.Builder putAllPathParams(String key, Iterable<String> values) {
+            mutablePathParams().putAll(key, values);
+            return this;
+        }
+
         public Request.Builder putAllPathParams(Map<String, ? extends String> entries) {
+            entries.forEach(mutablePathParams()::put);
+            return this;
+        }
+
+        public Request.Builder putAllPathParams(Multimap<String, ? extends String> entries) {
             mutablePathParams().putAll(entries);
             return this;
         }
@@ -279,10 +298,10 @@ public final class Request {
             return queryParams;
         }
 
-        private Map<String, String> mutablePathParams() {
+        private ListMultimap<String, String> mutablePathParams() {
             if (!isPathMutable()) {
                 setPathMutable();
-                pathParams = new HashMap<>(pathParams);
+                pathParams = ArrayListMultimap.create(pathParams);
             }
             return pathParams;
         }
@@ -295,8 +314,8 @@ public final class Request {
             return isQueryMutable() ? Multimaps.unmodifiableListMultimap(queryParams) : queryParams;
         }
 
-        private Map<String, String> unmodifiablePathParams() {
-            return isPathMutable() ? Collections.unmodifiableMap(pathParams) : pathParams;
+        private ListMultimap<String, String> unmodifiablePathParams() {
+            return isPathMutable() ? Multimaps.unmodifiableListMultimap(pathParams) : pathParams;
         }
 
         public Request build() {


### PR DESCRIPTION
This is useful reading files based on paths from a remote
non-conjure server. Previously we opted not to support this sort
of thing because Dialogue was conjure-first, however adoption
of the annotation processor for non-conjure services has exposed
the need.

## After this PR
==COMMIT_MSG==
Dialogue path parameters support multi-segment values
==COMMIT_MSG==

## Possible downsides?
Potential infinite recursion if `Endpoint` is manually implemented without overriding one render method.
