### PR TITLE
Warn against BinaryRequestBody footgun

### DIFF
--- a/changelog/@unreleased/pr-1842.v2.yml
+++ b/changelog/@unreleased/pr-1842.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Warn against BinaryRequestBody footgun
+  links:
+  - https://github.com/palantir/dialogue/pull/1842

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -95,7 +95,6 @@ public final class DialogueRequestAnnotationsProcessorTest {
     public void testCannotUseConjureRequestBody() {
         Compilation compilation = compileTestClass(TEST_CLASSES_BASE_DIR, UsesBinaryRequestBody.class);
         assertThat(compilation).hadErrorContaining("prefer the more expressive RequestBody type");
-        assertThat(compilation).hadErrorCount(1);
     }
 
     private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -30,6 +30,7 @@ import com.palantir.myservice.service.MultipleParamAnnotations;
 import com.palantir.myservice.service.MyService;
 import com.palantir.myservice.service.RequestAnnotatedClass;
 import com.palantir.myservice.service.UnparseableHttpPath;
+import com.palantir.myservice.service.UsesBinaryRequestBody;
 import com.palantir.myservice.service.WrongFactoryAnnotation;
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,6 +89,13 @@ public final class DialogueRequestAnnotationsProcessorTest {
                 .inFile(compilation.sourceFiles().get(0))
                 .onLineContaining("String greet(@Request.PathParam String greeting)");
         assertThat(compilation).hadErrorCount(2);
+    }
+
+    @Test
+    public void testCannotUseConjureRequestBody() {
+        Compilation compilation = compileTestClass(TEST_CLASSES_BASE_DIR, UsesBinaryRequestBody.class);
+        assertThat(compilation).hadErrorContaining("prefer the more expressive RequestBody type");
+        assertThat(compilation).hadErrorCount(1);
     }
 
     private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/UsesBinaryRequestBody.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/UsesBinaryRequestBody.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.service;
+
+import com.palantir.dialogue.BinaryRequestBody;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.annotations.Request;
+
+// Annotation processor is not invoked directly here.
+// @DialogueService(MyServiceDialogueServiceFactory.class)
+public interface UsesBinaryRequestBody {
+
+    @Request(method = HttpMethod.PUT, path = "/conjure/binary/request")
+    void conjureBinaryRequest(@Request.Body BinaryRequestBody requestBody);
+}


### PR DESCRIPTION
Currently, using BinaryRequestBody uses the custom-type json codepath, resulting in all values being serialized as an octet-stream of `{}` :disappointed:. It's not obvious that BinaryRequestBody isn't supported by the dialogue annotation processor.

RequestBody is more expressive, and works as expected. The annotation processor was designed to solve cases that conjure isn't meant for, where the BinaryRequestBody is specific to conjure semantics.
In a future change, we may opt to implement BinaryRequestBody out of the box.

## After this PR
==COMMIT_MSG==
Warn against BinaryRequestBody footgun
==COMMIT_MSG==
