### PR TITLE
Dialogue response body stream safety

### DIFF
--- a/changelog/@unreleased/pr-1740.v2.yml
+++ b/changelog/@unreleased/pr-1740.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue response body stream safety improvements to prevent accidental
+    stream reuse and confusing warnings.
+  links:
+  - https://github.com/palantir/dialogue/pull/1740

--- a/dialogue-apache-hc5-client/build.gradle
+++ b/dialogue-apache-hc5-client/build.gradle
@@ -24,4 +24,6 @@ dependencies {
     testImplementation project(':dialogue-serde')
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+    testRuntimeOnly 'org.apache.logging.log4j:log4j-core'
 }

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.dialogue.hc5;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multimaps;
@@ -264,6 +265,9 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
         @Nullable
         private ListMultimap<String, String> headers;
 
+        @Nullable
+        private InputStream responseBody;
+
         HttpClientResponse(
                 ApacheHttpClientChannels.CloseableClient client,
                 CloseableHttpResponse response,
@@ -275,10 +279,19 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
 
         @Override
         public InputStream body() {
+            InputStream snapshot = this.responseBody;
+            if (snapshot == null) {
+                snapshot = createResponseBody();
+                this.responseBody = snapshot;
+            }
+            return snapshot;
+        }
+
+        private InputStream createResponseBody() {
             HttpEntity entity = response.getEntity();
             if (entity != null) {
                 try {
-                    return new ResponseInputStream(client, entity.getContent(), this);
+                    return new ResponseInputStream(entity.getContent(), this);
                 } catch (IOException e) {
                     throw new SafeRuntimeException("Failed to get response stream", e);
                 }
@@ -339,6 +352,9 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                                             clientSnapshot.clientConfiguration().taggedMetricRegistry())
                                     .connectionClosedPartiallyConsumedResponse(clientSnapshot.name())
                                     .mark();
+                            // Important not to call response.close which still has access to the underlying
+                            // socket channel, which may be in use by another exchange.
+                            return;
                         }
                     }
                     response.close();
@@ -346,6 +362,10 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                     log.warn("Failed to close response", e);
                 }
             }
+        }
+
+        boolean isOpen() {
+            return client != null;
         }
 
         @Override
@@ -455,37 +475,73 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
 
     private static final class ResponseInputStream extends FilterInputStream {
 
-        // Client reference is used to prevent premature termination
-        @Nullable
-        private ApacheHttpClientChannels.CloseableClient client;
-
         private final HttpClientResponse response;
 
-        ResponseInputStream(
-                @Nullable ApacheHttpClientChannels.CloseableClient client,
-                InputStream stream,
-                HttpClientResponse response) {
+        ResponseInputStream(InputStream stream, HttpClientResponse response) {
             super(stream);
-            this.client = client;
             this.response = response;
         }
 
         @Override
-        public void close() throws IOException {
-            try {
-                try {
-                    response.close();
-                } finally {
-                    super.close();
-                }
-            } finally {
-                client = null;
+        public int read() throws IOException {
+            checkOpen();
+            return super.read();
+        }
+
+        @Override
+        public int read(byte[] buffer) throws IOException {
+            checkOpen();
+            return super.read(buffer);
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) throws IOException {
+            checkOpen();
+            return super.read(buffer, off, len);
+        }
+
+        @Override
+        public long skip(long num) throws IOException {
+            checkOpen();
+            return super.skip(num);
+        }
+
+        @Override
+        public void close() {
+            if (response.isOpen()) {
+                response.close();
+                // no need to close the delegate stream itself, closing the response is sufficient
+                // to release resources.
+            }
+        }
+
+        private void checkOpen() throws IOException {
+            if (!response.isOpen()) {
+                throw new DialogueStreamClosedException();
             }
         }
 
         @Override
         public String toString() {
-            return "ResponseInputStream{client=" + client + ", in=" + in + '}';
+            return "ResponseInputStream{" + in + '}';
+        }
+    }
+
+    private static final class DialogueStreamClosedException extends IOException implements SafeLoggable {
+        private static final String MESSAGE = "Response has already been closed";
+
+        DialogueStreamClosedException() {
+            super(MESSAGE);
+        }
+
+        @Override
+        public String getLogMessage() {
+            return MESSAGE;
+        }
+
+        @Override
+        public List<Arg<?>> getArgs() {
+            return ImmutableList.of();
         }
     }
 }

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -352,8 +352,8 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                                             clientSnapshot.clientConfiguration().taggedMetricRegistry())
                                     .connectionClosedPartiallyConsumedResponse(clientSnapshot.name())
                                     .mark();
-                            // Important not to call response.close which still has access to the underlying
-                            // socket channel, which may be in use by another exchange.
+                            // Do not call response.close which internally attempts to drain the response
+                            // because the underlying resources have already been closed.
                             return;
                         }
                     }

--- a/dialogue-apache-hc5-client/src/test/resources/log4j2-test.xml
+++ b/dialogue-apache-hc5-client/src/test/resources/log4j2-test.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %p [%t] %c - %msg%n%ex"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## Before this PR
Warnings logged when the response body was closed before fully consuming content due to a `runtime.discardEndpoint()` followed by `response.close()` which internally attempts to consume remaining data from a stream that has been disconnected.

## After this PR
==COMMIT_MSG==
Dialogue response body stream safety improvements to prevent accidental stream reuse and confusing warnings.
==COMMIT_MSG==