### PR TITLE
Disable socks system proxy auto-detect if not specified

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -480,9 +480,9 @@ public final class ApacheHttpClientChannels {
                             new InstrumentedHostnameVerifier(
                                     new DefaultHostnameVerifier(), name, conf.taggedMetricRegistry())) {
                         @Override
-                        public Socket createSocket(final HttpContext context) throws IOException {
+                        public Socket createSocket(final HttpContext _context) {
                             return socksProxyAddress == null
-                                    ? super.createSocket(context)
+                                    ? new Socket(Proxy.NO_PROXY)
                                     : new Socket(new Proxy(Proxy.Type.SOCKS, socksProxyAddress));
                         }
                     };
@@ -491,9 +491,9 @@ public final class ApacheHttpClientChannels {
                     RegistryBuilder.<ConnectionSocketFactory>create()
                             .register(URIScheme.HTTP.id, new PlainConnectionSocketFactory() {
                                 @Override
-                                public Socket createSocket(final HttpContext context) throws IOException {
+                                public Socket createSocket(final HttpContext _context) {
                                     return socksProxyAddress == null
-                                            ? super.createSocket(context)
+                                            ? new Socket(Proxy.NO_PROXY)
                                             : new Socket(new Proxy(Proxy.Type.SOCKS, socksProxyAddress));
                                 }
                             })


### PR DESCRIPTION
## Before this PR
super.createSocket(context) calls new Socket(). This defaults to a SocksSocketImpl [here](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.base/share/classes/java/net/Socket.java#L505). In #connect, this grabs the default system proxy selector if a proxy was not set ([here](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.base/share/classes/java/net/SocksSocketImpl.java#L367)).
We've started out with a proxy selector from the client configuration that returned no proxy, and ended up using the system default one.
I don't think this behaviour matches that of an HTTP proxy either which won't default to the system one.

## After this PR
==COMMIT_MSG==
When no proxy is set, respect this instead of defaulting to the system socks proxy.
==COMMIT_MSG==

## Possible downsides?
None I believe. It is still possible to use the system socks proxy if that is the desired behaviour, by passing in the system ProxySelector in the configuration. This is the default behaviour in ClientConfiguration when no proxy is provided, so the default behaviour will stay the same after this PR.
