### PR TITLE
BinaryRequestBody implementations may be repeatable

### DIFF
--- a/changelog/@unreleased/pr-1536.v2.yml
+++ b/changelog/@unreleased/pr-1536.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: BinaryRequestBody implementations may be repeatable
+  links:
+  - https://github.com/palantir/dialogue/pull/1536

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -141,9 +141,7 @@ final class ConjureBodySerDe implements BodySerDe {
 
             @Override
             public boolean repeatable() {
-                // BinaryRequestBody values are not currently repeatable. If a need arises we may
-                // consider adding a 'boolean repeatable()' default method.
-                return false;
+                return value.repeatable();
             }
 
             @Override

--- a/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
@@ -29,6 +29,11 @@ public interface BinaryRequestBody extends Closeable {
     /** Invoked to write data to the request stream. */
     void write(OutputStream requestBody) throws IOException;
 
+    /** Returns <pre>true</pre> if {@link #write(OutputStream)} may be invoked multiple times. */
+    default boolean repeatable() {
+        return false;
+    }
+
     /** This method may be overridden to return resources. */
     @Override
     default void close() throws IOException {
@@ -45,6 +50,12 @@ public interface BinaryRequestBody extends Closeable {
                 Preconditions.checkState(!invoked, "Write has already been called");
                 invoked = true;
                 ByteStreams.copy(inputStream, requestBody);
+            }
+
+            @Override
+            public boolean repeatable() {
+                // The stream is exhausted as it is read, thus this is not repeatable.
+                return false;
             }
 
             @Override


### PR DESCRIPTION
Some implementations write a byte-array to the request outputstream,
which is absolutely repeatable. We shouldn't prevent such bodies
from being retried.

==COMMIT_MSG==
BinaryRequestBody implementations may be repeatable
==COMMIT_MSG==