### PR TITLE
LeakDetector retains the creation-point traceId

### DIFF
--- a/changelog/@unreleased/pr-1482.v2.yml
+++ b/changelog/@unreleased/pr-1482.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: LeakDetector retains the creation-point traceId to ease the process
+    of debugging resource leaks
+  links:
+  - https://github.com/palantir/dialogue/pull/1482


### PR DESCRIPTION
Previously this data wasn't accessible because leaks are reported
from a background cleaner thread once references are released.

==COMMIT_MSG==
LeakDetector retains the creation-point traceId to ease the process of debugging resource leaks
==COMMIT_MSG==