### PR TITLE
Dialogue guards against HTTPCLIENT-1924 client self-closure

### DIFF
--- a/changelog/@unreleased/pr-1951.v2.yml
+++ b/changelog/@unreleased/pr-1951.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue guards against HTTPCLIENT-1924 client self-closure
+  links:
+  - https://github.com/palantir/dialogue/pull/1951

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue.hc5;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tracing.CloseableTracer;
@@ -47,6 +48,7 @@ final class InstrumentedPoolingHttpClientConnectionManager
     private final TaggedMetricRegistry registry;
     private final String clientName;
     private final Timer connectTimer;
+    private volatile boolean closed;
 
     InstrumentedPoolingHttpClientConnectionManager(
             PoolingHttpClientConnectionManager manager, TaggedMetricRegistry registry, String clientName) {
@@ -58,12 +60,41 @@ final class InstrumentedPoolingHttpClientConnectionManager
 
     @Override
     public void close() {
-        manager.close();
+        if (!closed) {
+            log.warn(
+                    "Dialogue ConnectionManager close invoked unexpectedly and ignored",
+                    SafeArg.of("clientName", clientName),
+                    new SafeRuntimeException("stacktrace"));
+            // Note: manager.close is not invoked here, see closeUnderlyingConnectionManager.
+        }
     }
 
     @Override
     public void close(CloseMode closeMode) {
-        manager.close(closeMode);
+        if (!closed) {
+            log.warn(
+                    "Dialogue ConnectionManager close invoked unexpectedly and ignored",
+                    SafeArg.of("clientName", clientName),
+                    SafeArg.of("closeMode", closeMode),
+                    new SafeRuntimeException("stacktrace"));
+            // Note: manager.close is not invoked here, see closeUnderlyingConnectionManager.
+        }
+    }
+
+    /**
+     * This method is used to close the underlying connection manager, while the {@link #close()} methods are
+     * overridden specifically not to do so in order to avoid unexpected closure in MainClientExec when
+     * an Error is encountered due to HTTPCLIENT-1924:
+     * https://github.com/apache/httpcomponents-client/blob/5b61e132c3871ddfa967ab21b3af5d6d738bc6e8/
+     * httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java#L161-L164
+     * Note that MainClientExec pool self-closure will likely leak a connection each time it occurs, however
+     * dialogue bounds connections to Integer.MAX_VALUE, so this is preferable over
+     */
+    void closeUnderlyingConnectionManager() {
+        if (!closed) {
+            closed = true;
+            manager.close();
+        }
     }
 
     @Override

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
@@ -84,11 +84,11 @@ final class InstrumentedPoolingHttpClientConnectionManager
     /**
      * This method is used to close the underlying connection manager, while the {@link #close()} methods are
      * overridden specifically not to do so in order to avoid unexpected closure in MainClientExec when
-     * an Error is encountered due to HTTPCLIENT-1924:
+     * an Error is encountered due to HTTPCLIENT-1924.
      * https://github.com/apache/httpcomponents-client/blob/5b61e132c3871ddfa967ab21b3af5d6d738bc6e8/
      * httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java#L161-L164
      * Note that MainClientExec pool self-closure will likely leak a connection each time it occurs, however
-     * dialogue bounds connections to Integer.MAX_VALUE, so this is preferable over
+     * dialogue bounds connections to Integer.MAX_VALUE, so this is preferable over.
      */
     void closeUnderlyingConnectionManager() {
         if (!closed) {

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ErrorRecoveryTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ErrorRecoveryTest.java
@@ -1,0 +1,122 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.dialogue.hc5;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.Iterables;
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Clients;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestBody;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TestConfigurations;
+import com.palantir.dialogue.TestEndpoint;
+import io.undertow.Undertow;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import javax.net.ssl.SSLContext;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("checkstyle:NestedTryDepth")
+public final class ErrorRecoveryTest {
+
+    @Test
+    public void errorRecovery() throws Exception {
+        Clients clients = DefaultConjureRuntime.builder().build().clients();
+        Undertow server = startServer();
+        try {
+            String uri = "https://localhost:" + getPort(server);
+            ClientConfiguration conf = TestConfigurations.create(uri);
+            try (ApacheHttpClientChannels.CloseableClient client =
+                    ApacheHttpClientChannels.createCloseableHttpClient(conf, "client")) {
+                Channel channel = ApacheHttpClientChannels.createSingleUri(uri, client);
+                EndpointChannel endpointChannel = request -> channel.execute(TestEndpoint.POST, request);
+                assertThatThrownBy(() ->
+                                singleRequest(clients, endpointChannel, Optional.of(ErrorThrowingRequestBody.INSTANCE)))
+                        .isInstanceOf(StackOverflowError.class);
+                // Following a failure, the client should be operable.
+                singleRequest(clients, endpointChannel, Optional.empty());
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static void singleRequest(Clients clients, EndpointChannel endpointChannel, Optional<RequestBody> body) {
+        clients.callBlocking(endpointChannel, Request.builder().body(body).build(), VoidDeserializer.INSTANCE);
+    }
+
+    private static Undertow startServer() {
+        SSLContext sslContext = SslSocketFactories.createSslContext(TestConfigurations.SSL_CONFIG);
+        Undertow server = Undertow.builder()
+                .setHandler(ResponseCodeHandler.HANDLE_200)
+                .addHttpsListener(0, null, sslContext)
+                .build();
+        server.start();
+        return server;
+    }
+
+    private static int getPort(Undertow undertow) {
+        return ((InetSocketAddress)
+                        Iterables.getOnlyElement(undertow.getListenerInfo()).getAddress())
+                .getPort();
+    }
+
+    private enum VoidDeserializer implements Deserializer<Void> {
+        INSTANCE;
+
+        @Override
+        public Void deserialize(Response response) {
+            response.close();
+            return null;
+        }
+
+        @Override
+        public Optional<String> accepts() {
+            return Optional.empty();
+        }
+    }
+
+    private enum ErrorThrowingRequestBody implements RequestBody {
+        INSTANCE;
+
+        @Override
+        public void writeTo(OutputStream _output) {
+            throw new StackOverflowError();
+        }
+
+        @Override
+        public String contentType() {
+            return "application/octet-stream";
+        }
+
+        @Override
+        public boolean repeatable() {
+            return false;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## Before this PR
The underlying http client closes itself when an Error is thrown.

## After this PR
==COMMIT_MSG==
Dialogue guards against HTTPCLIENT-1924 client self-closure
==COMMIT_MSG==

## Possible downsides?
In cases that would previously self-close, we're guaranteed that a connection will leak. Our connection pool allows two billion entries, so it's not the worst thing in the world so long as it doesn't happen in a hot loop, which is unlikely, and in the unlikely worst case causes similar issues to the self-closure problem.