### PR TITLE
Add retries for PUT and DELETE

### DIFF
--- a/changelog/@unreleased/pr-1429.v2.yml
+++ b/changelog/@unreleased/pr-1429.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue will now retry PUT and DELETE requests that return a 500 status
+    code.
+  links:
+  - https://github.com/palantir/dialogue/pull/1429

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -405,10 +405,9 @@ final class RetryingChannel implements EndpointChannel {
             case GET:
             case HEAD:
             case OPTIONS:
-                return true;
             case PUT:
             case DELETE:
-                // in theory PUT and DELETE should be fine to retry too, we're just being conservative for now.
+                return true;
             case POST:
             case PATCH:
                 return false;

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -282,6 +282,46 @@ public class RetryingChannelTest {
     }
 
     @Test
+    public void retries_500s_for_put() throws Exception {
+        when(channel.execute(any()))
+                .thenReturn(Futures.immediateFuture(new TestResponse().code(500)))
+                .thenReturn(Futures.immediateFuture(new TestResponse().code(200)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.PUT,
+                "my-channel",
+                3,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response).isDone();
+        assertThat(response.get().code()).isEqualTo(200);
+        verify(channel, times(2)).execute(REQUEST);
+    }
+
+    @Test
+    public void retries_500s_for_delete() throws Exception {
+        when(channel.execute(any()))
+                .thenReturn(Futures.immediateFuture(new TestResponse().code(500)))
+                .thenReturn(Futures.immediateFuture(new TestResponse().code(200)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.DELETE,
+                "my-channel",
+                3,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response).isDone();
+        assertThat(response.get().code()).isEqualTo(200);
+        verify(channel, times(2)).execute(REQUEST);
+    }
+
+    @Test
     public void doesnt_retry_500s_for_post() throws Exception {
         when(channel.execute(any())).thenReturn(Futures.immediateFuture(new TestResponse().code(500)));
 

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/TestEndpoint.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/TestEndpoint.java
@@ -30,6 +30,18 @@ public enum TestEndpoint implements Endpoint {
         public HttpMethod httpMethod() {
             return HttpMethod.POST;
         }
+    },
+    PUT {
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.PUT;
+        }
+    },
+    DELETE {
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.DELETE;
+        }
     };
 
     @Override


### PR DESCRIPTION
## Before this PR
PUT and DELETE requests that would result in a 500 status code would not be retried.

## After this PR
==COMMIT_MSG==
Dialogue will now retry PUT and DELETE requests that return a 500 status code.
==COMMIT_MSG==

## Possible downsides?
If could potentially expose issues with PUT and DELETE endpoints that are not actually idempotent which was previously masked by the lack of retries. 
