### PR TITLE
BinaryRequestBody and ContentBody use InputStream.transferTo(OutputStream)

### DIFF
--- a/changelog/@unreleased/pr-1983.v2.yml
+++ b/changelog/@unreleased/pr-1983.v2.yml
@@ -1,0 +1,19 @@
+type: improvement
+improvement:
+  description: |-
+    BinaryRequestBody and ContentBody use InputStream.transferToOutputStream
+
+    Allow for optimization when underlying input stream (such as `ByteArrayInputStream`, `ChannelInputStream`) overrides `transferTo(OutputStream)` to avoid extra array allocations and copy larger chunks at a time (e.g. allowing 16KiB chunks via `ApacheHttpClientBlockingChannel.ModulatingOutputStream` from #1790).
+
+    When running on JDK 21+, this also enables 16KiB byte chunk copies via `InputStream.transferTo(OutputStream)` per JDK-8299336, where as on JDK < 21 and when using Guava `ByteStreams.copy` 8KiB byte chunk copies are used.
+
+    References:
+    * https://github.com/palantir/hadoop-crypto/pull/586
+    * https://bugs.openjdk.org/browse/JDK-8299336
+    * https://bugs.openjdk.org/browse/JDK-8067661
+    * https://bugs.openjdk.org/browse/JDK-8265891
+    * https://bugs.openjdk.org/browse/JDK-8273038
+    * https://bugs.openjdk.org/browse/JDK-8279283
+    * https://bugs.openjdk.org/browse/JDK-8296431
+  links:
+  - https://github.com/palantir/dialogue/pull/1983

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/InputStreamContentBody.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/InputStreamContentBody.java
@@ -16,7 +16,6 @@
 
 package com.palantir.dialogue.annotations;
 
-import com.google.common.io.ByteStreams;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -39,7 +38,7 @@ final class InputStreamContentBody implements ContentBody {
 
     @Override
     public void writeTo(OutputStream output) throws IOException {
-        ByteStreams.copy(inputStream, output);
+        inputStream.transferTo(output);
     }
 
     @Override

--- a/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
+++ b/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
@@ -144,8 +144,9 @@ public class IntegrationTest {
 
         undertowHandler = exchange -> {
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/octet-stream");
-            InputStream bigInputStream = repeat(sample, limit);
-            ByteStreams.copy(bigInputStream, exchange.getOutputStream());
+            try (InputStream bigInputStream = repeat(sample, limit)) {
+                bigInputStream.transferTo(exchange.getOutputStream());
+            }
         };
 
         Stopwatch sw = Stopwatch.createStarted();

--- a/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BinaryRequestBody.java
@@ -16,7 +16,6 @@
 
 package com.palantir.dialogue;
 
-import com.google.common.io.ByteStreams;
 import com.palantir.logsafe.Preconditions;
 import java.io.Closeable;
 import java.io.IOException;
@@ -49,7 +48,7 @@ public interface BinaryRequestBody extends Closeable {
             public void write(OutputStream requestBody) throws IOException {
                 Preconditions.checkState(!invoked, "Write has already been called");
                 invoked = true;
-                ByteStreams.copy(inputStream, requestBody);
+                inputStream.transferTo(requestBody);
             }
 
             @Override


### PR DESCRIPTION
## Before this PR
Dialogue used Guava `ByteStreams.copy` for 8KiB byte buffer chunk copies.

## After this PR
==COMMIT_MSG==
`BinaryRequestBody` and `ContentBody` use `InputStream.transferTo(OutputStream)`

Allow for optimization when underlying input stream (such as `ByteArrayInputStream`, `ChannelInputStream`) overrides `transferTo(OutputStream)` to avoid extra array allocations and copy larger chunks at a time (e.g. allowing 16KiB chunks via `ApacheHttpClientBlockingChannel.ModulatingOutputStream` from #1790).

When running on JDK 21+, this also enables 16KiB byte chunk copies via `InputStream.transferTo(OutputStream)` per JDK-8299336, where as on JDK < 21 and when using Guava `ByteStreams.copy` 8KiB byte chunk copies are used.

References:
* https://github.com/palantir/hadoop-crypto/pull/586
* https://bugs.openjdk.org/browse/JDK-8299336
* https://bugs.openjdk.org/browse/JDK-8067661
* https://bugs.openjdk.org/browse/JDK-8265891
* https://bugs.openjdk.org/browse/JDK-8273038
* https://bugs.openjdk.org/browse/JDK-8279283
* https://bugs.openjdk.org/browse/JDK-8296431


==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
