### PR TITLE
Disable socks system proxy auto-detect if not specified

### DIFF
--- a/changelog/@unreleased/pr-1713.v2.yml
+++ b/changelog/@unreleased/pr-1713.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable socks system proxy auto-detect if not specified
+  links:
+  - https://github.com/palantir/dialogue/pull/1713


### PR DESCRIPTION
Credit to @rtxv15 for #1711 which I've re-created without a fork to allow CI to run in a standard way.

The SSLSocketFactory creates plain sockets by default using
`new Socket()` rather than specifying `NO_PROXY` in cases that
a proxy is not expected. We explictly avoid using proxy controls
set at the jvm level for non-socks proxies, and never intentionally
used socks proxies from the jvm in dialogue. Socks proxies
are used for testing in some cases, but not in any production
environments, thus the risk introduced by this change is minimal.

==COMMIT_MSG==
Disable socks system proxy auto-detect if not specified
==COMMIT_MSG==