### PR TITLE
Add diamonds when initializing ErrorHandlingDeserializingFactory

### DIFF
--- a/changelog/@unreleased/pr-1776.v2.yml
+++ b/changelog/@unreleased/pr-1776.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Add diamonds when initializing ErrorHandlingDeserializingFactory in
+    generated code
+  links:
+  - https://github.com/palantir/dialogue/pull/1776

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -166,7 +166,7 @@ public final class ServiceImplementationGenerator {
                 ParameterizedTypeName.get(ClassName.get(Deserializer.class), innerType);
 
         CodeBlock realDeserializer = CodeBlock.of(
-                "new $T(new $T(), new $T()).deserializerFor(new $T<$T>() {})",
+                "new $T<>(new $T(), new $T()).deserializerFor(new $T<$T>() {})",
                 ErrorHandlingDeserializerFactory.class,
                 deserializerFactoryType,
                 errorDecoderType,

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -46,14 +46,14 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
 
             private final EndpointChannel greetChannel = endpointChannelFactory.endpoint(Endpoints.greet);
 
-            private final Deserializer<String> greetDeserializer = new ErrorHandlingDeserializerFactory(
+            private final Deserializer<String> greetDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new Json(), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<String>() {});
 
             private final EndpointChannel getGreetingAsyncChannel =
                     endpointChannelFactory.endpoint(Endpoints.getGreetingAsync);
 
-            private final Deserializer<String> getGreetingAsyncDeserializer = new ErrorHandlingDeserializerFactory(
+            private final Deserializer<String> getGreetingAsyncDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new CustomStringDeserializer(), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<String>() {});
 
@@ -66,7 +66,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             private final EndpointChannel customResponseChannel =
                     endpointChannelFactory.endpoint(Endpoints.customResponse);
 
-            private final Deserializer<Response> customResponseDeserializer = new ErrorHandlingDeserializerFactory(
+            private final Deserializer<Response> customResponseDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new ResponseDeserializer(), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<Response>() {});
 


### PR DESCRIPTION
## Before this PR
Compiler emits an unchecked call warning in the generated code.

## After this PR
==COMMIT_MSG==
Add diamonds when initializing ErrorHandlingDeserializingFactory in generated code
==COMMIT_MSG==

## Possible downsides?
Don't think there's any.
