### PR TITLE
Support request compression using the `compress-request` endpoint tag

### DIFF
--- a/changelog/@unreleased/pr-1708.v2.yml
+++ b/changelog/@unreleased/pr-1708.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support request compression using the `compress-request` endpoint tag
+  links:
+  - https://github.com/palantir/dialogue/pull/1708

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentEncodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentEncodingChannel.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentEncodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentEncodingChannel.java
@@ -126,6 +126,7 @@ final class ContentEncodingChannel implements EndpointChannel {
      * Specialized implementation of {@link GZIPOutputStream} which uses {@link Deflater#BEST_SPEED} to reduce
      * CPU utilization with a slight cost to compression ratio.
      */
+    @SuppressWarnings("FilterOutputStreamSlowMultibyteWrite") // false positive
     private static final class BestSpeedGzipOutputStream extends GZIPOutputStream {
 
         BestSpeedGzipOutputStream(OutputStream out) throws IOException {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentEncodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentEncodingChannel.java
@@ -1,0 +1,146 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.net.HttpHeaders;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestBody;
+import com.palantir.dialogue.Response;
+import com.palantir.logsafe.Preconditions;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.zip.Deflater;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Adds support for transparently encoding sending <code>Content-Encoding: gzip</code> requests
+ * in a client agnostic way based on a Conjure endpoint tag. This requires prior knowledge that
+ * the remote server is capable of handling compressed data.
+ */
+final class ContentEncodingChannel implements EndpointChannel {
+
+    private static final String ENABLEMENT_TAG = "compress-request";
+    private static final String GZIP = "gzip";
+    private static final int BUFFER_SIZE = 8 * 1024;
+
+    private final EndpointChannel delegate;
+
+    /** Wraps a delegate if the endpoint has opted into request compression. */
+    static EndpointChannel of(EndpointChannel delegate, Endpoint endpoint) {
+        if (endpoint.tags().contains(ENABLEMENT_TAG)) {
+            return new ContentEncodingChannel(delegate);
+        }
+        return delegate;
+    }
+
+    ContentEncodingChannel(EndpointChannel delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "Channel is required");
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Request request) {
+        Request augmentedRequest = wrap(request);
+        return delegate.execute(augmentedRequest);
+    }
+
+    static Request wrap(Request request) {
+        Optional<RequestBody> body = request.body();
+        if (body.isEmpty()
+                || request.headerParams().containsKey(HttpHeaders.CONTENT_ENCODING)
+                || request.headerParams().containsKey(HttpHeaders.CONTENT_LENGTH)) {
+            // Do not replace existing content-encoding values
+            return request;
+        }
+        return Request.builder()
+                .from(request)
+                .putHeaderParams(HttpHeaders.CONTENT_ENCODING, GZIP)
+                .body(new ContentEncodingRequestBody(body.get()))
+                .build();
+    }
+
+    private static final class ContentEncodingRequestBody implements RequestBody {
+
+        private final RequestBody delegate;
+
+        ContentEncodingRequestBody(RequestBody delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void writeTo(OutputStream output) throws IOException {
+            try (OutputStream gzipOutput = new BestSpeedGzipOutputStream(output);
+                    // Buffer inputs to the compressor to reduce native interaction overhead
+                    OutputStream bufferedOutput = new BufferedOutputStream(gzipOutput, BUFFER_SIZE)) {
+                delegate.writeTo(bufferedOutput);
+            }
+        }
+
+        @Override
+        public String contentType() {
+            return delegate.contentType();
+        }
+
+        @Override
+        public boolean repeatable() {
+            return delegate.repeatable();
+        }
+
+        @Override
+        public OptionalLong contentLength() {
+            // When content is compressed, the content-length is mutated.
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        @Override
+        public String toString() {
+            return "ContentEncodingRequestBody{" + delegate + '}';
+        }
+    }
+
+    /**
+     * Specialized implementation of {@link GZIPOutputStream} which uses {@link Deflater#BEST_SPEED} to reduce
+     * CPU utilization with a slight cost to compression ratio.
+     */
+    private static final class BestSpeedGzipOutputStream extends GZIPOutputStream {
+
+        BestSpeedGzipOutputStream(OutputStream out) throws IOException {
+            super(out, BUFFER_SIZE);
+            def.setLevel(Deflater.BEST_SPEED);
+        }
+
+        @Override
+        public String toString() {
+            return "BestSpeedGzipOutputStream{" + out + '}';
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ContentEncodingChannel{" + delegate + '}';
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -182,6 +182,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                         channel, endpoint, cf.clientConf().userAgent().get());
                 channel = DeprecationWarningChannel.create(cf, channel, endpoint);
                 channel = new ContentDecodingChannel(channel);
+                channel = ContentEncodingChannel.of(channel, endpoint);
                 channel = TracedChannel.create(cf, channel, endpoint);
                 if (ChannelToEndpointChannel.isConstant(endpoint)) {
                     // Avoid producing metrics for non-constant endpoints which may produce

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentEncodingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentEncodingChannelTest.java
@@ -129,6 +129,7 @@ class ContentEncodingChannelTest {
                 return "1.2.3";
             }
 
+            @Override
             public Set<String> tags() {
                 return ImmutableSet.of("compress-request");
             }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentEncodingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentEncodingChannelTest.java
@@ -1,0 +1,186 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestBody;
+import com.palantir.dialogue.TestEndpoint;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.zip.GZIPInputStream;
+import org.junit.jupiter.api.Test;
+
+class ContentEncodingChannelTest {
+
+    @Test
+    void testCompression() {
+        byte[] expected = "Hello".getBytes(StandardCharsets.UTF_8);
+        Request request = Request.builder()
+                .body(new RequestBody() {
+                    @Override
+                    public void writeTo(OutputStream output) throws IOException {
+                        output.write(expected);
+                    }
+
+                    @Override
+                    public String contentType() {
+                        return "text/plain";
+                    }
+
+                    @Override
+                    public boolean repeatable() {
+                        return true;
+                    }
+
+                    @Override
+                    public OptionalLong contentLength() {
+                        return OptionalLong.of(expected.length);
+                    }
+
+                    @Override
+                    public void close() {}
+                })
+                .build();
+        Request wrapped = ContentEncodingChannel.wrap(request);
+        assertThat(wrapped.body()).hasValueSatisfying(body -> {
+            assertThat(body.contentLength()).isEmpty();
+            assertThat(inflate(content(body))).isEqualTo(expected);
+        });
+    }
+
+    @Test
+    void testNoBody() {
+        Request request = Request.builder().build();
+        Request wrapped = ContentEncodingChannel.wrap(request);
+        assertThat(wrapped).isSameAs(request);
+    }
+
+    @Test
+    void testContentEncodingExists() {
+        Request request = Request.builder()
+                .putHeaderParams("Content-Encoding", "identity")
+                .body(StubBody.INSTANCE)
+                .build();
+        Request wrapped = ContentEncodingChannel.wrap(request);
+        assertThat(wrapped).isSameAs(request);
+    }
+
+    @Test
+    void testContentLengthExistsOutsideBody() {
+        // This case shouldn't be supported in any way, however
+        // it's best to handle unexpected cases gracefully.
+        Request request = Request.builder()
+                .putHeaderParams("Content-Length", "123")
+                .body(StubBody.INSTANCE)
+                .build();
+        Request wrapped = ContentEncodingChannel.wrap(request);
+        assertThat(wrapped).isSameAs(request);
+    }
+
+    @Test
+    void testChannelCreationWithTag() {
+        EndpointChannel delegate = _req -> Futures.immediateCancelledFuture();
+        EndpointChannel result = ContentEncodingChannel.of(delegate, new Endpoint() {
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.POST;
+            }
+
+            @Override
+            public String serviceName() {
+                return "service";
+            }
+
+            @Override
+            public String endpointName() {
+                return "endpoint";
+            }
+
+            @Override
+            public String version() {
+                return "1.2.3";
+            }
+
+            public Set<String> tags() {
+                return ImmutableSet.of("compress-request");
+            }
+        });
+        assertThat(result).isNotSameAs(delegate);
+    }
+
+    @Test
+    void testChannelCreationWithoutTag() {
+        EndpointChannel delegate = _req -> Futures.immediateCancelledFuture();
+        EndpointChannel result = ContentEncodingChannel.of(delegate, TestEndpoint.POST);
+        assertThat(result).isSameAs(delegate);
+    }
+
+    private static byte[] content(RequestBody body) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            body.writeTo(baos);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] inflate(byte[] data) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(bais)) {
+            return ByteStreams.toByteArray(gzipInputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private enum StubBody implements RequestBody {
+        INSTANCE;
+
+        @Override
+        public void writeTo(OutputStream output) throws IOException {
+            output.write("test".getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String contentType() {
+            return "text/plain";
+        }
+
+        @Override
+        public boolean repeatable() {
+            return false;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
Using the `compress-request` tag signifies prior knowledge that the
remote server supports GZIP content-encoding on request bodies.
Unlike response compression, there is no form of negotiation.

This is associated with individual endpoints, regardless of the content type (json/smile/octet-stream/etc). I considered a custom implementation such that small requests are not compressed while large requests are, however there are two drawback which make it less desirable:
1. More complex to write (the request must be partially buffered until a threshold is reached, then either compressed, or sent)
2. Due to the lack of negotiation, this may fail against some servers. Tests _generally_ use small inputs which are not likely to reach a compression threshold, thus may not expose potential failures if such a threshold exists.

==COMMIT_MSG==
Support request compression using the `compress-request` endpoint tag
==COMMIT_MSG==

## Possible downsides?
Requires prior knowledge. Our standard webserver provides this guarantee, however conjure is much broader than our reference implementation, thus the feature may be used on an opt-in basis.