### PR TITLE
Stricter compilation in annotation processor test

### DIFF
--- a/changelog/@unreleased/pr-1777.v2.yml
+++ b/changelog/@unreleased/pr-1777.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Enable stricter compilation flags in annotation processor test. No
+    user facing change.
+  links:
+  - https://github.com/palantir/dialogue/pull/1777

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -109,6 +109,8 @@ public final class DialogueRequestAnnotationsProcessorTest {
             return Compiler.javac()
                     // This is required because this tool does not know about our gradle setting.
                     .withOptions("-source", "11")
+                    .withOptions("-Werror")
+                    .withOptions("-Xlint:unchecked")
                     .withProcessors(new DialogueRequestAnnotationsProcessor())
                     .compile(JavaFileObjects.forResource(clazzPath.toUri().toURL()));
         } catch (MalformedURLException e) {


### PR DESCRIPTION
## Before this PR
FLUP for https://github.com/palantir/dialogue/pull/1776
Our annotation processor can generate code which may have compiler warnings. 

## After this PR
We can enforce that doesn't happen by setting the appropriate compiler flags in the test.

==COMMIT_MSG==
Enable stricter compilation flags in annotation processor test. No user facing change.
==COMMIT_MSG==

## Possible downsides?
Don't think so.
