### PR TITLE
Java 11 clients use TLSv1.3 in addition to TLSv1.2

### DIFF
--- a/changelog/@unreleased/pr-1629.v2.yml
+++ b/changelog/@unreleased/pr-1629.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Java 11 clients use TLSv1.3 in addition to TLSv1.2
+  links:
+  - https://github.com/palantir/dialogue/pull/1629

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/TlsProtocols.java
@@ -16,26 +16,14 @@
 
 package com.palantir.dialogue.hc5;
 
-import com.google.common.primitives.Ints;
-
 /** Internal utility functionality to slowly roll out new TLS protocol support. */
 final class TlsProtocols {
 
-    private static final boolean JAVA_15_OR_LATER = isJava15OrLater();
     private static final String TLS_V1_2 = "TLSv1.2";
     private static final String TLS_V1_3 = "TLSv1.3";
 
     static String[] get() {
-        if (JAVA_15_OR_LATER) {
-            return new String[] {TLS_V1_3, TLS_V1_2};
-        } else {
-            return new String[] {TLS_V1_2};
-        }
-    }
-
-    private static boolean isJava15OrLater() {
-        Integer version = Ints.tryParse(System.getProperty("java.specification.version"));
-        return version != null && version >= 15;
+        return new String[] {TLS_V1_3, TLS_V1_2};
     }
 
     private TlsProtocols() {}


### PR DESCRIPTION
Previously TLSv1.3 was gated on JDK-15+ due to issues in early
releases of java 11. These have been resolved in later releases,
at this point we want to allow all clients to use modern protocols
to give us the option to remove TLSv1.2 support as early as possible
in case vulnerabilities are discovered.

Background:
https://webtide.com/openjdk-11-and-tls-1-3-issues/ describes the original issues we ran into
Tracked by https://bugs.openjdk.java.net/browse/JDK-8213202
Fixed in jdk12, and backported to jdk11 (11.0.3) here:
https://bugs.openjdk.java.net/browse/JDK-8218094
https://www.oracle.com/java/technologies/javase/11-0-3-relnotes.html

## After this PR
==COMMIT_MSG==
Java 11 clients use TLSv1.3 in addition to TLSv1.2
==COMMIT_MSG==
