### PR TITLE
Fix Sticky2 early queued response handling

### DIFF
--- a/changelog/@unreleased/pr-1534.v2.yml
+++ b/changelog/@unreleased/pr-1534.v2.yml
@@ -1,0 +1,14 @@
+type: fix
+fix:
+  description: |-
+    Fix Sticky2 early queued response handling.
+
+    Previously the initial response future was mishandled in a way
+    that caused cancellation to 'leak' between queued futures, this
+    meant that pending responses could be dropped on the floor rather
+    than being deserialized as expected.
+    Secondly, this fixes an issue in which certain sticky2 requests
+    could be retried in error if they fail with an exception after the
+    initial request completed with a valid response.
+  links:
+  - https://github.com/palantir/dialogue/pull/1534

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyEndpointChannels2.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyEndpointChannels2.java
@@ -26,6 +26,7 @@ import com.palantir.dialogue.EndpointChannelFactory;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.futures.DialogueFutures;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -195,7 +196,7 @@ final class StickyEndpointChannels2 implements Supplier<Channel> {
                     successfulCall(response);
                 } catch (Throwable t) {
                     response.close();
-                    throw new IllegalStateException("Failed to update state with successful call", t);
+                    throw new SafeIllegalStateException("Failed to update state with successful call", t);
                 }
                 return response;
             }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/StickyEndpointChannels2Test.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/StickyEndpointChannels2Test.java
@@ -181,6 +181,21 @@ public final class StickyEndpointChannels2Test {
         request2.assertDoneFailed();
     }
 
+    @Test
+    public void cancel_in_flight_request_does_not_cancel_queued() {
+        Channel channel = sticky.get();
+
+        TestHarness request1 =
+                new TestHarness(channel).expectAddStickyTokenRequest().execute().assertNotDone();
+
+        TestHarness request2 =
+                new TestHarness(channel).expectAddStickyTokenRequest().execute().assertNotDone();
+
+        request1.cancelResponse().assertDoneCancelled();
+
+        request2.assertNotDone();
+    }
+
     private final class TestHarness {
         Channel channel;
         Request request = Request.builder().build();

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
@@ -51,7 +51,14 @@ public final class DialogueFutures {
 
     public static <T> ListenableFuture<T> catchingAllAsync(
             ListenableFuture<T> input, AsyncFunction<Throwable, T> function) {
-        return new DialogueDirectAsyncCatchingFuture<T>(input, function);
+        return new DialogueDirectAsyncCatchingFuture<>(input, function);
+    }
+
+    public static <T> ListenableFuture<T> catchingAllAsync(
+            ListenableFuture<T> input,
+            AsyncFunction<Throwable, T> function,
+            AsyncFunction<Throwable, T> onCancellation) {
+        return new DialogueDirectAsyncCatchingFuture<>(input, function, onCancellation);
     }
 
     @CanIgnoreReturnValue

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
@@ -50,15 +50,15 @@ public final class DialogueFutures {
     }
 
     public static <T> ListenableFuture<T> catchingAllAsync(
-            ListenableFuture<T> input, AsyncFunction<Throwable, T> function) {
-        return new DialogueDirectAsyncCatchingFuture<>(input, function);
+            ListenableFuture<T> input, AsyncFunction<Throwable, T> onException) {
+        return new DialogueDirectAsyncCatchingFuture<>(input, onException);
     }
 
     public static <T> ListenableFuture<T> catchingAllAsync(
             ListenableFuture<T> input,
-            AsyncFunction<Throwable, T> function,
+            AsyncFunction<Throwable, T> onException,
             AsyncFunction<Throwable, T> onCancellation) {
-        return new DialogueDirectAsyncCatchingFuture<>(input, function, onCancellation);
+        return new DialogueDirectAsyncCatchingFuture<>(input, onException, onCancellation);
     }
 
     @CanIgnoreReturnValue

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueFutures.java
@@ -50,15 +50,8 @@ public final class DialogueFutures {
     }
 
     public static <T> ListenableFuture<T> catchingAllAsync(
-            ListenableFuture<T> input, AsyncFunction<Throwable, T> onException) {
-        return new DialogueDirectAsyncCatchingFuture<>(input, onException);
-    }
-
-    public static <T> ListenableFuture<T> catchingAllAsync(
-            ListenableFuture<T> input,
-            AsyncFunction<Throwable, T> onException,
-            AsyncFunction<Throwable, T> onCancellation) {
-        return new DialogueDirectAsyncCatchingFuture<>(input, onException, onCancellation);
+            ListenableFuture<T> input, AsyncFunction<Throwable, T> function) {
+        return new DialogueDirectAsyncCatchingFuture<T>(input, function);
     }
 
     @CanIgnoreReturnValue

--- a/dialogue-futures/src/test/java/com/palantir/dialogue/futures/DialogueFuturesTest.java
+++ b/dialogue-futures/src/test/java/com/palantir/dialogue/futures/DialogueFuturesTest.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -314,58 +313,6 @@ class DialogueFuturesTest {
         transformationCompletionLatch.countDown();
 
         assertThat(output.get(1, TimeUnit.SECONDS)).isEqualTo("value");
-        thread.join();
-    }
-
-    @Test
-    void testCatchCancelAsyncCancelWhileSettingFuture() throws Exception {
-        CountDownLatch transformationEnteredLatch = new CountDownLatch(1);
-        CountDownLatch transformationCompletionLatch = new CountDownLatch(1);
-
-        SettableFuture<String> input = SettableFuture.create();
-        ListenableFuture<String> output = DialogueFutures.catchingAllAsync(
-                input, _ignored -> Futures.immediateFailedFuture(new RuntimeException()), _ignored2 -> {
-                    transformationEnteredLatch.countDown();
-                    Uninterruptibles.awaitUninterruptibly(transformationCompletionLatch);
-                    return Futures.immediateFuture("value");
-                });
-        Thread thread = new Thread(() -> input.cancel(true));
-        thread.start();
-        transformationEnteredLatch.await();
-        assertThat(output.cancel(true)).isFalse();
-        assertThat(output.isCancelled()).isFalse();
-        assertThat(output.isDone()).isFalse();
-
-        transformationCompletionLatch.countDown();
-
-        assertThat(output.get(1, TimeUnit.SECONDS)).isEqualTo("value");
-        thread.join();
-    }
-
-    @Test
-    void testCatchCancelAsyncCancelWhileSettingFuture_cancel() throws Exception {
-        CountDownLatch transformationEnteredLatch = new CountDownLatch(1);
-        CountDownLatch transformationCompletionLatch = new CountDownLatch(1);
-
-        SettableFuture<String> input = SettableFuture.create();
-        ListenableFuture<String> output = DialogueFutures.catchingAllAsync(
-                input, _ignored -> Futures.immediateFailedFuture(new RuntimeException()), _ignored2 -> {
-                    transformationEnteredLatch.countDown();
-                    Uninterruptibles.awaitUninterruptibly(transformationCompletionLatch);
-                    return Futures.immediateCancelledFuture();
-                });
-        Thread thread = new Thread(() -> input.cancel(true));
-        thread.start();
-        transformationEnteredLatch.await();
-        assertThat(output.cancel(true)).isFalse();
-        assertThat(output.isCancelled()).isFalse();
-        assertThat(output.isDone()).isFalse();
-
-        transformationCompletionLatch.countDown();
-
-        assertThatThrownBy(output::get).isInstanceOf(CancellationException.class);
-        assertThat(output.isCancelled()).isTrue();
-        assertThat(output.isDone()).isTrue();
         thread.join();
     }
 


### PR DESCRIPTION
Previously the initial response future was mishandled in a way
that caused cancellation to 'leak' between queued futures, this
meant that pending responses could be dropped on the floor rather
than being deserialized as expected.

Secondly, this fixes an issue in which certain sticky2 requests
could be retried in error if they fail with an exception after the
initial request completed with a valid response.

## After this PR
==COMMIT_MSG==
Fix Sticky2 early queued response handling
==COMMIT_MSG==

## Possible downsides?
:ghost: Futures are scary :ghost:
