### PR TITLE
Retryer differentiates 308 status QoSException and non-QosException

### DIFF
--- a/changelog/@unreleased/pr-1714.v2.yml
+++ b/changelog/@unreleased/pr-1714.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Retryer differentiates 308 status QoSException and non-QosException
+  links:
+  - https://github.com/palantir/dialogue/pull/1714

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -15,13 +15,18 @@
  */
 package com.palantir.dialogue.core;
 
+import com.google.common.net.HttpHeaders;
 import com.palantir.dialogue.Response;
 
 /** Utility functionality for {@link Response} handling. */
 final class Responses {
 
     static boolean isRetryOther(Response response) {
-        return response.code() == 308;
+        // Note that a 308 status may be a non-retryable signal, for instance google sometimes
+        // uses a '308 Resume Incomplete', so we must verify the presence of a Location header
+        // to differentiate the two.
+        return response.code() == 308
+                && response.getFirstHeader(HttpHeaders.LOCATION).isPresent();
     }
 
     static boolean isTooManyRequests(Response response) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/PinUntilErrorNodeSelectionStrategyChannelTest.java
@@ -272,6 +272,7 @@ public class PinUntilErrorNodeSelectionStrategyChannelTest {
     }
 
     private static Response response(int status) {
-        return TestResponse.withBody(null).code(status);
+        TestResponse result = TestResponse.withBody(null).code(status);
+        return status == 308 ? result.withHeader("Location", "https://localhost") : result;
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryOtherValidatingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryOtherValidatingChannelTest.java
@@ -72,6 +72,12 @@ public final class RetryOtherValidatingChannelTest {
         verifyNoInteractions(failureReporter);
     }
 
+    @Test
+    public void testDoesNotReportMissingLocation() {
+        execute(null);
+        verifyNoInteractions(failureReporter);
+    }
+
     private void execute(@Nullable String retryOtherUri) {
         RetryOtherValidatingChannel channel = new RetryOtherValidatingChannel(
                 delegate,


### PR DESCRIPTION
Distinction is based on the presence of a `Location` header. Note
that the default error decoder still requires strictly conjure
spec, logging an error in the case of a 308 without location info,
however non-conjure dialogue-annotations clients bring their own
error decoders to handle expected cases.

==COMMIT_MSG==
Retryer differentiates 308 status QoSException and non-QosException
==COMMIT_MSG==
