### PR TITLE
Validate path params

### DIFF
--- a/changelog/@unreleased/pr-1886.v2.yml
+++ b/changelog/@unreleased/pr-1886.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: '`dialogue-annotations-processor` now validates that the path template
+    parameters match the `@PathParam` method parameters.'
+  links:
+  - https://github.com/palantir/dialogue/pull/1886

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -26,9 +26,12 @@ import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.myservice.service.MismatchedPathParam;
 import com.palantir.myservice.service.MultipleParamAnnotations;
 import com.palantir.myservice.service.MyService;
 import com.palantir.myservice.service.RequestAnnotatedClass;
+import com.palantir.myservice.service.UnmatchedPathParam;
+import com.palantir.myservice.service.UnmatchedPathTemplateParam;
 import com.palantir.myservice.service.UnparseableHttpPath;
 import com.palantir.myservice.service.UsesBinaryRequestBody;
 import com.palantir.myservice.service.WrongFactoryAnnotation;
@@ -95,6 +98,24 @@ public final class DialogueRequestAnnotationsProcessorTest {
     public void testCannotUseConjureRequestBody() {
         Compilation compilation = compileTestClass(TEST_CLASSES_BASE_DIR, UsesBinaryRequestBody.class);
         assertThat(compilation).hadErrorContaining("prefer the more expressive RequestBody type");
+    }
+
+    @Test
+    public void mismatchedPathParam() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, MismatchedPathParam.class))
+                .hadErrorContaining("Path template parameters do not match method path parameters");
+    }
+
+    @Test
+    public void unmatchedPathParam() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, UnmatchedPathParam.class))
+                .hadErrorContaining("Path template parameters do not match method path parameters");
+    }
+
+    @Test
+    public void unmatchedPathTemplateParam() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, UnmatchedPathTemplateParam.class))
+                .hadErrorContaining("Path template parameters do not match method path parameters");
     }
 
     private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MismatchedPathParam.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MismatchedPathParam.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.service;
+
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.annotations.Request;
+
+public interface MismatchedPathParam {
+    @Request(method = HttpMethod.GET, path = "/{param1}")
+    String mismatchedPathParam(@Request.PathParam String param2);
+}

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/UnmatchedPathParam.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/UnmatchedPathParam.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.service;
+
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.annotations.Request;
+
+public interface UnmatchedPathParam {
+    @Request(method = HttpMethod.GET, path = "/")
+    String unmatchedPathParam(@Request.PathParam String param);
+}

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/UnmatchedPathTemplateParam.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/UnmatchedPathTemplateParam.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.service;
+
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.annotations.Request;
+
+public interface UnmatchedPathTemplateParam {
+    @Request(method = HttpMethod.GET, path = "/{param}")
+    String unmatchedPathTemplateParam();
+}


### PR DESCRIPTION
Similar to https://github.com/palantir/conjure-java/pull/1876, but for Dialogue.

## Before this PR

`dialogue-annotations-processor` does not validate that the path template parameters match the `@PathParam` method parameters.

## After this PR

`dialogue-annotations-processor` validates that the path template parameters match the `@PathParam` method parameters.