### PR TITLE
RetryingChannel: Retry request if message is not consumed.

### DIFF
--- a/changelog/@unreleased/pr-1972.v2.yml
+++ b/changelog/@unreleased/pr-1972.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Update RetryingChannel to retry requests if the request body is not
+    consumed, or the request is repeatable.
+  links:
+  - https://github.com/palantir/dialogue/pull/1972

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -447,7 +447,7 @@ final class RetryingChannel implements EndpointChannel {
 
     private static final class ConsumptionTrackingRequestBody implements RequestBody {
         private final RequestBody delegate;
-        private boolean consumed;
+        private volatile boolean consumed;
 
         ConsumptionTrackingRequestBody(RequestBody delegate) {
             this.delegate = delegate;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -493,7 +493,7 @@ final class RetryingChannel implements EndpointChannel {
         }
         return Request.builder()
                 .from(request)
-                .body(request.body().map(ConsumptionTrackingRequestBody::new))
+                .body(new ConsumptionTrackingRequestBody(request.body().get()))
                 .build();
     }
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -534,7 +534,8 @@ public class RetryingChannelTest {
     }
 
     @Test
-    public void nonRetryableRequestBodyRetriedWhenConnectionFails() throws ExecutionException, InterruptedException {
+    public void requestWithNonRepeatableBodyRetriedWhenConnectionFails()
+            throws ExecutionException, InterruptedException {
         when(channel.execute(any()))
                 .thenReturn(CONNECTION_FAILED)
                 .thenReturn(CONNECTION_FAILED)

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -17,7 +17,6 @@
 package com.palantir.dialogue.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -565,7 +565,6 @@ public class RetryingChannelTest {
                     public void close() {}
                 })
                 .build());
-
         assertThat(response).isDone();
         assertThat(response.get())
                 .as("requests should be retried if they are not consumed")


### PR DESCRIPTION
## Before this PR
Currently we only retry requests that have a repeatable body. We should also retry non-repeatable requests if the body is not consumed.

## After this PR
==COMMIT_MSG==
Update RetryingChannel to retry requests if the request body is not consumed, or the request is repeatable.
==COMMIT_MSG==