### PR TITLE
Remove DefaultLocale override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ subprojects {
             } else {
                 options.errorprone.option('NullAway:AnnotatedPackages', 'com.palantir')
             }
-            options.errorprone.warn('DefaultLocale')
         }
     })
 


### PR DESCRIPTION
This is being replaced by the standard `StringCaseLocaleUsage` check.

https://github.com/palantir/gradle-baseline/pull/2589