### PR TITLE
Dialogue attempts not to retain context classloaders

### DIFF
--- a/changelog/@unreleased/pr-1912.v2.yml
+++ b/changelog/@unreleased/pr-1912.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue attempts not to retain context classloaders
+  links:
+  - https://github.com/palantir/dialogue/pull/1912

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/CleanerSupport.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/CleanerSupport.java
@@ -16,17 +16,15 @@
 
 package com.palantir.dialogue.hc5;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.lang.ref.Cleaner;
 import java.lang.ref.Cleaner.Cleanable;
 
 /** Reflective shim to allow consumers on new runtime versions to take advantage of java.lang.ref.Cleaner. */
 final class CleanerSupport {
 
-    private static final Cleaner cleaner = Cleaner.create(new ThreadFactoryBuilder()
-            .setDaemon(true)
-            .setNameFormat("dialogue-cleaner-%d")
-            .build());
+    // Ideally we would use a name pattern like 'dialogue-cleaner-%d', however it's more important
+    // that this cleaner does not retain context classloader references.
+    private static final Cleaner cleaner = Cleaner.create();
 
     /** Arguments are passed to {@code java.lang.ref.Cleaner.register(Object, Runnable)}. */
     static Cleanable register(Object object, Runnable action) {

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ScheduledIdleConnectionEvictor.java
@@ -17,7 +17,6 @@
 package com.palantir.dialogue.hc5;
 
 import com.google.common.base.Suppliers;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.dialogue.core.DialogueExecutors;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -46,10 +45,7 @@ final class ScheduledIdleConnectionEvictor {
                     SharedTaggedMetricRegistries.getSingleton(),
                     DialogueExecutors.newSharedSingleThreadScheduler(MetricRegistries.instrument(
                             SharedTaggedMetricRegistries.getSingleton(),
-                            new ThreadFactoryBuilder()
-                                    .setNameFormat(EXECUTOR_NAME + "-%d")
-                                    .setDaemon(true)
-                                    .build(),
+                            DialogueExecutors.newDaemonThreadFactory(EXECUTOR_NAME),
                             EXECUTOR_NAME)),
                     EXECUTOR_NAME));
 

--- a/dialogue-blocking-channels/build.gradle
+++ b/dialogue-blocking-channels/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     api project(':dialogue-target')
     api 'com.google.guava:guava'
     implementation project(':dialogue-futures')
+    implementation project(':dialogue-core')
     implementation 'com.palantir.tracing:tracing'
     implementation 'com.palantir.tritium:tritium-metrics'
     implementation 'com.palantir.safe-logging:logger'

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
@@ -76,10 +75,7 @@ final class RetryingChannel implements EndpointChannel {
     static final Supplier<ScheduledExecutorService> sharedScheduler =
             Suppliers.memoize(() -> DialogueExecutors.newSharedSingleThreadScheduler(MetricRegistries.instrument(
                     SharedTaggedMetricRegistries.getSingleton(),
-                    new ThreadFactoryBuilder()
-                            .setNameFormat(SCHEDULER_NAME + "-%d")
-                            .setDaemon(true)
-                            .build(),
+                    DialogueExecutors.newDaemonThreadFactory(SCHEDULER_NAME),
                     SCHEDULER_NAME)));
 
     @SuppressWarnings("UnnecessaryLambda") // no allocations


### PR DESCRIPTION
Dialogue didn't behave well in systems using classloaders which must be unloaded later.

## After this PR
==COMMIT_MSG==
Dialogue attempts not to retain context classloaders
==COMMIT_MSG==

## Possible downsides?
The cleaner thread is no longer named something that points to dialogue. We could use the same ThreadFactory utility that I adopted elsewhere, however the cleaner is the most important thread to clean up (the others will expire) and the default constructor uses an internal `InnocuousThread` implementation which does an even better job of avoiding holding external references.
