### PR TITLE
Eagerly throw on null request parameters

### DIFF
--- a/changelog/@unreleased/pr-1920.v2.yml
+++ b/changelog/@unreleased/pr-1920.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Eagerly throw on null request parameters (header names, query parameter
+    names and values, path parameter names and values) to provide helpful stack traces
+    into user code when null values are inserted into the Request builder instead
+    of stack traces that just point to Dialogue's async threads.
+  links:
+  - https://github.com/palantir/dialogue/pull/1920

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -205,18 +204,12 @@ public final class Request {
         }
 
         public Request.Builder putAllHeaderParams(Multimap<String, ? extends String> entries) {
-            if (entries.containsKey(null)) {
-                throw new SafeNullPointerException("Header name must not be null");
-            }
             mutableHeaderParams().putAll(entries);
             return this;
         }
 
         public Request.Builder putQueryParams(String key, String... values) {
             Preconditions.checkNotNull(key, "Query parameter name must not be null");
-            for (String value : values) {
-                Preconditions.checkNotNull(value, "Query parameter value must not be null");
-            }
             mutableQueryParams().putAll(key, Arrays.asList(values));
             return this;
         }
@@ -242,18 +235,11 @@ public final class Request {
 
         public Request.Builder putAllQueryParams(String key, Iterable<String> values) {
             Preconditions.checkNotNull(key, "Query parameter name must not be null");
-            for (String value : values) {
-                Preconditions.checkNotNull(value, "Query parameter value must not be null");
-            }
             mutableQueryParams().putAll(key, values);
             return this;
         }
 
         public Request.Builder putAllQueryParams(Multimap<String, ? extends String> entries) {
-            entries.forEach((key, value) -> {
-                Preconditions.checkNotNull(key, "Query parameter name must not be null");
-                Preconditions.checkNotNull(value, "Query parameter value must not be null");
-            });
             mutableQueryParams().putAll(entries);
             return this;
         }
@@ -279,27 +265,16 @@ public final class Request {
 
         public Request.Builder putAllPathParams(String key, Iterable<String> values) {
             Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
-            for (String value : values) {
-                Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
-            }
             mutablePathParams().putAll(key, values);
             return this;
         }
 
         public Request.Builder putAllPathParams(Map<String, ? extends String> entries) {
-            entries.forEach((key, value) -> {
-                Preconditions.checkNotNull(key, "Path parameter name must not be null");
-                Preconditions.checkNotNull(value, "Path parameter value must not be null");
-            });
             entries.forEach(mutablePathParams()::put);
             return this;
         }
 
         public Request.Builder putAllPathParams(Multimap<String, ? extends String> entries) {
-            entries.forEach((key, value) -> {
-                Preconditions.checkNotNull(key, "Path parameter name must not be null");
-                Preconditions.checkNotNull(value, "Path parameter value must not be null");
-            });
             mutablePathParams().putAll(entries);
             return this;
         }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -187,6 +188,7 @@ public final class Request {
         }
 
         public Request.Builder putHeaderParams(String key, String value) {
+            Preconditions.checkArgumentNotNull(key, "Header name must not be null");
             mutableHeaderParams().put(key, value);
             return this;
         }
@@ -197,26 +199,38 @@ public final class Request {
         }
 
         public Request.Builder putAllHeaderParams(String key, Iterable<String> values) {
+            Preconditions.checkArgumentNotNull(key, "Header name must not be null");
             mutableHeaderParams().putAll(key, values);
             return this;
         }
 
         public Request.Builder putAllHeaderParams(Multimap<String, ? extends String> entries) {
+            if (entries.containsKey(null)) {
+                throw new SafeIllegalArgumentException("Header name must not be null");
+            }
             mutableHeaderParams().putAll(entries);
             return this;
         }
 
         public Request.Builder putQueryParams(String key, String... values) {
+            Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
+            for (String value : values) {
+                Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
+            }
             mutableQueryParams().putAll(key, Arrays.asList(values));
             return this;
         }
 
         public Request.Builder putQueryParams(String key, String value) {
+            Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
+            Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
             mutableQueryParams().put(key, value);
             return this;
         }
 
         public Request.Builder putQueryParams(Map.Entry<String, ? extends String> entry) {
+            Preconditions.checkArgumentNotNull(entry.getKey(), "Query parameter name must not be null");
+            Preconditions.checkArgumentNotNull(entry.getValue(), "Query parameter value must not be null");
             mutableQueryParams().put(entry.getKey(), entry.getValue());
             return this;
         }
@@ -227,21 +241,33 @@ public final class Request {
         }
 
         public Request.Builder putAllQueryParams(String key, Iterable<String> values) {
+            Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
+            for (String value : values) {
+                Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
+            }
             mutableQueryParams().putAll(key, values);
             return this;
         }
 
         public Request.Builder putAllQueryParams(Multimap<String, ? extends String> entries) {
+            entries.forEach((key, value) -> {
+                Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
+                Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
+            });
             mutableQueryParams().putAll(entries);
             return this;
         }
 
         public Request.Builder putPathParams(String key, String value) {
+            Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
+            Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
             mutablePathParams().put(key, value);
             return this;
         }
 
         public Request.Builder putPathParams(Map.Entry<String, ? extends String> entry) {
+            Preconditions.checkArgumentNotNull(entry.getKey(), "Path parameter name must not be null");
+            Preconditions.checkArgumentNotNull(entry.getValue(), "Path parameter value must not be null");
             mutablePathParams().put(entry.getKey(), entry.getValue());
             return this;
         }
@@ -252,16 +278,28 @@ public final class Request {
         }
 
         public Request.Builder putAllPathParams(String key, Iterable<String> values) {
+            Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
+            for (String value : values) {
+                Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
+            }
             mutablePathParams().putAll(key, values);
             return this;
         }
 
         public Request.Builder putAllPathParams(Map<String, ? extends String> entries) {
+            entries.forEach((key, value) -> {
+                Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
+                Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
+            });
             entries.forEach(mutablePathParams()::put);
             return this;
         }
 
         public Request.Builder putAllPathParams(Multimap<String, ? extends String> entries) {
+            entries.forEach((key, value) -> {
+                Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
+                Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
+            });
             mutablePathParams().putAll(entries);
             return this;
         }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -188,7 +188,7 @@ public final class Request {
         }
 
         public Request.Builder putHeaderParams(String key, String value) {
-            Preconditions.checkArgumentNotNull(key, "Header name must not be null");
+            Preconditions.checkNotNull(key, "Header name must not be null");
             mutableHeaderParams().put(key, value);
             return this;
         }
@@ -199,38 +199,38 @@ public final class Request {
         }
 
         public Request.Builder putAllHeaderParams(String key, Iterable<String> values) {
-            Preconditions.checkArgumentNotNull(key, "Header name must not be null");
+            Preconditions.checkNotNull(key, "Header name must not be null");
             mutableHeaderParams().putAll(key, values);
             return this;
         }
 
         public Request.Builder putAllHeaderParams(Multimap<String, ? extends String> entries) {
             if (entries.containsKey(null)) {
-                throw new SafeIllegalArgumentException("Header name must not be null");
+                throw new SafeNullPointerException("Header name must not be null");
             }
             mutableHeaderParams().putAll(entries);
             return this;
         }
 
         public Request.Builder putQueryParams(String key, String... values) {
-            Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
+            Preconditions.checkNotNull(key, "Query parameter name must not be null");
             for (String value : values) {
-                Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
+                Preconditions.checkNotNull(value, "Query parameter value must not be null");
             }
             mutableQueryParams().putAll(key, Arrays.asList(values));
             return this;
         }
 
         public Request.Builder putQueryParams(String key, String value) {
-            Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
-            Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
+            Preconditions.checkNotNull(key, "Query parameter name must not be null");
+            Preconditions.checkNotNull(value, "Query parameter value must not be null");
             mutableQueryParams().put(key, value);
             return this;
         }
 
         public Request.Builder putQueryParams(Map.Entry<String, ? extends String> entry) {
-            Preconditions.checkArgumentNotNull(entry.getKey(), "Query parameter name must not be null");
-            Preconditions.checkArgumentNotNull(entry.getValue(), "Query parameter value must not be null");
+            Preconditions.checkNotNull(entry.getKey(), "Query parameter name must not be null");
+            Preconditions.checkNotNull(entry.getValue(), "Query parameter value must not be null");
             mutableQueryParams().put(entry.getKey(), entry.getValue());
             return this;
         }
@@ -241,9 +241,9 @@ public final class Request {
         }
 
         public Request.Builder putAllQueryParams(String key, Iterable<String> values) {
-            Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
+            Preconditions.checkNotNull(key, "Query parameter name must not be null");
             for (String value : values) {
-                Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
+                Preconditions.checkNotNull(value, "Query parameter value must not be null");
             }
             mutableQueryParams().putAll(key, values);
             return this;
@@ -251,23 +251,23 @@ public final class Request {
 
         public Request.Builder putAllQueryParams(Multimap<String, ? extends String> entries) {
             entries.forEach((key, value) -> {
-                Preconditions.checkArgumentNotNull(key, "Query parameter name must not be null");
-                Preconditions.checkArgumentNotNull(value, "Query parameter value must not be null");
+                Preconditions.checkNotNull(key, "Query parameter name must not be null");
+                Preconditions.checkNotNull(value, "Query parameter value must not be null");
             });
             mutableQueryParams().putAll(entries);
             return this;
         }
 
         public Request.Builder putPathParams(String key, String value) {
-            Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
-            Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
+            Preconditions.checkNotNull(key, "Path parameter name must not be null");
+            Preconditions.checkNotNull(value, "Path parameter value must not be null");
             mutablePathParams().put(key, value);
             return this;
         }
 
         public Request.Builder putPathParams(Map.Entry<String, ? extends String> entry) {
-            Preconditions.checkArgumentNotNull(entry.getKey(), "Path parameter name must not be null");
-            Preconditions.checkArgumentNotNull(entry.getValue(), "Path parameter value must not be null");
+            Preconditions.checkNotNull(entry.getKey(), "Path parameter name must not be null");
+            Preconditions.checkNotNull(entry.getValue(), "Path parameter value must not be null");
             mutablePathParams().put(entry.getKey(), entry.getValue());
             return this;
         }
@@ -288,8 +288,8 @@ public final class Request {
 
         public Request.Builder putAllPathParams(Map<String, ? extends String> entries) {
             entries.forEach((key, value) -> {
-                Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
-                Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
+                Preconditions.checkNotNull(key, "Path parameter name must not be null");
+                Preconditions.checkNotNull(value, "Path parameter value must not be null");
             });
             entries.forEach(mutablePathParams()::put);
             return this;
@@ -297,8 +297,8 @@ public final class Request {
 
         public Request.Builder putAllPathParams(Multimap<String, ? extends String> entries) {
             entries.forEach((key, value) -> {
-                Preconditions.checkArgumentNotNull(key, "Path parameter name must not be null");
-                Preconditions.checkArgumentNotNull(value, "Path parameter value must not be null");
+                Preconditions.checkNotNull(key, "Path parameter name must not be null");
+                Preconditions.checkNotNull(value, "Path parameter value must not be null");
             });
             mutablePathParams().putAll(entries);
             return this;


### PR DESCRIPTION
## Before this PR
Null header names, query parameter names/values, and path parameter names/values will throw exceptions during request execution or URL rendering respectively without any useful stack trace, making debugging the root cause of these issues difficult.

For example, this is the error when a null query parameter value is used:
```
java.lang.NullPointerException: Cannot invoke "String.getBytes(java.nio.charset.Charset)" because "source" is null
    at com.palantir.dialogue.core.BaseUrl$UrlEncoder.encode(BaseUrl.java:279)
    at com.palantir.dialogue.core.BaseUrl$UrlEncoder.encodeQueryNameOrValue(BaseUrl.java:271)
    at com.palantir.dialogue.core.BaseUrl$DefaultUrlBuilder.queryParam(BaseUrl.java:164)
    ...
    at com.palantir.dialogue.core.BaseUrl.render(BaseUrl.java:58)
    at com.palantir.dialogue.hc5.ApacheHttpClientBlockingChannel.execute(ApacheHttpClientBlockingChannel.java:99)
    ...
```

## After this PR
==COMMIT_MSG==
Eagerly throw on null request parameters

By throwing when the null values are inserted into the Request builder it's possible to get a helpful stack trace instead of one that just traces back into one of Dialogue's async threads.
==COMMIT_MSG==

## Possible downsides?
- Slightly worse performance due to having to check all entries inserted against null
