### PR TITLE
Provide more info on field type mismatch

### DIFF
--- a/changelog/@unreleased/pr-1947.v2.yml
+++ b/changelog/@unreleased/pr-1947.v2.yml
@@ -1,7 +1,6 @@
 type: improvement
 improvement:
-  description: |-
-    <!-- User-facing outcomes this PR delivers -->
-    Provide more information for debugging when the @DialogueService annotation processor detects type mismatches.
+  description: Provide more information for debugging when the @DialogueService annotation
+    processor detects type mismatches.
   links:
   - https://github.com/palantir/dialogue/pull/1947

--- a/changelog/@unreleased/pr-1947.v2.yml
+++ b/changelog/@unreleased/pr-1947.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    <!-- User-facing outcomes this PR delivers -->
+    Provide more information for debugging when the @DialogueService annotation processor detects type mismatches.
+  links:
+  - https://github.com/palantir/dialogue/pull/1947

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/AnnotationReflector.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/AnnotationReflector.java
@@ -83,7 +83,14 @@ public interface AnnotationReflector {
                 SafeArg.of("fields", methods()));
         Optional<Object> maybeValue = Optional.ofNullable(values().get(fieldName));
         return maybeValue.map(value -> {
-            Preconditions.checkArgument(valueClazz.isInstance(value), "Value not of the right type");
+            Preconditions.checkArgument(
+                    valueClazz.isInstance(value),
+                    "Value not of the right type",
+                    SafeArg.of("fieldName", fieldName),
+                    SafeArg.of("type", annotationTypeElement()),
+                    SafeArg.of("fields", methods()),
+                    SafeArg.of("expected", valueClazz),
+                    SafeArg.of("actual", value.getClass()));
             return (T) value;
         });
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The code compilation might otherwise look okay until the annotation processor runs and it's not clear what the type mismatch is since the fields and types aren't reported.

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
Provide more information for debugging when the @DialogueService annotation processor detects type mismatches.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
