### PR TITLE
Handle annotation processing quirk in eclipse

### DIFF
--- a/changelog/@unreleased/pr-1917.v2.yml
+++ b/changelog/@unreleased/pr-1917.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    <!-- User-facing outcomes this PR delivers -->
+    Fix annotation processing error in eclipse
+  links:
+  - https://github.com/palantir/dialogue/pull/1917

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
@@ -182,6 +182,10 @@ public final class DialogueRequestAnnotationsProcessor extends AbstractProcessor
                                 if (typeName.equals(expectedGenerated)) {
                                     return null;
                                 }
+                                if (typeName.equals(generatedClass.name)) {
+                                    // Eclipse will give back the wrong type name in the initial round.
+                                    return null;
+                                }
                                 TypeElement factoryElement =
                                         elements.getTypeElement(DialogueServiceFactory.class.getName());
                                 if (factoryElement == null) {


### PR DESCRIPTION
In eclipse, when a file is initially created, the class name will not be the fully qualified name because it hasn't been evaluated yet. This prevents a compilation error.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
In eclipse, sometimes there will be a compilation error that never goes away.

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
Fix annotation processing error in eclipse 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None. The code already does not support a lack of package name:
```
String expectedGenerated = serviceInterface.packageName() + '.' + generatedClass.name;
```