### PR TITLE
UrlBuilder supports adding multiple path segments at once

### DIFF
--- a/changelog/@unreleased/pr-2016.v2.yml
+++ b/changelog/@unreleased/pr-2016.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    UrlBuilder supports adding multiple path segments at once.
+    Deprecation metric is only created when a deprecated endpoint is invoked.
+  links:
+  - https://github.com/palantir/dialogue/pull/2016

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -36,6 +37,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -151,6 +153,12 @@ public final class BaseUrl {
         @Override
         public DefaultUrlBuilder pathSegment(String thePath) {
             this.pathSegments.add(BaseUrl.UrlEncoder.encodePathSegment(thePath));
+            return this;
+        }
+
+        @Override
+        public DefaultUrlBuilder pathSegments(Collection<String> paths) {
+            this.pathSegments.addAll(Collections2.transform(paths, BaseUrl.UrlEncoder::encodePathSegment));
             return this;
         }
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -23,6 +23,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.TestEndpoint;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +66,8 @@ public final class UrlBuilderTest {
         assertThat(minimalUrl().pathSegment("foo").build().toString()).isEqualTo("http://host:80/foo");
         assertThat(minimalUrl().pathSegment("foo").pathSegment("bar").build().toString())
                 .isEqualTo("http://host:80/foo/bar");
+        assertThat(minimalUrl().pathSegments(List.of("foo", "bar")).build().toString())
+                .isEqualTo("http://host:80/foo/bar");
         assertThat(minimalUrl().pathSegment("foo/bar").build().toString()).isEqualTo("http://host:80/foo%2Fbar");
         assertThat(minimalUrl()
                         .pathSegment("!@#$%^&*()_+{}[]|\\|\"':;/?.>,<~`")
@@ -72,6 +75,12 @@ public final class UrlBuilderTest {
                         .toString())
                 .isEqualTo("http://host:80/%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
                         + "%5B%5D%7C%5C%7C%22%27%3A%3B%2F%3F.%3E%2C%3C~%60");
+        assertThat(minimalUrl()
+                        .pathSegments(List.of("!@#$%^&*()_+{}", "[]|\\|\"':;/?.>,<~`"))
+                        .build()
+                        .toString())
+                .isEqualTo("http://host:80/%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
+                        + "/%5B%5D%7C%5C%7C%22%27%3A%3B%2F%3F.%3E%2C%3C~%60");
     }
 
     @Test
@@ -79,6 +88,12 @@ public final class UrlBuilderTest {
         assertThat(minimalUrl()
                         .pathSegment("")
                         .pathSegment("")
+                        .pathSegment("bar")
+                        .build()
+                        .toString())
+                .isEqualTo("http://host:80///bar");
+        assertThat(minimalUrl()
+                        .pathSegments(List.of("", ""))
                         .pathSegment("bar")
                         .build()
                         .toString())

--- a/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/PathTemplate.java
@@ -80,7 +80,7 @@ public final class PathTemplate {
             if (segment.fixed != null) {
                 url.pathSegment(segment.fixed);
             } else {
-                parameters.get(segment.variable).forEach(url::pathSegment);
+                url.pathSegments(parameters.get(segment.variable));
             }
         }
     }

--- a/dialogue-target/src/main/java/com/palantir/dialogue/UrlBuilder.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/UrlBuilder.java
@@ -16,10 +16,17 @@
 
 package com.palantir.dialogue;
 
+import java.util.Collection;
+
 public interface UrlBuilder {
 
     /** URL-encodes the given path segment and adds it to the list of segments. */
     UrlBuilder pathSegment(String thePath);
+
+    default UrlBuilder pathSegments(Collection<String> paths) {
+        paths.forEach(this::pathSegment);
+        return this;
+    }
 
     /**
      * URL-encodes the given query parameter name and value and adds them to the list of query parameters. Note that


### PR DESCRIPTION
## Before this PR
For high volume services, adding the URL path segments can trigger reallocations as the list resizes.

Calls to non-deprecated endpoints incurred the cost of creating the deprecation metric name.

## After this PR
==COMMIT_MSG==
UrlBuilder supports adding multiple path segments at once.
Deprecation metric is only created when a deprecated endpoint is invoked.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
