### PR TITLE
dialogue.client.connection.create differentiates success and failure

### DIFF
--- a/changelog/@unreleased/pr-2020.v2.yml
+++ b/changelog/@unreleased/pr-2020.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: dialogue.client.connection.create differentiates success and failure
+  links:
+  - https://github.com/palantir/dialogue/pull/2020

--- a/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
+++ b/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
@@ -55,6 +55,9 @@ namespaces:
           - name: client-name
           - name: client-type
             values: [ apache-hc5 ]
+          - name: result
+            values: [ success, failure ]
+            docs: Describes whether or not a connection was successfully established.
         docs: Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.
 
       connection.closed.partially-consumed-response:

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -23,6 +23,7 @@ Dialogue client response metrics provided by the Apache client channel.
 - `dialogue.client.connection.create` (timer): Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.
   - `client-name`
   - `client-type` values (`apache-hc5`)
+  - `result` values (`success`,`failure`): Describes whether or not a connection was successfully established.
 - `dialogue.client.connection.closed.partially-consumed-response` (meter): Reports the rate that connections are closed due to response closure prior to response data being fully exhausted. When this occurs, subsequent requests must create new handshakes, incurring latency and CPU overhead due to handshakes.
   - `client-name`
   - `client-type` values (`apache-hc5`)


### PR DESCRIPTION
This metric is helpful for safely reducing connect timeouts, unfortunately some failures will always result in a timeout, so we need to rule out failed attempts.
==COMMIT_MSG==
dialogue.client.connection.create differentiates success and failure
==COMMIT_MSG==
