### PR TITLE
make the meshmode enum public in order to allow use of stripMeshPrefix

### DIFF
--- a/changelog/@unreleased/pr-1948.v2.yml
+++ b/changelog/@unreleased/pr-1948.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make MeshMode enum public to allow use of stripMeshPrefix
+  links:
+  - https://github.com/palantir/dialogue/pull/1948

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/MeshMode.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/MeshMode.java
@@ -20,7 +20,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.List;
 
-enum MeshMode {
+public enum MeshMode {
     DEFAULT_NO_MESH,
     USE_EXTERNAL_MESH;
 


### PR DESCRIPTION
## Before this PR
There are some places where we need to strip the mesh mode prefix from urls before handing those urls to other non-dialogue clients (e.g. conda, gradle package managers, etc).

I shared some other context in an internal slack channel.

## After this PR
==COMMIT_MSG==
Make MeshMode enum public to allow use of stripMeshPrefix
==COMMIT_MSG==

It would be good if, when we do this modification, we do this using a common library function (rather than just inlining the url manipulation). This will make it easier to track where this manipulation needs to be done, and will make it easier to unwind should we ever change the way we produce mesh urls.
