### PR TITLE
Follow 307 redirects in RetryOtherValidatingChannel

### DIFF
--- a/changelog/@unreleased/pr-1987.v2.yml
+++ b/changelog/@unreleased/pr-1987.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Follow 307 redirects in RetryOtherValidatingChannel
+  links:
+  - https://github.com/palantir/dialogue/pull/1987

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -25,7 +25,7 @@ final class Responses {
         // Note that a 308 status may be a non-retryable signal, for instance google sometimes
         // uses a '308 Resume Incomplete', so we must verify the presence of a Location header
         // to differentiate the two.
-        return response.code() == 308
+        return (response.code() == 307 || response.code() == 308)
                 && response.getFirstHeader(HttpHeaders.LOCATION).isPresent();
     }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Dialogue client would error if it received a 307 response (Temporary Redirect).

## After this PR
Dialogue client will follow the redirect if it receives a 307 response with a "Location" header.

==COMMIT_MSG==
Follow 307 redirects in RetryOtherValidatingChannel
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
