### PR TITLE
Support alias parameter types

### DIFF
--- a/changelog/@unreleased/pr-1782.v2.yml
+++ b/changelog/@unreleased/pr-1782.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Dialogue annotations now supports alias parameter types.
+  links:
+  - https://github.com/palantir/dialogue/pull/1782

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyAliasType.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyAliasType.java
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-package com.palantir.myservice.service;
+package com.palantir.myservice.example;
 
-public final class MyCustomParamType {
+import org.immutables.value.Value;
 
-    private final String value;
-
-    public MyCustomParamType(String value) {
-        this.value = value;
-    }
-
-    public String value() {
-        return value;
-    }
+@Value.Immutable
+public interface MyAliasType {
+    @Value.Parameter
+    String get();
 }

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomType.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomType.java
@@ -16,11 +16,11 @@
 
 package com.palantir.myservice.example;
 
-public final class MyCustomParamType {
+public final class MyCustomType {
 
     private final String value;
 
-    public MyCustomParamType(String value) {
+    public MyCustomType(String value) {
         this.value = value;
     }
 

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomTypeParamEncoder.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyCustomTypeParamEncoder.java
@@ -16,13 +16,11 @@
 
 package com.palantir.myservice.example;
 
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
-import com.palantir.dialogue.annotations.MultimapParamEncoder;
+import com.palantir.dialogue.annotations.ParamEncoder;
 
-public final class MyCustomMultimapEncoder implements MultimapParamEncoder<MyCustomType> {
+public final class MyCustomTypeParamEncoder implements ParamEncoder<MyCustomType> {
     @Override
-    public Multimap<String, String> toParamValues(MyCustomType value) {
-        return ImmutableMultimap.of("value-from-multimap", value.value());
+    public String toParamValue(MyCustomType value) {
+        return value.value();
     }
 }

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MySerializableType.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MySerializableType.java
@@ -22,5 +22,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableMySerializableType.class)
 public interface MySerializableType {
+    @Value.Parameter
     String value();
 }

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MySerializableTypeBodySerializer.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MySerializableTypeBodySerializer.java
@@ -28,7 +28,7 @@ public final class MySerializableTypeBodySerializer extends StdSerializer<MySeri
 
     private static final Serializer<MySerializableType> SERIALIZER = new Json(
                     new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT))
-            .serializerFor(new TypeMarker<MySerializableType>() {});
+            .serializerFor(new TypeMarker<>() {});
 
     @Override
     public RequestBody serialize(MySerializableType value) {

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -30,7 +30,6 @@ import com.palantir.myservice.example.PutFileRequest.PutFileRequestSerializer;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.UUID;
 
 @DialogueService(MyServiceDialogueServiceFactory.class)
@@ -67,19 +66,23 @@ public interface MyService {
     @Request(method = HttpMethod.PUT, path = "/custom/request2", errorDecoder = AlwaysThrowErrorDecoder.class)
     void customVoidErrorDecoder();
 
-    @Request(method = HttpMethod.POST, path = "/params/{myPathParam}/{myPathParam2}")
+    @SuppressWarnings("TooManyArguments")
+    @Request(method = HttpMethod.POST, path = "/params/{path1}/{path2}")
     void params(
-            @Request.QueryParam("q") String query,
+            @Request.QueryParam("q1") String query1,
             // Lists of primitive types are supported for @QueryParam and @Header
-            @Request.QueryParam("q1") List<String> query1,
+            @Request.QueryParam("q2") List<String> query2,
+            // Optionals of primitive types are supported for @QueryParam and @Header
+            @Request.QueryParam("q3") Optional<String> query3,
+            // Alias types are supported for @QueryParam and @Header
+            @Request.QueryParam("q4") MyAliasType query4,
             // Path parameter variable name must match the request path component
-            @Request.PathParam UUID myPathParam,
-            @Request.PathParam(encoder = MyCustomParamTypeEncoder.class) MyCustomParamType myPathParam2,
-            @Request.Header("Custom-Header") int requestHeaderValue,
-            // Headers can be optional
-            @Request.Header("Custom-Optional-Header") OptionalInt maybeRequestHeaderValue,
-            // Optional lists of primitives are supported too!
-            @Request.Header("Custom-Optional-Header1") Optional<List<Integer>> maybeRequestHeaderValue1,
+            @Request.PathParam UUID path1,
+            @Request.PathParam(encoder = MyCustomTypeParamEncoder.class) MyCustomType path2,
+            @Request.Header("h1") String header1,
+            @Request.Header("h2") List<String> header2,
+            @Request.Header("h3") Optional<String> header3,
+            @Request.Header("h4") MyAliasType header4,
             // Can supply a map to fill in arbitrary query values
             @Request.QueryMap(encoder = MapToMultimapParamEncoder.class) Map<String, String> queryParams,
             // Custom encoding classes may be provided for the request and response.
@@ -93,7 +96,7 @@ public interface MyService {
             // or you can supply a multimap directly
             @Request.QueryMap Multimap<String, String> multiQueryParams,
             // or you can supply a custom converter
-            @Request.QueryMap(encoder = MyCustomMultimapEncoder.class) MyCustomParamType myParamToMultimap);
+            @Request.QueryMap(encoder = MyCustomMultimapEncoder.class) MyCustomType myParamToMultimap);
 
     @Request(method = HttpMethod.POST, path = "/multipart")
     void multipart(@Request.Body(PutFileRequestSerializer.class) PutFileRequest request);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
@@ -17,7 +17,6 @@
 package com.palantir.dialogue.annotations.processor.data;
 
 import com.squareup.javapoet.TypeName;
-import java.util.Optional;
 import org.derive4j.Data;
 import org.immutables.value.Value;
 
@@ -25,13 +24,15 @@ import org.immutables.value.Value;
 public interface ArgumentType {
     interface Cases<R> {
         /** Should be handled by {@link com.palantir.dialogue.annotations.ParameterSerializer}. */
-        R primitive(TypeName javaTypeName, String parameterSerializerMethodName, Optional<TypeName> listInnerType);
+        R primitive(TypeName javaTypeName, String parameterSerializerMethodName);
 
-        R rawRequestBody(TypeName requestBodyType);
+        R list(TypeName javaTypeName, String parameterSerializerMethodName);
+
+        R alias(TypeName javaTypeName, String parameterSerializerMethodName);
 
         R optional(TypeName optionalJavaType, OptionalType optionalType);
 
-        R mapType(TypeName javaTypeName);
+        R rawRequestBody(TypeName requestBodyType);
 
         R customType(TypeName customTypeName);
     }
@@ -45,6 +46,6 @@ public interface ArgumentType {
 
         String valueGetMethodName();
 
-        ArgumentType underlyingType();
+        ArgumentType innerType();
     }
 }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/EndpointDefinitions.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/EndpointDefinitions.java
@@ -86,10 +86,10 @@ public final class EndpointDefinitions {
     }
 
     private Optional<ArgumentDefinition> getArgumentDefinition(EndpointName endpointName, VariableElement param) {
-        Optional<ArgumentType> argumentType = argumentTypesResolver.getArgumentType(param);
+        ArgumentType argumentType = argumentTypesResolver.getArgumentType(param);
         Optional<ParameterType> parameterType = paramTypesResolver.getParameterType(endpointName, param);
 
-        if (argumentType.isEmpty() || parameterType.isEmpty()) {
+        if (parameterType.isEmpty()) {
             return Optional.empty();
         }
 
@@ -98,7 +98,7 @@ public final class EndpointDefinitions {
 
         return Optional.of(ImmutableArgumentDefinition.builder()
                 .argName(ImmutableArgumentName.of(param.getSimpleName().toString()))
-                .argType(argumentType.get())
+                .argType(argumentType)
                 .paramType(parameterType.get())
                 .build());
     }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
@@ -178,14 +178,18 @@ public final class ParamTypesResolver {
 
         if (encoderTypeName.isPresent() && listEncoderTypeName.isPresent()) {
             context.reportError("Only one of encoder and listEncoder can be set", variableElement);
-
             return Optional.empty();
         }
 
         if (encoderTypeName.isPresent()) {
             return getParameterEncoder(endpointName, variableElement, encoderTypeName, encoderTypeAndMethod);
         }
-        return getParameterEncoder(endpointName, variableElement, listEncoderTypeName, listEncoderTypeAndMethod);
+
+        if (listEncoderTypeName.isPresent()) {
+            return getParameterEncoder(endpointName, variableElement, listEncoderTypeName, listEncoderTypeAndMethod);
+        }
+
+        return Optional.empty();
     }
 
     private Optional<ParameterEncoderType> getParameterEncoder(

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyAliasType.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyAliasType.java
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package com.palantir.myservice.example;
+package com.palantir.myservice.service;
 
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
-import com.palantir.dialogue.annotations.MultimapParamEncoder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
 
-public final class MyCustomMultimapEncoder implements MultimapParamEncoder<MyCustomType> {
-    @Override
-    public Multimap<String, String> toParamValues(MyCustomType value) {
-        return ImmutableMultimap.of("value-from-multimap", value.value());
-    }
+@Value.Immutable
+@JsonSerialize(as = ImmutableMySerializableType.class)
+public interface MyAliasType {
+    String get();
 }

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomStringParamEncoder.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomStringParamEncoder.java
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-package com.palantir.myservice.example;
+package com.palantir.myservice.service;
 
+import com.palantir.dialogue.annotations.ListParamEncoder;
 import com.palantir.dialogue.annotations.ParamEncoder;
+import java.util.Collections;
+import java.util.List;
 
-public final class MyCustomParamTypeEncoder implements ParamEncoder<MyCustomParamType> {
+public final class MyCustomStringParamEncoder implements ParamEncoder<String>, ListParamEncoder<String> {
     @Override
-    public String toParamValue(MyCustomParamType value) {
-        return value.value();
+    public String toParamValue(String value) {
+        return value;
+    }
+
+    @Override
+    public List<String> toParamValues(String value) {
+        return Collections.singletonList(value);
     }
 }

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomType.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomType.java
@@ -16,19 +16,15 @@
 
 package com.palantir.myservice.service;
 
-import com.palantir.dialogue.annotations.ListParamEncoder;
-import com.palantir.dialogue.annotations.ParamEncoder;
-import java.util.Collections;
-import java.util.List;
+public final class MyCustomType {
 
-public final class MyCustomStringParameterEncoder implements ParamEncoder<String>, ListParamEncoder<String> {
-    @Override
-    public String toParamValue(String value) {
-        return value;
+    private final String value;
+
+    public MyCustomType(String value) {
+        this.value = value;
     }
 
-    @Override
-    public List<String> toParamValues(String value) {
-        return Collections.singletonList(value);
+    public String value() {
+        return value;
     }
 }

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomTypeParamEncoder.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyCustomTypeParamEncoder.java
@@ -21,15 +21,14 @@ import com.palantir.dialogue.annotations.ParamEncoder;
 import java.util.Collections;
 import java.util.List;
 
-public final class MyCustomParamTypeParameterEncoder
-        implements ParamEncoder<MyCustomParamType>, ListParamEncoder<MyCustomParamType> {
+public final class MyCustomTypeParamEncoder implements ParamEncoder<MyCustomType>, ListParamEncoder<MyCustomType> {
     @Override
-    public String toParamValue(MyCustomParamType value) {
+    public String toParamValue(MyCustomType value) {
         return value.value();
     }
 
     @Override
-    public List<String> toParamValues(MyCustomParamType value) {
+    public List<String> toParamValues(MyCustomType value) {
         return Collections.singletonList(value.value());
     }
 }

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
@@ -21,12 +21,12 @@ import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.annotations.Request;
-import com.palantir.dialogue.annotations.ToStringParamEncoder;
 import com.palantir.tokens.auth.AuthHeader;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.UUID;
 
 // Annotation processor is not invoked directly here.
@@ -63,33 +63,31 @@ public interface MyService {
     @Request(method = HttpMethod.PUT, path = "/custom/request1")
     Response customResponse();
 
-    @Request(method = HttpMethod.POST, path = "/params/{myPathParam}/{myPathParam2}")
+    @Request(method = HttpMethod.POST, path = "/params/{path1}/{path2}")
     void params(
-            @Request.QueryParam("q") String query,
-            @Request.QueryParam(value = "q1", encoder = MyCustomParamTypeParameterEncoder.class)
-                    MyCustomParamType query1,
-            @Request.QueryParam(value = "q2", encoder = MyCustomParamTypeParameterEncoder.class)
-                    Optional<MyCustomParamType> query2,
-            @Request.QueryParam(value = "q3", encoder = MyCustomStringParameterEncoder.class) String query3,
-            @Request.QueryParam(value = "q4", encoder = MyCustomStringParameterEncoder.class) Optional<String> query4,
-            @Request.QueryParam(value = "q5") List<String> query5,
-            @Request.QueryParam(value = "q6") Optional<List<String>> query6,
-            // Path parameter variable name must match the request path component
-            @Request.PathParam UUID myPathParam,
-            @Request.PathParam(encoder = MyCustomParamTypeParameterEncoder.class) MyCustomParamType myPathParam2,
-            @Request.Header("Custom-Header") int requestHeaderValue,
-            // Headers can be optional
-            @Request.Header("Custom-Optional-Header1") Optional<String> maybeCustomOptionalHeader1Value,
-            @Request.Header("Custom-Optional-Header2") OptionalInt maybeCustomOptionalHeader2Value,
-            @Request.Header(value = "Custom-Optional-Header3", encoder = MyCustomParamTypeParameterEncoder.class)
-                    Optional<MyCustomParamType> maybeCustomOptionalHeader3Value,
-            @Request.Header("Custom-Header1") List<String> customListHeader,
-            @Request.Header("Custom-Optional-Header3") Optional<List<String>> customOptionalListHeader,
-            @Request.Header(value = "Custom-To-String-Header", encoder = ToStringParamEncoder.class)
-                    BigInteger bigInteger,
-            // Custom encoding classes may be provided for the request and response.
-            // JSON should be easiest (default?).
-            // By changing this to MySpecialJson.class you can have
-            // it's own object mapper; this is same as BodySerDe in dialogue
+            @Request.QueryParam("q1") String query1,
+            @Request.QueryParam("q2") Optional<String> query2,
+            @Request.QueryParam("q3") OptionalInt query3,
+            @Request.QueryParam("q4") OptionalLong query4,
+            @Request.QueryParam("q5") OptionalDouble query5,
+            @Request.QueryParam("q6") List<String> query6,
+            @Request.QueryParam("q7") MyAliasType query7,
+            @Request.QueryParam(value = "q8", encoder = MyCustomTypeParamEncoder.class) MyCustomType query8,
+            @Request.QueryParam(value = "q9", encoder = MyCustomTypeParamEncoder.class) Optional<MyCustomType> query9,
+            @Request.QueryParam(value = "q10", encoder = MyCustomStringParamEncoder.class) String query10,
+            @Request.QueryParam(value = "q11", encoder = MyCustomStringParamEncoder.class) Optional<String> query11,
+            @Request.PathParam UUID path1,
+            @Request.PathParam(encoder = MyCustomTypeParamEncoder.class) MyCustomType path2,
+            @Request.Header("h1") String header1,
+            @Request.Header("h2") Optional<String> header2,
+            @Request.Header("h3") OptionalInt header3,
+            @Request.Header("h4") OptionalLong header4,
+            @Request.Header("h5") OptionalDouble header5,
+            @Request.Header("h6") List<String> header6,
+            @Request.Header("h7") MyAliasType header7,
+            @Request.Header(value = "h8", encoder = MyCustomTypeParamEncoder.class) MyCustomType header8,
+            @Request.Header(value = "h9", encoder = MyCustomTypeParamEncoder.class) Optional<MyCustomType> header9,
+            @Request.Header(value = "h10", encoder = MyCustomStringParamEncoder.class) String header10,
+            @Request.Header(value = "h11", encoder = MyCustomStringParamEncoder.class) Optional<String> header11,
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);
 }

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -22,15 +22,15 @@ import com.palantir.dialogue.annotations.ErrorHandlingVoidDeserializer;
 import com.palantir.dialogue.annotations.Json;
 import com.palantir.dialogue.annotations.ParameterSerializer;
 import com.palantir.dialogue.annotations.ResponseDeserializer;
-import com.palantir.dialogue.annotations.ToStringParamEncoder;
 import com.palantir.tokens.auth.AuthHeader;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.Void;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.processing.Generated;
@@ -70,23 +70,23 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                             new ResponseDeserializer(), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<Response>() {});
 
-            private final MyCustomParamTypeParameterEncoder paramsQuery1Encoder =
-                    new MyCustomParamTypeParameterEncoder();
+            private final MyCustomTypeParamEncoder paramsQuery8Encoder = new MyCustomTypeParamEncoder();
 
-            private final MyCustomParamTypeParameterEncoder paramsQuery2Encoder =
-                    new MyCustomParamTypeParameterEncoder();
+            private final MyCustomTypeParamEncoder paramsQuery9Encoder = new MyCustomTypeParamEncoder();
 
-            private final MyCustomStringParameterEncoder paramsQuery3Encoder = new MyCustomStringParameterEncoder();
+            private final MyCustomStringParamEncoder paramsQuery10Encoder = new MyCustomStringParamEncoder();
 
-            private final MyCustomStringParameterEncoder paramsQuery4Encoder = new MyCustomStringParameterEncoder();
+            private final MyCustomStringParamEncoder paramsQuery11Encoder = new MyCustomStringParamEncoder();
 
-            private final MyCustomParamTypeParameterEncoder paramsMyPathParam2Encoder =
-                    new MyCustomParamTypeParameterEncoder();
+            private final MyCustomTypeParamEncoder paramsPath2Encoder = new MyCustomTypeParamEncoder();
 
-            private final MyCustomParamTypeParameterEncoder paramsMaybeCustomOptionalHeader3ValueEncoder =
-                    new MyCustomParamTypeParameterEncoder();
+            private final MyCustomTypeParamEncoder paramsHeader8Encoder = new MyCustomTypeParamEncoder();
 
-            private final ToStringParamEncoder paramsBigIntegerEncoder = new ToStringParamEncoder();
+            private final MyCustomTypeParamEncoder paramsHeader9Encoder = new MyCustomTypeParamEncoder();
+
+            private final MyCustomStringParamEncoder paramsHeader10Encoder = new MyCustomStringParamEncoder();
+
+            private final MyCustomStringParamEncoder paramsHeader11Encoder = new MyCustomStringParamEncoder();
 
             private final Serializer<MySerializableType> paramsSerializer =
                     new MySerializableTypeBodySerializer().serializerFor(new TypeMarker<MySerializableType>() {});
@@ -126,78 +126,88 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
 
             @Override
             public void params(
-                    String query,
-                    MyCustomParamType query1,
-                    Optional<MyCustomParamType> query2,
-                    String query3,
-                    Optional<String> query4,
-                    List<String> query5,
-                    Optional<List<String>> query6,
-                    UUID myPathParam,
-                    MyCustomParamType myPathParam2,
-                    int requestHeaderValue,
-                    Optional<String> maybeCustomOptionalHeader1Value,
-                    OptionalInt maybeCustomOptionalHeader2Value,
-                    Optional<MyCustomParamType> maybeCustomOptionalHeader3Value,
-                    List<String> customListHeader,
-                    Optional<List<String>> customOptionalListHeader,
-                    BigInteger bigInteger,
+                    String query1,
+                    Optional<String> query2,
+                    OptionalInt query3,
+                    OptionalLong query4,
+                    OptionalDouble query5,
+                    List<String> query6,
+                    MyAliasType query7,
+                    MyCustomType query8,
+                    Optional<MyCustomType> query9,
+                    String query10,
+                    Optional<String> query11,
+                    UUID path1,
+                    MyCustomType path2,
+                    String header1,
+                    Optional<String> header2,
+                    OptionalInt header3,
+                    OptionalLong header4,
+                    OptionalDouble header5,
+                    List<String> header6,
+                    MyAliasType header7,
+                    MyCustomType header8,
+                    Optional<MyCustomType> header9,
+                    String header10,
+                    Optional<String> header11,
                     MySerializableType body) {
                 Request.Builder _request = Request.builder();
-                _request.putQueryParams("q", _parameterSerializer.serializeString(query));
-                _request.putAllQueryParams("q1", paramsQuery1Encoder.toParamValues(query1));
+                _request.putQueryParams("q1", _parameterSerializer.serializeString(query1));
                 if (query2.isPresent()) {
-                    _request.putAllQueryParams("q2", paramsQuery2Encoder.toParamValues(query2.get()));
+                    _request.putQueryParams("q2", _parameterSerializer.serializeString(query2.get()));
                 }
-                _request.putAllQueryParams("q3", paramsQuery3Encoder.toParamValues(query3));
+                if (query3.isPresent()) {
+                    _request.putQueryParams("q3", _parameterSerializer.serializeInteger(query3.getAsInt()));
+                }
                 if (query4.isPresent()) {
-                    _request.putAllQueryParams("q4", paramsQuery4Encoder.toParamValues(query4.get()));
+                    _request.putQueryParams("q4", _parameterSerializer.serializeLong(query4.getAsLong()));
+                }
+                if (query5.isPresent()) {
+                    _request.putQueryParams("q5", _parameterSerializer.serializeDouble(query5.getAsDouble()));
                 }
                 _request.putAllQueryParams(
-                        "q5",
-                        query5.stream()
+                        "q6",
+                        query6.stream()
                                 .map(_parameterSerializer::serializeString)
                                 .collect(Collectors.toList()));
-                if (query6.isPresent()) {
-                    _request.putAllQueryParams(
-                            "q6",
-                            query6.get().stream()
-                                    .map(_parameterSerializer::serializeString)
-                                    .collect(Collectors.toList()));
+                _request.putQueryParams("q7", _parameterSerializer.serializeString(query7.get()));
+                _request.putAllQueryParams("q8", paramsQuery8Encoder.toParamValues(query8));
+                if (query9.isPresent()) {
+                    _request.putAllQueryParams("q9", paramsQuery9Encoder.toParamValues(query9.get()));
                 }
-                _request.putPathParams("myPathParam", _parameterSerializer.serializeUuid(myPathParam));
-                _request.putPathParams("myPathParam2", paramsMyPathParam2Encoder.toParamValue(myPathParam2));
-                _request.putHeaderParams("Custom-Header", _parameterSerializer.serializeInteger(requestHeaderValue));
-                if (maybeCustomOptionalHeader1Value.isPresent()) {
-                    _request.putHeaderParams(
-                            "Custom-Optional-Header1",
-                            _parameterSerializer.serializeString(maybeCustomOptionalHeader1Value.get()));
+                _request.putAllQueryParams("q10", paramsQuery10Encoder.toParamValues(query10));
+                if (query11.isPresent()) {
+                    _request.putAllQueryParams("q11", paramsQuery11Encoder.toParamValues(query11.get()));
                 }
-                if (maybeCustomOptionalHeader2Value.isPresent()) {
-                    _request.putHeaderParams(
-                            "Custom-Optional-Header2",
-                            _parameterSerializer.serializeInteger(maybeCustomOptionalHeader2Value.getAsInt()));
+                _request.putPathParams("path1", _parameterSerializer.serializeUuid(path1));
+                _request.putPathParams("path2", paramsPath2Encoder.toParamValue(path2));
+                _request.putHeaderParams("h1", _parameterSerializer.serializeString(header1));
+                if (header2.isPresent()) {
+                    _request.putHeaderParams("h2", _parameterSerializer.serializeString(header2.get()));
                 }
-                if (maybeCustomOptionalHeader3Value.isPresent()) {
-                    _request.putAllHeaderParams(
-                            "Custom-Optional-Header3",
-                            paramsMaybeCustomOptionalHeader3ValueEncoder.toParamValues(
-                                    maybeCustomOptionalHeader3Value.get()));
+                if (header3.isPresent()) {
+                    _request.putHeaderParams("h3", _parameterSerializer.serializeInteger(header3.getAsInt()));
+                }
+                if (header4.isPresent()) {
+                    _request.putHeaderParams("h4", _parameterSerializer.serializeLong(header4.getAsLong()));
+                }
+                if (header5.isPresent()) {
+                    _request.putHeaderParams("h5", _parameterSerializer.serializeDouble(header5.getAsDouble()));
                 }
                 _request.putAllHeaderParams(
-                        "Custom-Header1",
-                        customListHeader.stream()
+                        "h6",
+                        header6.stream()
                                 .map(_parameterSerializer::serializeString)
                                 .collect(Collectors.toList()));
-                if (customOptionalListHeader.isPresent()) {
-                    _request.putAllHeaderParams(
-                            "Custom-Optional-Header3",
-                            customOptionalListHeader.get().stream()
-                                    .map(_parameterSerializer::serializeString)
-                                    .collect(Collectors.toList()));
+                _request.putHeaderParams("h7", _parameterSerializer.serializeString(header7.get()));
+                _request.putAllHeaderParams("h8", paramsHeader8Encoder.toParamValues(header8));
+                if (header9.isPresent()) {
+                    _request.putAllHeaderParams("h9", paramsHeader9Encoder.toParamValues(header9.get()));
                 }
-                _request.putAllHeaderParams(
-                        "Custom-To-String-Header", paramsBigIntegerEncoder.toParamValues(bigInteger));
+                _request.putAllHeaderParams("h10", paramsHeader10Encoder.toParamValues(header10));
+                if (header11.isPresent()) {
+                    _request.putAllHeaderParams("h11", paramsHeader11Encoder.toParamValues(header11.get()));
+                }
                 _request.body(paramsSerializer.serialize(body));
                 runtime.clients().callBlocking(paramsChannel, _request.build(), paramsDeserializer);
             }
@@ -328,8 +338,8 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
         params {
             private final PathTemplate pathTemplate = PathTemplate.builder()
                     .fixed("params")
-                    .variable("myPathParam")
-                    .variable("myPathParam2")
+                    .variable("path1")
+                    .variable("path2")
                     .build();
 
             @Override


### PR DESCRIPTION
This is particularly useful if you have Conjure alias types you'd like to use in a Dialogue annotations interface. But it works for any types that have a `get` method which returns a Conjure primitive type.

This can be viewed as the counterpart to the Conjure Undertow annotations feature to [find a static factory decoder method](https://github.com/palantir/conjure-java/blob/b68a179b34e52a05495b9b9b795f6113b9a8ece7/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java#L372-L393).

The consequential changes are in `ArgumentTypesResolver` - most of rest is just cleaning up some of the tests.