### PR TITLE
[WIP] DialogueListenableFuture

### DIFF
--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncCatchingFuture.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncCatchingFuture.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue.futures;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.io.Closeable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -35,7 +36,7 @@ import java.util.concurrent.TimeoutException;
  * Note that this means it's possible for a cancel invocation to return false and fail to terminate the future,
  * which allows dialogue to close responses properly without leaking resources.
  */
-final class DialogueDirectAsyncCatchingFuture<T> implements ListenableFuture<T>, Runnable {
+final class DialogueDirectAsyncCatchingFuture<T> implements DialogueListenableFuture<T>, Runnable {
     private volatile ListenableFuture<T> currentFuture;
     private final ListenableFuture<T> output;
 
@@ -94,4 +95,7 @@ final class DialogueDirectAsyncCatchingFuture<T> implements ListenableFuture<T>,
     public void run() {
         this.currentFuture = output;
     }
+
+    @Override
+    public void failureCallback(Runnable onFailure) {}
 }

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncTransformationFuture.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectAsyncTransformationFuture.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeoutException;
  * Note that this means it's possible for a cancel invocation to return false and fail to terminate the future,
  * which allows dialogue to close responses properly without leaking resources.
  */
-final class DialogueDirectAsyncTransformationFuture<I, O> implements ListenableFuture<O>, Runnable {
+final class DialogueDirectAsyncTransformationFuture<I, O> implements DialogueListenableFuture<O>, Runnable {
     private volatile ListenableFuture<?> currentFuture;
     private final ListenableFuture<O> output;
 
@@ -88,5 +88,10 @@ final class DialogueDirectAsyncTransformationFuture<I, O> implements ListenableF
     @Override
     public void run() {
         this.currentFuture = output;
+    }
+
+    @Override
+    public void failureCallback(Runnable onFailure) {
+
     }
 }

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectTransformationFuture.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueDirectTransformationFuture.java
@@ -37,17 +37,17 @@ import javax.annotation.Nullable;
  * Note that this means it's possible for a cancel invocation to return false and fail to terminate the future,
  * which allows dialogue to close responses properly without leaking resources.
  */
-final class DialogueDirectTransformationFuture<I, O> implements ListenableFuture<O>, FutureCallback<I> {
+final class DialogueDirectTransformationFuture<I, O> implements DialogueListenableFuture<O>, FutureCallback<I> {
     /** Freed upon completion to allow inputs to be garbage collected. */
     @Nullable
-    private ListenableFuture<I> input;
+    private DialogueListenableFuture<I> input;
 
     @Nullable
     private Function<? super I, ? extends O> function;
 
     private final SettableFuture<O> output;
 
-    DialogueDirectTransformationFuture(ListenableFuture<I> input, Function<? super I, ? extends O> function) {
+    DialogueDirectTransformationFuture(DialogueListenableFuture<I> input, Function<? super I, ? extends O> function) {
         this.input = input;
         this.function = function;
         this.output = SettableFuture.create();
@@ -119,5 +119,11 @@ final class DialogueDirectTransformationFuture<I, O> implements ListenableFuture
         }
         input = null;
         function = null;
+    }
+
+    @Override
+    public void failureCallback(Runnable onFailure) {
+        // If null, needs to run immediately?
+        input.failureCallback(onFailure);
     }
 }

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueListenableFuture.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/DialogueListenableFuture.java
@@ -1,0 +1,19 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ */
+
+package com.palantir.dialogue.futures;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface DialogueListenableFuture<V> extends ListenableFuture<V> {
+
+    /**
+     * Adds a callback to this future which will run if this future fails.
+     * If the future is transformed, the ownership of the {@code onFailure} will be passed to the transformed future.
+     * If currently owning future is completed with exception (or cancelled) the {@code onFailure} will be run.
+     *
+     * @param onFailure onFailure to manage
+     */
+    void failureCallback(Runnable onFailure);
+}

--- a/dialogue-futures/src/main/java/com/palantir/dialogue/futures/ResourceContext.java
+++ b/dialogue-futures/src/main/java/com/palantir/dialogue/futures/ResourceContext.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ */
+
+package com.palantir.dialogue.futures;
+
+final class ResourceContext {
+
+    private Runnable closeHandler;
+    private boolean closed;
+
+    private ResourceContext() {}
+
+    synchronized ResourceContext onClose(Runnable onClose) {
+        if (closed) {
+            // This should not throw here: this needs to be somehow tied to the future?
+            onClose.run();
+        } else {
+            closeHandler = compose(this.closeHandler, onClose);
+        }
+        return this;
+    }
+
+    synchronized void close() {
+        // is this enough to protect against #close being called multiple times.
+        if (!closed && closeHandler != null) {
+            Runnable onClose = closeHandler;
+            closeHandler = null;
+            onClose.run();
+        }
+        closed = true;
+    }
+
+    static ResourceContext createEmpty() {
+        return new ResourceContext();
+    }
+
+    private static Runnable compose(Runnable r1, Runnable r2) {
+        if (r1 == null) {
+            return r2;
+        }
+        return () -> {
+            try {
+                r1.run();
+            } catch (Throwable t1) {
+                try {
+                    r2.run();
+                } catch (Throwable t2) {
+                    t1.addSuppressed(t2);
+                }
+                throw t1;
+            }
+            r2.run();
+        };
+    }
+}


### PR DESCRIPTION
## Before this PR
This PR is complete garbage, implementation wise, but is a conversation starter.

What if our leaf futures started a context (that has a single useful method #failureCallback) which allows us to add callbacks that should run, should the future fail in any way. The leaf future that returns the Response from the network layer, simply add the Response#close as a callback to the future it returns.

Then all transformation futures (transform/transformAsync/catchingAll) simply need to share this context and propagate it up the chain. If any future fails, we close the context. Closing the context means all the callbacks get run, and forgotten (you can't run #close multiple times).

Subtleties:
1. What happens when context is already closed: I currently think the callback should run immediately to not leak, but where does the close exception go if it happens?
2. This is obviously a simplistic solution which assumes there are no forks in the chain of futures: so there's isn't a transformAsync applied twice where the returned futures do completely different things and append new failureCallbacks. In this implementation failure anywhere along either fork would close all resources. I feel like that's probably an assumption we can make for our codebase, implementing forking of contexts sounds not fun.

To make this more specific, we could instead have DialogueResponseFuture, so this is only tied to responses, and not e.g. closing timers or any other stuff.
