### PR TITLE
Fix cancellation race resulting in a leaked response on retry 

### DIFF
--- a/changelog/@unreleased/pr-1542.v2.yml
+++ b/changelog/@unreleased/pr-1542.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix cancellation race resulting in a leaked response on retry
+  links:
+  - https://github.com/palantir/dialogue/pull/1542

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -319,7 +319,7 @@ final class RetryingChannel implements EndpointChannel {
                     },
                     backoffNanoseconds,
                     TimeUnit.NANOSECONDS);
-            return wrap(Futures.transformAsync(scheduled, input -> input, DialogueFutures.safeDirectExecutor()));
+            return wrap(DialogueFutures.transformAsync(scheduled, input -> input));
         }
 
         private long getBackoffNanoseconds() {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -329,7 +329,7 @@ final class RetryingChannel implements EndpointChannel {
                             return;
                         }
                         ListenableFuture<Response> delegateResult = delegate.execute(request);
-                        DialogueFutures.addDirectCallback(delegateResult, new FutureCallback<Response>() {
+                        DialogueFutures.addDirectCallback(delegateResult, new FutureCallback<>() {
                             @Override
                             public void onSuccess(Response result) {
                                 if (!responseFuture.set(result)) {


### PR DESCRIPTION
==COMMIT_MSG==
Fix cancellation race resulting in a leaked response on retry
==COMMIT_MSG==
