### PR TITLE
Use blocking interface in annotation processor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ import java.util.UUID;
 public interface MyService {
 
     @Request(method = HttpMethod.POST, path = "/params/{myPathParam}/{myPathParam2}", accept=MyCustomResponseDeserializer.class)
-    ListenableFuture<MyCustomResponse> params(
+    MyCustomResponse params(
             @Request.QueryParam("q") String query,
             // Path parameter variable name must match the request path component
             @Request.PathParam UUID myPathParam,


### PR DESCRIPTION
We've seen consumers use async interfaces when it's not necessary simply because that's what appears to be suggested by the README. We'd prefer consumers to use sync interfaces where possible because they are easier to reason about.