### PR TITLE
Sticky sessions reuse metric references

### DIFF
--- a/changelog/@unreleased/pr-1619.v2.yml
+++ b/changelog/@unreleased/pr-1619.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Sticky sessions reuse metric references for better performance
+  links:
+  - https://github.com/palantir/dialogue/pull/1619


### PR DESCRIPTION
Previously these would be re-loaded from the metric registry
for each session (which are created very frequently). By reusing
metric references, we avoid MetricName creation, hashing,
and registry (concurrenthashmap) traversal.

## After this PR
==COMMIT_MSG==
Sticky sessions reuse metric references for better performance
==COMMIT_MSG==