### PR TITLE
Remove noisy and unnecessary TLS protocol version logging

### DIFF
--- a/changelog/@unreleased/pr-1481.v2.yml
+++ b/changelog/@unreleased/pr-1481.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove noisy and unnecessary TLS protocol version logging
+  links:
+  - https://github.com/palantir/dialogue/pull/1481

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -483,7 +483,7 @@ public final class ApacheHttpClientChannels {
             SSLConnectionSocketFactory sslSocketFactory =
                     new SSLConnectionSocketFactory(
                             MetricRegistries.instrument(conf.taggedMetricRegistry(), rawSocketFactory, name),
-                            TlsProtocols.enabledFor(name),
+                            TlsProtocols.get(),
                             supportedCipherSuites(
                                     conf.enableGcmCipherSuites()
                                             ? CipherSuites.allCipherSuites()

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
@@ -17,21 +17,16 @@
 package com.palantir.dialogue.hc5;
 
 import com.google.common.primitives.Ints;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
 
 /** Internal utility functionality to slowly roll out new TLS protocol support. */
 final class TlsProtocols {
 
-    private static final SafeLogger log = SafeLoggerFactory.get(TlsProtocols.class);
     private static final boolean JAVA_15_OR_LATER = isJava15OrLater();
     private static final String TLS_V1_2 = "TLSv1.2";
     private static final String TLS_V1_3 = "TLSv1.3";
 
-    static String[] enabledFor(String clientName) {
+    static String[] get() {
         if (JAVA_15_OR_LATER) {
-            log.info("Enabling TLSv1.3 support for client '{}'", SafeArg.of("client", clientName));
             return new String[] {TLS_V1_3, TLS_V1_2};
         } else {
             return new String[] {TLS_V1_2};


### PR DESCRIPTION
This was helpful when we initially began rolling out TLSv1.3
support, however now that all Java 15+ clients are using TLSv1.3
it doesn't provide any valuable information.

==COMMIT_MSG==
Remove noisy and unnecessary TLS protocol version logging
==COMMIT_MSG==
