### PR TITLE
Dialogue does not produce timer metrics for non-constant endpoints

### DIFF
--- a/changelog/@unreleased/pr-1414.v2.yml
+++ b/changelog/@unreleased/pr-1414.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue does not produce timer metrics for non-constant endpoints
+  links:
+  - https://github.com/palantir/dialogue/pull/1414

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToEndpointChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ChannelToEndpointChannel.java
@@ -48,7 +48,7 @@ final class ChannelToEndpointChannel implements Channel {
      * Constant {@link Endpoint endpoints} may be safely used as cache keys, as opposed to dynamically created
      * {@link Endpoint} objects which would result in a memory leak.
      */
-    private static boolean isConstant(Endpoint endpoint) {
+    static boolean isConstant(Endpoint endpoint) {
         // The conjure generator creates endpoints as enum values, which can safely be cached because they aren't
         // dynamically created.
         return endpoint instanceof Enum;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -183,7 +183,11 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = DeprecationWarningChannel.create(cf, channel, endpoint);
                 channel = new ContentDecodingChannel(channel);
                 channel = TracedChannel.create(cf, channel, endpoint);
-                channel = TimingEndpointChannel.create(cf, channel, endpoint);
+                if (ChannelToEndpointChannel.isConstant(endpoint)) {
+                    // Avoid producing metrics for non-constant endpoints which may produce
+                    // high cardinality.
+                    channel = TimingEndpointChannel.create(cf, channel, endpoint);
+                }
                 channel = new InterruptionChannel(channel);
                 return new NeverThrowEndpointChannel(channel); // this must come last as a defensive backstop
             };


### PR DESCRIPTION
This remove timer metrics from jaxrs feign clients, and may impact
hand-written clients.
The annotation processor is not impacted.

==COMMIT_MSG==
Dialogue does not produce timer metrics for non-constant endpoints
==COMMIT_MSG==

I don't expect this to have a great deal of impact, but it's a helpful backstop against metric registry memory leaks.
