### PR TITLE
Dialogue request and response serializers are cached

### DIFF
--- a/changelog/@unreleased/pr-1586.v2.yml
+++ b/changelog/@unreleased/pr-1586.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue request and response serializers are cached, reducing the
+    cost of sticky sessions which frequently re-create client interfaces
+  links:
+  - https://github.com/palantir/dialogue/pull/1586

--- a/dialogue-serde/build.gradle
+++ b/dialogue-serde/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     testImplementation project(':dialogue-test-common')
     testImplementation project(':dialogue-example')

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.java.dialogue.serde;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.dialogue.BinaryRequestBody;
@@ -47,12 +49,12 @@ final class ConjureBodySerDe implements BodySerDe {
 
     private static final SafeLogger log = SafeLoggerFactory.get(ConjureBodySerDe.class);
     private final List<Encoding> encodingsSortedByWeight;
-    private final ErrorDecoder errorDecoder;
     private final Encoding defaultEncoding;
-    private final EmptyContainerDeserializer emptyContainerDeserializer;
     private final Deserializer<InputStream> binaryInputStreamDeserializer;
     private final Deserializer<Optional<InputStream>> optionalBinaryInputStreamDeserializer;
     private final Deserializer<Void> emptyBodyDeserializer;
+    private final LoadingCache<TypeMarker<?>, Serializer<?>> serializers;
+    private final LoadingCache<TypeMarker<?>, Deserializer<?>> deserializers;
 
     /**
      * Selects the first (based on input order) of the provided encodings that
@@ -65,10 +67,8 @@ final class ConjureBodySerDe implements BodySerDe {
             EmptyContainerDeserializer emptyContainerDeserializer) {
         List<WeightedEncoding> encodings = decorateEncodings(rawEncodings);
         this.encodingsSortedByWeight = sortByWeight(encodings);
-        this.errorDecoder = errorDecoder;
         Preconditions.checkArgument(encodings.size() > 0, "At least one Encoding is required");
         this.defaultEncoding = encodings.get(0).encoding();
-        this.emptyContainerDeserializer = emptyContainerDeserializer;
         this.binaryInputStreamDeserializer = new EncodingDeserializerRegistry<>(
                 ImmutableList.of(BinaryEncoding.INSTANCE),
                 errorDecoder,
@@ -80,6 +80,13 @@ final class ConjureBodySerDe implements BodySerDe {
                 emptyContainerDeserializer,
                 BinaryEncoding.OPTIONAL_MARKER);
         this.emptyBodyDeserializer = new EmptyBodyDeserializer(errorDecoder);
+        // Class unloading: Not supported, Jackson keeps strong references to the types
+        // it sees: https://github.com/FasterXML/jackson-databind/issues/489
+        this.serializers =
+                Caffeine.newBuilder().build(token -> new EncodingSerializerRegistry<>(defaultEncoding, token));
+        this.deserializers = Caffeine.newBuilder()
+                .build(token -> new EncodingDeserializerRegistry<>(
+                        encodingsSortedByWeight, errorDecoder, emptyContainerDeserializer, token));
     }
 
     private static List<WeightedEncoding> decorateEncodings(List<WeightedEncoding> input) {
@@ -99,14 +106,15 @@ final class ConjureBodySerDe implements BodySerDe {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> Serializer<T> serializer(TypeMarker<T> token) {
-        return new EncodingSerializerRegistry<>(defaultEncoding, token);
+        return (Serializer<T>) serializers.get(token);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> Deserializer<T> deserializer(TypeMarker<T> token) {
-        return new EncodingDeserializerRegistry<>(
-                encodingsSortedByWeight, errorDecoder, emptyContainerDeserializer, token);
+        return (Deserializer<T>) deserializers.get(token);
     }
 
     @Override

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
@@ -32,7 +32,8 @@ import java.util.List;
  */
 public final class DefaultConjureRuntime implements ConjureRuntime {
     @VisibleForTesting
-    static final CaffeineSpec DEFAULT_SERDE_CACHE_SPEC = CaffeineSpec.parse("maximumSize=1000,expireAfterAccess=1m");
+    static final CaffeineSpec DEFAULT_SERDE_CACHE_SPEC =
+            CaffeineSpec.parse("maximumSize=1000,expireAfterAccess=1m,softValues");
 
     static final ImmutableList<WeightedEncoding> DEFAULT_ENCODINGS = ImmutableList.of(
             WeightedEncoding.of(Encodings.json(), .9),

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
@@ -33,7 +33,7 @@ import java.util.List;
 public final class DefaultConjureRuntime implements ConjureRuntime {
     @VisibleForTesting
     static final CaffeineSpec DEFAULT_SERDE_CACHE_SPEC =
-            CaffeineSpec.parse("maximumSize=1000,expireAfterAccess=1m,softValues");
+            CaffeineSpec.parse("maximumSize=1000,expireAfterAccess=1m,weakValues");
 
     static final ImmutableList<WeightedEncoding> DEFAULT_ENCODINGS = ImmutableList.of(
             WeightedEncoding.of(Encodings.json(), .9),

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultConjureRuntime.java
@@ -47,7 +47,7 @@ public final class DefaultConjureRuntime implements ConjureRuntime {
                 builder.encodings.isEmpty() ? DEFAULT_ENCODINGS : builder.encodings,
                 ErrorDecoder.INSTANCE,
                 Encodings.emptyContainerDeserializer(),
-                builder.cacheSpec);
+                DEFAULT_SERDE_CACHE_SPEC);
     }
 
     public static Builder builder() {
@@ -73,18 +73,7 @@ public final class DefaultConjureRuntime implements ConjureRuntime {
 
         private final List<WeightedEncoding> encodings = new ArrayList<>();
 
-        private CaffeineSpec cacheSpec = DEFAULT_SERDE_CACHE_SPEC;
-
         private Builder() {}
-
-        /**
-         * Specify the serializer and deserializer cache configuration.
-         */
-        @CanIgnoreReturnValue
-        public Builder serializerCacheSpecification(String specification) {
-            cacheSpec = CaffeineSpec.parse(specification);
-            return this;
-        }
 
         @CanIgnoreReturnValue
         public Builder encodings(Encoding value) {

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/BinaryEncodingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/BinaryEncodingTest.java
@@ -35,7 +35,8 @@ public class BinaryEncodingTest {
         BodySerDe serializers = new ConjureBodySerDe(
                 ImmutableList.of(WeightedEncoding.of(new ConjureBodySerDeTest.StubEncoding("application/json"))),
                 ErrorDecoder.INSTANCE,
-                Encodings.emptyContainerDeserializer());
+                Encodings.emptyContainerDeserializer(),
+                DefaultConjureRuntime.DEFAULT_SERDE_CACHE_SPEC);
         InputStream deserialized = serializers.inputStreamDeserializer().deserialize(response);
         assertThat(deserialized.available()).isEqualTo(0);
         CloseRecordingInputStream rawInputStream = response.body();
@@ -58,7 +59,8 @@ public class BinaryEncodingTest {
         BodySerDe serializers = new ConjureBodySerDe(
                 ImmutableList.of(WeightedEncoding.of(new ConjureBodySerDeTest.StubEncoding("application/json"))),
                 ErrorDecoder.INSTANCE,
-                Encodings.emptyContainerDeserializer());
+                Encodings.emptyContainerDeserializer(),
+                DefaultConjureRuntime.DEFAULT_SERDE_CACHE_SPEC);
         Optional<InputStream> maybe =
                 serializers.optionalInputStreamDeserializer().deserialize(response);
         assertThat(maybe).isPresent();

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -75,7 +75,8 @@ public class ConjureBodySerDeTest {
                         .map(c -> WeightedEncoding.of(new StubEncoding(c)))
                         .collect(ImmutableList.toImmutableList()),
                 errorDecoder,
-                Encodings.emptyContainerDeserializer());
+                Encodings.emptyContainerDeserializer(),
+                DefaultConjureRuntime.DEFAULT_SERDE_CACHE_SPEC);
     }
 
     @Test
@@ -113,7 +114,8 @@ public class ConjureBodySerDeTest {
         BodySerDe serializers = new ConjureBodySerDe(
                 ImmutableList.of(WeightedEncoding.of(plain, .5), WeightedEncoding.of(json, 1)),
                 ErrorDecoder.INSTANCE,
-                Encodings.emptyContainerDeserializer());
+                Encodings.emptyContainerDeserializer(),
+                DefaultConjureRuntime.DEFAULT_SERDE_CACHE_SPEC);
         // first encoding is default
         RequestBody body = serializers.serializer(TYPE).serialize("test");
         assertThat(body.contentType()).isEqualTo(plain.getContentType());
@@ -173,7 +175,8 @@ public class ConjureBodySerDeTest {
         BodySerDe serializers = new ConjureBodySerDe(
                 ImmutableList.of(WeightedEncoding.of(BrokenEncoding.INSTANCE)),
                 ErrorDecoder.INSTANCE,
-                Encodings.emptyContainerDeserializer());
+                Encodings.emptyContainerDeserializer(),
+                DefaultConjureRuntime.DEFAULT_SERDE_CACHE_SPEC);
         assertThatThrownBy(() -> serializers.deserializer(TYPE).deserialize(response))
                 .isInstanceOf(SafeRuntimeException.class)
                 .hasMessage("brokenEncoding is broken");

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsTest.java
@@ -79,7 +79,10 @@ public final class DefaultClientsTest {
 
     private Response response = new TestResponse();
     private BodySerDe bodySerde = new ConjureBodySerDe(
-            DefaultConjureRuntime.DEFAULT_ENCODINGS, ErrorDecoder.INSTANCE, Encodings.emptyContainerDeserializer());
+            DefaultConjureRuntime.DEFAULT_ENCODINGS,
+            ErrorDecoder.INSTANCE,
+            Encodings.emptyContainerDeserializer(),
+            DefaultConjureRuntime.DEFAULT_SERDE_CACHE_SPEC);
     private final SettableFuture<Response> responseFuture = SettableFuture.create();
     private final ListeningExecutorService executor =
             MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());

--- a/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
@@ -50,6 +50,23 @@ public abstract class TypeMarker<T> {
     }
 
     @Override
+    public final boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other instanceof TypeMarker) {
+            TypeMarker<?> that = (TypeMarker<?>) other;
+            return type.equals(that.type);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return type.hashCode();
+    }
+
+    @Override
     public final String toString() {
         return "TypeMarker{type=" + type + '}';
     }


### PR DESCRIPTION
This allows instances to be reused when multiple endpoints
consume or return the same type. More importantly, this reduces
the cost of sticky channels where client instances are recreated.

## After this PR
==COMMIT_MSG==
Dialogue request and response serializers are cached, reducing the cost of sticky sessions which frequently re-create client interfaces
==COMMIT_MSG==