### PR TITLE
Change SOCKS proxy not found logging level

### DIFF
--- a/changelog/@unreleased/pr-1480.v2.yml
+++ b/changelog/@unreleased/pr-1480.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Failing to find a SOCKS proxy address no longer logs at an error level.
+  links:
+  - https://github.com/palantir/dialogue/pull/1480

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -616,7 +616,7 @@ public final class ApacheHttpClientChannels {
             }
             return address;
         } catch (RuntimeException e) {
-            log.error("Failed to find a SOCKS proxy", e);
+            log.debug("Failed to find a SOCKS proxy", e);
             return null;
         }
     }


### PR DESCRIPTION
## Before this PR
Failing to find a SOCKS proxy address was logging at an error level.

## After this PR
==COMMIT_MSG==
Failing to find a SOCKS proxy address no longer logs at an error level.
==COMMIT_MSG==

## Possible downsides?
