### PR TITLE
Fix Request's accept HTTP code range comment

### DIFF
--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
@@ -48,7 +48,7 @@ public @interface Request {
 
     /**
      * Response body {@link Deserializer}. By default this deserializer is only used for successful
-     * (i.e. {@code 300 <= response.code() <= 599}) responses.
+     * (i.e. {@code 200 <= response.code() < 300}) responses.
      *
      * @return class that implements a zero-arg constructor to be used to deserialize the response
      */


### PR DESCRIPTION
## Before this PR
The dialogue annotation `Request` class has a comment that indicates the `accept` deserializer factory is used upon successful responses, but indicates http codes for these being `300 <= code =< 599`

## After this PR
==COMMIT_MSG==
Fix Request's accept HTTP code range comment
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
