### PR TITLE
Respect Retry-After header in 429 and 503 responses

### DIFF
--- a/changelog/@unreleased/pr-1595.v2.yml
+++ b/changelog/@unreleased/pr-1595.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue now clients now respect the Retry-After header in 429 and
+    503 responses.
+  links:
+  - https://github.com/palantir/dialogue/pull/1595


### PR DESCRIPTION
Not sure whether this omission was intentional or whether we just never got around to implementing it.

## Before this PR
Dialogue does not respect the `Retry-After` header on 429 and 503 responses. Retried requests always use the next exponential backoff.

## After this PR
Dialogue respect the `Retry-After` header on 429 and 503 responses. If a `Retry-After` header is present, that backoff values will be used instead of the exponential backoff value.