### PR TITLE
Attempt to avoid gzip response compression between backend services

### DIFF
--- a/changelog/@unreleased/pr-1996.v2.yml
+++ b/changelog/@unreleased/pr-1996.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid gzip response compression between backend services
+  links:
+  - https://github.com/palantir/dialogue/pull/1996

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -78,6 +78,8 @@ final class ContentDecodingChannel implements EndpointChannel {
     @Override
     public ListenableFuture<Response> execute(Request request) {
         Request augmentedRequest = acceptEncoding(request, sendAcceptGzip);
+        // In cases where gzip is not expected, we continue to handle gzipped responses to avoid abrupt failures
+        // against servers which hard-code 'Content-Encoding: gzip' responses without checking request headers.
         return DialogueFutures.transform(delegate.execute(augmentedRequest), ContentDecodingChannel::decompress);
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -110,7 +110,7 @@ final class ContentDecodingChannel implements EndpointChannel {
 
     @Override
     public String toString() {
-        return "ContentDecodingChannel{" + delegate + '}';
+        return "ContentDecodingChannel{delegate=" + delegate + ", sendAcceptGzip=" + sendAcceptGzip + '}';
     }
 
     private static final class ContentDecodingResponse implements Response {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -181,7 +181,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = UserAgentEndpointChannel.create(
                         channel, endpoint, cf.clientConf().userAgent().get());
                 channel = DeprecationWarningChannel.create(cf, channel, endpoint);
-                channel = ContentDecodingChannel.create(cf, channel);
+                channel = ContentDecodingChannel.create(cf, channel, endpoint);
                 channel = new RangeAcceptsIdentityEncodingChannel(channel);
                 channel = ContentEncodingChannel.of(channel, endpoint);
                 channel = TracedChannel.create(cf, channel, endpoint);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -181,7 +181,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = UserAgentEndpointChannel.create(
                         channel, endpoint, cf.clientConf().userAgent().get());
                 channel = DeprecationWarningChannel.create(cf, channel, endpoint);
-                channel = new ContentDecodingChannel(channel);
+                channel = ContentDecodingChannel.create(cf, channel);
                 channel = new RangeAcceptsIdentityEncodingChannel(channel);
                 channel = ContentEncodingChannel.of(channel, endpoint);
                 channel = TracedChannel.create(cf, channel, endpoint);


### PR DESCRIPTION
## Before this PR
Gzip compression is expensive.

## After this PR
==COMMIT_MSG==
Avoid gzip response compression between backend services
==COMMIT_MSG==

## Possible downsides?
It's possible that we may stop using gzip response compression somewhere it's helpful, most such environments don't have multiple addressable nodes, though. We do not run single nodes of production services, so I expect this heuristic to be quite accurate.
In ideal world, I might prefer to add metadata to the client request which the server can use to intelligently opt out of compression -- that would be fairly similar to setting the accept-encoding header on the client, and increase complexity of the rollout.