### PR TITLE
Expand ChannelCache toString

### DIFF
--- a/changelog/@unreleased/pr-1470.v2.yml
+++ b/changelog/@unreleased/pr-1470.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Expand ChannelCache toString to provide actionable data when we see
+    'channelCache nearing capacity' logging
+  links:
+  - https://github.com/palantir/dialogue/pull/1470

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -39,6 +39,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import org.immutables.value.Value;
 
@@ -193,7 +194,14 @@ final class ChannelCache {
         return "ChannelCache{"
                 + "instanceNumber=" + instanceNumber
                 + ", apacheCache.size=" + apacheCache.size()
+                // Channel names are safe-loggable
+                + ", apacheCache=" + apacheCache.keySet()
                 + ", channelCache.size=" + channelCache.estimatedSize() + "/" + MAX_CACHED_CHANNELS
+                + ", channelCache="
+                // Channel names are safe-loggable
+                + channelCache.asMap().keySet().stream()
+                        .map(ChannelCacheKey::channelName)
+                        .collect(Collectors.joining(", ", "[", "]"))
                 + '}';
     }
 


### PR DESCRIPTION
## Before this PR
Unable to tell why we're logging `channelCache nearing capacity`

## After this PR
==COMMIT_MSG==
Expand ChannelCache toString to provide actionable data when we see 'channelCache nearing capacity' logging
==COMMIT_MSG==

## Possible downsides?
It could produce very large strings?
