### PR TITLE
Modulate response output writes to 16KiB blocks

### DIFF
--- a/changelog/@unreleased/pr-1790.v2.yml
+++ b/changelog/@unreleased/pr-1790.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Modulate response output writes to 16KiB blocks
+
+    Block size of 16 KB is small enough to allow cipher implementations to become hot and optimize properly when given large inputs. Otherwise large array writes into a javax.crypto.CipherOutputStream fail to use intrinsified implementations. If 16 KB blocks aren't enough to produce hot methods, the I/O is small and infrequent enough that performance isn't relevant.  For more information, see the details around com.sun.crypto.provider.GHASH::processBlocks in
+    https://github.com/palantir/hadoop-crypto/pull/586#issuecomment-964394587
+  links:
+  - https://github.com/palantir/dialogue/pull/1790

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -509,6 +509,11 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                 remaining -= toWrite;
             }
         }
+
+        @Override
+        public void write(int value) throws IOException {
+            out.write(value);
+        }
     }
 
     private static final class ResponseInputStream extends FilterInputStream {


### PR DESCRIPTION
## Before this PR
When Dialogue would execute `RequestBody#writeTo`, a `RequestBody` implementation may attempt to write a large buffer to the resulting output stream causing suboptimal cipher throughput due to the large size.

See https://github.com/palantir/hadoop-crypto/pull/586 & https://github.com/palantir/hadoop-crypto/pull/587

## After this PR
==COMMIT_MSG==
Modulate response output writes to 16KiB blocks

Block size of 16 KB is small enough to allow cipher implementations to become hot and optimize properly when given large inputs. Otherwise large array writes into a javax.crypto.CipherOutputStream fail to use intrinsified implementations. If 16 KB blocks aren't enough to produce hot methods, the I/O is small and infrequent enough that performance isn't relevant.  For more information, see the details around com.sun.crypto.provider.GHASH::processBlocks in
https://github.com/palantir/hadoop-crypto/pull/586#issuecomment-964394587
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
