### PR TITLE
Check available before trying to read

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -389,7 +389,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             InputStream stream = entity.getContent();
             // Fast check: The stream has been fully exhausted in the expected case,
             // no need to create buffers for drainage unless we know there's data to drain.
-            if (stream.read() == -1) {
+            if (stream.available() == 0 || stream.read() == -1) {
                 return false;
             }
             return REMAINING_CONTENT_CONNECTION_DISCARD_THRESHOLD


### PR DESCRIPTION
## Before this PR
Timelock is seeing a number of `StreamClosedException`s from `com.palantir.dialogue.hc5.ApacheHttpClientBlockingChannel.hasSubstantialRemainingData(CloseableHttpResponse):392`

![image](https://user-images.githubusercontent.com/54594/208227189-108808a0-df50-40da-b448-ecd20eb2217b.png)


## After this PR
==COMMIT_MSG==
Check available before trying to read
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
