### PR TITLE
Check before allocating args for debug logging

### DIFF
--- a/changelog/@unreleased/pr-1578.v2.yml
+++ b/changelog/@unreleased/pr-1578.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Check before allocating args for debug logging
+  links:
+  - https://github.com/palantir/dialogue/pull/1578

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/Reflection.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/Reflection.java
@@ -69,7 +69,9 @@ final class Reflection {
         try {
             return Optional.of(dialogueInterface.getMethod("of", Channel.class, ConjureRuntime.class));
         } catch (NoSuchMethodException e) {
-            log.debug("Failed to get static 'of' method", SafeArg.of("interface", dialogueInterface), e);
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to get static 'of' method", SafeArg.of("interface", dialogueInterface), e);
+            }
             return Optional.empty();
         }
     }
@@ -78,7 +80,9 @@ final class Reflection {
         try {
             return Optional.of(dialogueInterface.getMethod("of", EndpointChannelFactory.class, ConjureRuntime.class));
         } catch (NoSuchMethodException e) {
-            log.debug("Failed to get static 'of' method", SafeArg.of("interface", dialogueInterface), e);
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to get static 'of' method", SafeArg.of("interface", dialogueInterface), e);
+            }
             return Optional.empty();
         }
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -278,11 +278,13 @@ final class QueuedChannel implements Channel {
                             SafeArg.of("channel", channelName),
                             SafeArg.of("service", endpoint.serviceName()),
                             SafeArg.of("endpoint", endpoint.endpointName())))) {
-                        log.debug(
-                                "Queued response has already been completed",
-                                SafeArg.of("channel", channelName),
-                                SafeArg.of("service", endpoint.serviceName()),
-                                SafeArg.of("endpoint", endpoint.endpointName()));
+                        if (log.isDebugEnabled()) {
+                            log.debug(
+                                    "Queued response has already been completed",
+                                    SafeArg.of("channel", channelName),
+                                    SafeArg.of("service", endpoint.serviceName()),
+                                    SafeArg.of("endpoint", endpoint.endpointName()));
+                        }
                     }
                 }
                 return false;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -113,10 +113,12 @@ final class RetryingChannel implements EndpointChannel {
         }
 
         if (cf.mesh() == MeshMode.USE_EXTERNAL_MESH) {
-            log.debug(
-                    "Disabling retrying channel due to MeshMode",
-                    SafeArg.of("channel", cf.channelName()),
-                    SafeArg.of("ignoredMaxNumRetries", clientConf.maxNumRetries()));
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Disabling retrying channel due to MeshMode",
+                        SafeArg.of("channel", cf.channelName()),
+                        SafeArg.of("ignoredMaxNumRetries", clientConf.maxNumRetries()));
+            }
             return channel;
         }
 
@@ -281,12 +283,14 @@ final class RetryingChannel implements EndpointChannel {
                     return scheduleRetry(retryReason, backoffNanoseconds);
                 } else if (log.isDebugEnabled()) {
                     callsiteStacktrace.ifPresent(clientSideThrowable::addSuppressed);
-                    log.debug(
-                            "Not attempting to retry failure. channel: {}, service: {}, endpoint: {}",
-                            SafeArg.of("channelName", channelName),
-                            SafeArg.of("serviceName", endpoint.serviceName()),
-                            SafeArg.of("endpoint", endpoint.endpointName()),
-                            clientSideThrowable);
+                    if (log.isDebugEnabled()) {
+                        log.debug(
+                                "Not attempting to retry failure. channel: {}, service: {}, endpoint: {}",
+                                SafeArg.of("channelName", channelName),
+                                SafeArg.of("serviceName", endpoint.serviceName()),
+                                SafeArg.of("endpoint", endpoint.endpointName()),
+                                clientSideThrowable);
+                    }
                 }
             }
             return Futures.immediateFailedFuture(clientSideThrowable);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentEndpointChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/UserAgentEndpointChannel.java
@@ -69,12 +69,14 @@ final class UserAgentEndpointChannel implements EndpointChannel {
         try {
             return baseAgent.addAgent(UserAgent.Agent.of(endpoint.serviceName(), endpointVersion));
         } catch (IllegalArgumentException e) {
-            log.debug(
-                    "Failed to construct UserAgent for service {} version {}. "
-                            + "This information will not be included",
-                    SafeArg.of("service", endpointService),
-                    SafeArg.of("version", endpointVersion),
-                    e);
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Failed to construct UserAgent for service {} version {}. "
+                                + "This information will not be included",
+                        SafeArg.of("service", endpointService),
+                        SafeArg.of("version", endpointVersion),
+                        e);
+            }
             return baseAgent;
         }
     }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/JacksonEmptyContainerLoader.java
@@ -76,17 +76,21 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
             if (parameter.isPresent()) {
                 return invokeStaticFactoryMethod(method, parameter.get());
             } else {
-                log.debug(
-                        "Found a @JsonCreator, but couldn't construct the parameter",
-                        SafeArg.of("type", type),
-                        SafeArg.of("parameter", parameter));
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Found a @JsonCreator, but couldn't construct the parameter",
+                            SafeArg.of("type", type),
+                            SafeArg.of("parameter", parameter));
+                }
                 return Optional.empty();
             }
         }
 
-        log.debug(
-                "Jackson couldn't instantiate an empty instance and also couldn't find a usable @JsonCreator",
-                SafeArg.of("type", type));
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Jackson couldn't instantiate an empty instance and also couldn't find a usable @JsonCreator",
+                    SafeArg.of("type", type));
+        }
         return Optional.empty();
     }
 
@@ -150,7 +154,9 @@ final class JacksonEmptyContainerLoader implements EmptyContainerDeserializer {
         try {
             return Optional.ofNullable(method.invoke(null, parameter));
         } catch (IllegalAccessException | InvocationTargetException e) {
-            log.debug("Reflection instantiation failed", e);
+            if (log.isDebugEnabled()) {
+                log.debug("Reflection instantiation failed", e);
+            }
             return Optional.empty();
         }
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Some hot paths were allocating a lot of `SafeArg` only used for debug logging, even when debug logging is not enabled.

Example that popped in JFR:
```
SafeArg com.palantir.logsafe.SafeArg.of(String, Object)
Optional com.palantir.conjure.java.dialogue.serde.JacksonEmptyContainerLoader.constructEmptyInstance(Type, TypeMarker, int)
```

## After this PR
==COMMIT_MSG==
Check before allocating args for debug logging
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
