### PR TITLE
Dialogue schedulers allow threads to time out when no work is scheduled

### DIFF
--- a/changelog/@unreleased/pr-1431.v2.yml
+++ b/changelog/@unreleased/pr-1431.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue schedulers allow threads to time out when no work is scheduled
+  links:
+  - https://github.com/palantir/dialogue/pull/1431

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
@@ -18,12 +18,12 @@ package com.palantir.dialogue.hc5;
 
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.dialogue.core.DialogueExecutors;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import java.time.Duration;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +44,7 @@ final class ScheduledIdleConnectionEvictor {
     private static final Supplier<ScheduledExecutorService> sharedScheduler =
             Suppliers.memoize(() -> MetricRegistries.instrument(
                     SharedTaggedMetricRegistries.getSingleton(),
-                    Executors.newSingleThreadScheduledExecutor(MetricRegistries.instrument(
+                    DialogueExecutors.newSharedSingleThreadScheduler(MetricRegistries.instrument(
                             SharedTaggedMetricRegistries.getSingleton(),
                             new ThreadFactoryBuilder()
                                     .setNameFormat(EXECUTOR_NAME + "-%d")

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueExecutors.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueExecutors.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/** Internal API which shouldn't be used outside of dialogue. */
+public final class DialogueExecutors {
+
+    private static final Duration DEFAULT_KEEP_ALIVE = Duration.ofSeconds(10);
+
+    /**
+     * Create an executor which allows all threads to exit after a timeout has elapsed, this prevents thread leakage
+     * when dialogue is packaged as a dynamically loaded plugin.
+     */
+    public static ScheduledExecutorService newSharedSingleThreadScheduler(ThreadFactory threadFactory) {
+        return newSharedSingleThreadScheduler(threadFactory, DEFAULT_KEEP_ALIVE);
+    }
+
+    @VisibleForTesting
+    @SuppressWarnings("DangerousThreadPoolExecutorUsage")
+    static ScheduledExecutorService newSharedSingleThreadScheduler(
+            ThreadFactory threadFactory, Duration keepAliveTime) {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, threadFactory);
+        // Core threads must be allowed to time out to allow garbage collection
+        executor.allowCoreThreadTimeOut(true);
+        executor.setKeepAliveTime(keepAliveTime.toNanos(), TimeUnit.NANOSECONDS);
+        // remove-on-cancel allows heavy cancellation without risk of OOM waiting for
+        // the originally scheduled deadline. This allows the keep-alive clock to
+        // begin counting when futures are canceled rather than after the scheduled
+        // task has completed.
+        executor.setRemoveOnCancelPolicy(true);
+        return executor;
+    }
+
+    private DialogueExecutors() {}
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -50,7 +50,6 @@ import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -74,7 +73,7 @@ final class RetryingChannel implements EndpointChannel {
      */
     @SuppressWarnings("deprecation") // Singleton registry for a singleton executor
     static final Supplier<ScheduledExecutorService> sharedScheduler =
-            Suppliers.memoize(() -> Executors.newSingleThreadScheduledExecutor(MetricRegistries.instrument(
+            Suppliers.memoize(() -> DialogueExecutors.newSharedSingleThreadScheduler(MetricRegistries.instrument(
                     SharedTaggedMetricRegistries.getSingleton(),
                     new ThreadFactoryBuilder()
                             .setNameFormat(SCHEDULER_NAME + "-%d")

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueExecutorsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueExecutorsTest.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.Runnables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+final class DialogueExecutorsTest {
+    private static final String THREAD_PREFIX = "dialogue-scheduler-";
+
+    @Test
+    void testThreadTimeout() throws Exception {
+        ScheduledExecutorService exec = DialogueExecutors.newSharedSingleThreadScheduler(
+                new ThreadFactoryBuilder()
+                        .setNameFormat(THREAD_PREFIX + "%d")
+                        .setDaemon(true)
+                        .build(),
+                Duration.ofMillis(100));
+        try {
+            assertThat(countExecutorThreads()).isEqualTo(0);
+            exec.schedule(Runnables.doNothing(), 1, TimeUnit.SECONDS).cancel(true);
+            assertThat(countExecutorThreads()).isEqualTo(1);
+
+            Awaitility.waitAtMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(countExecutorThreads())
+                    .as("Created threads should time out")
+                    .isEqualTo(0));
+
+            AtomicInteger counter = new AtomicInteger();
+            ScheduledFuture<Integer> scheduledFuture =
+                    exec.schedule(counter::incrementAndGet, 1, TimeUnit.MILLISECONDS);
+            assertThat(countExecutorThreads()).isEqualTo(1);
+            assertThat(scheduledFuture.get(500, TimeUnit.MILLISECONDS)).isEqualTo(1);
+        } finally {
+            exec.shutdownNow();
+            assertThat(exec.awaitTermination(1, TimeUnit.SECONDS))
+                    .as("Executor failed to stop")
+                    .isTrue();
+        }
+    }
+
+    private long countExecutorThreads() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(thread -> thread.getName().startsWith(THREAD_PREFIX))
+                .count();
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueExecutorsTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueExecutorsTest.java
@@ -48,11 +48,15 @@ final class DialogueExecutorsTest {
                     .as("Created threads should time out")
                     .isEqualTo(0));
 
+            // Test scheduling beyond the timeout
             AtomicInteger counter = new AtomicInteger();
-            ScheduledFuture<Integer> scheduledFuture =
-                    exec.schedule(counter::incrementAndGet, 1, TimeUnit.MILLISECONDS);
+            ScheduledFuture<Integer> scheduledFuture = exec.schedule(counter::incrementAndGet, 1, TimeUnit.SECONDS);
             assertThat(countExecutorThreads()).isEqualTo(1);
-            assertThat(scheduledFuture.get(500, TimeUnit.MILLISECONDS)).isEqualTo(1);
+            assertThat(scheduledFuture.get(1500, TimeUnit.MILLISECONDS)).isEqualTo(1);
+
+            Awaitility.waitAtMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(countExecutorThreads())
+                    .as("Created threads should time out")
+                    .isEqualTo(0));
         } finally {
             exec.shutdownNow();
             assertThat(exec.awaitTermination(1, TimeUnit.SECONDS))


### PR DESCRIPTION
This should allow dialogue clients to be used in dynamically
loaded/unloaded plugins without leaking scheduler threads.

## After this PR
==COMMIT_MSG==
Dialogue schedulers allow threads to time out when no work is scheduled
==COMMIT_MSG==