### PR TITLE
Add client request size metric channel

### DIFF
--- a/changelog/@unreleased/pr-2023.v2.yml
+++ b/changelog/@unreleased/pr-2023.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add a request size metric channel, which records the size of payloads
+    written by the client.
+  links:
+  - https://github.com/palantir/dialogue/pull/2023

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -71,7 +71,11 @@ Dialogue-specific metrics that are not necessarily applicable to other client im
 - `dialogue.client.request.queued.time` tagged `channel-name` (timer): Time spent waiting in the queue before execution.
 - `dialogue.client.request.endpoint.queued.time` tagged `channel-name`, `service-name`, `endpoint` (timer): Time spent waiting in the queue before execution on a specific endpoint due to server QoS.
 - `dialogue.client.request.sticky.queued.time` tagged `channel-name` (timer): Time spent waiting in the sticky queue before execution attempt.
-- `dialogue.client.requests.size` tagged `channel-name`, `service-name`, `endpoint`, `retryable` (histogram): Size of requests
+- `dialogue.client.requests.size` (histogram): Size of requests
+  - `repeatable` values (`true`,`false`)
+  - `channel-name`
+  - `service-name`
+  - `endpoint`
 - `dialogue.client.create` tagged `client-name`, `client-type` (meter): Marked every time a new client is created.
 
 ### dialogue.concurrencylimiter

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -71,6 +71,7 @@ Dialogue-specific metrics that are not necessarily applicable to other client im
 - `dialogue.client.request.queued.time` tagged `channel-name` (timer): Time spent waiting in the queue before execution.
 - `dialogue.client.request.endpoint.queued.time` tagged `channel-name`, `service-name`, `endpoint` (timer): Time spent waiting in the queue before execution on a specific endpoint due to server QoS.
 - `dialogue.client.request.sticky.queued.time` tagged `channel-name` (timer): Time spent waiting in the sticky queue before execution attempt.
+- `dialogue.client.requests.size` tagged `service-name`, `endpoint` (histogram): Size of requests
 - `dialogue.client.create` tagged `client-name`, `client-type` (meter): Marked every time a new client is created.
 
 ### dialogue.concurrencylimiter

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -71,7 +71,7 @@ Dialogue-specific metrics that are not necessarily applicable to other client im
 - `dialogue.client.request.queued.time` tagged `channel-name` (timer): Time spent waiting in the queue before execution.
 - `dialogue.client.request.endpoint.queued.time` tagged `channel-name`, `service-name`, `endpoint` (timer): Time spent waiting in the queue before execution on a specific endpoint due to server QoS.
 - `dialogue.client.request.sticky.queued.time` tagged `channel-name` (timer): Time spent waiting in the sticky queue before execution attempt.
-- `dialogue.client.requests.size` (histogram): Size of requests
+- `dialogue.client.requests.size` (histogram): Histogram of the sizes of requests larger than a threshold (1 MiB).
   - `repeatable` values (`true`,`false`)
   - `channel-name`
   - `service-name`

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -71,7 +71,7 @@ Dialogue-specific metrics that are not necessarily applicable to other client im
 - `dialogue.client.request.queued.time` tagged `channel-name` (timer): Time spent waiting in the queue before execution.
 - `dialogue.client.request.endpoint.queued.time` tagged `channel-name`, `service-name`, `endpoint` (timer): Time spent waiting in the queue before execution on a specific endpoint due to server QoS.
 - `dialogue.client.request.sticky.queued.time` tagged `channel-name` (timer): Time spent waiting in the sticky queue before execution attempt.
-- `dialogue.client.requests.size` tagged `service-name`, `endpoint` (histogram): Size of requests
+- `dialogue.client.requests.size` tagged `channel-name`, `service-name`, `endpoint`, `retryable` (histogram): Size of requests
 - `dialogue.client.create` tagged `client-name`, `client-type` (meter): Marked every time a new client is created.
 
 ### dialogue.concurrencylimiter

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -92,6 +92,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
 
         /**
          * Please use {@link #factory(DialogueChannelFactory)}.
+         *
          * @deprecated prefer {@link #factory(DialogueChannelFactory)}
          */
         @Deprecated
@@ -185,6 +186,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = new RangeAcceptsIdentityEncodingChannel(channel);
                 channel = ContentEncodingChannel.of(channel, endpoint);
                 channel = TracedChannel.create(cf, channel, endpoint);
+                channel = RequestSizeMetricsChannel.create(cf, channel, endpoint);
                 if (ChannelToEndpointChannel.isConstant(endpoint)) {
                     // Avoid producing metrics for non-constant endpoints which may produce
                     // high cardinality.
@@ -207,7 +209,9 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
             return new DialogueChannel(cf, channelFactory, stickyChannelSupplier);
         }
 
-        /** Does *not* do any clever live-reloading. */
+        /**
+         * Does *not* do any clever live-reloading.
+         */
         @CheckReturnValue
         public Channel buildNonLiveReloading() {
             return build();

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RequestSizeMetricsChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RequestSizeMetricsChannel.java
@@ -24,6 +24,8 @@ import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -31,6 +33,7 @@ import java.io.OutputStream;
 import java.util.Optional;
 
 final class RequestSizeMetricsChannel implements EndpointChannel {
+    private static final SafeLogger log = SafeLoggerFactory.get(RequestSizeMetricsChannel.class);
     private final EndpointChannel delegate;
     private final Histogram requestSize;
 
@@ -102,7 +105,7 @@ final class RequestSizeMetricsChannel implements EndpointChannel {
             try {
                 out.close();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                log.warn("Failed to close tracking output stream", e);
             }
             delegate.close();
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RequestSizeMetricsChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RequestSizeMetricsChannel.java
@@ -1,0 +1,141 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.codahale.metrics.Histogram;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestBody;
+import com.palantir.dialogue.Response;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Optional;
+
+final class RequestSizeMetricsChannel implements EndpointChannel {
+    private final EndpointChannel delegate;
+    private final Histogram requestSize;
+
+    static EndpointChannel create(Config cf, EndpointChannel channel, Endpoint endpoint) {
+        ClientConfiguration clientConf = cf.clientConf();
+        return new RequestSizeMetricsChannel(channel, endpoint, clientConf.taggedMetricRegistry());
+    }
+
+    RequestSizeMetricsChannel(EndpointChannel delegate, Endpoint endpoint, TaggedMetricRegistry registry) {
+        this.delegate = delegate;
+        DialogueClientMetrics dialogueClientMetrics = DialogueClientMetrics.of(registry);
+        this.requestSize = dialogueClientMetrics
+                .requestsSize()
+                .serviceName(endpoint.serviceName())
+                .endpoint(endpoint.endpointName())
+                .build();
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Request request) {
+        Request augmentedRequest = wrap(request);
+        return delegate.execute(augmentedRequest);
+    }
+
+    private Request wrap(Request request) {
+        Optional<RequestBody> body = request.body();
+        if (body.isEmpty()) {
+            // No need to record empty bodies
+            return request;
+        }
+
+        return Request.builder()
+                .from(request)
+                .body(new RequestSizeRecordingRequestBody(body.get(), this.requestSize))
+                .build();
+    }
+
+    private class RequestSizeRecordingRequestBody implements RequestBody {
+        private final RequestBody delegate;
+        private final Histogram size;
+        private SizeTrackingOutputStream out;
+
+        RequestSizeRecordingRequestBody(RequestBody requestBody, Histogram size) {
+            this.delegate = requestBody;
+            this.size = size;
+            // we'll never actually write to this output stream, but is safe to perform all operations on in case a
+            // client closes without calling write.
+            this.out = new SizeTrackingOutputStream(OutputStream.nullOutputStream(), size);
+        }
+
+        @Override
+        public void writeTo(OutputStream output) throws IOException {
+            out = new SizeTrackingOutputStream(output, size);
+            delegate.writeTo(out);
+        }
+
+        @Override
+        public String contentType() {
+            return delegate.contentType();
+        }
+
+        @Override
+        public boolean repeatable() {
+            return delegate.repeatable();
+        }
+
+        @Override
+        public void close() {
+            try {
+                out.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            delegate.close();
+        }
+
+        /**
+         * {@link SizeTrackingOutputStream} records the total number of bytes written to the output stream.
+         */
+        private final class SizeTrackingOutputStream extends FilterOutputStream {
+            private final Histogram size;
+            private long writes = 0;
+
+            SizeTrackingOutputStream(OutputStream delegate, Histogram size) {
+                super(delegate);
+                this.size = size;
+            }
+
+            @Override
+            public void write(byte[] buffer, int off, int len) throws IOException {
+                writes += len;
+                out.write(buffer, off, len);
+            }
+
+            @Override
+            public void write(int value) throws IOException {
+                writes += 1;
+                out.write(value);
+            }
+
+            @Override
+            public void close() throws IOException {
+                this.size.update(writes);
+                super.close();
+            }
+        }
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RequestSizeMetricsChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RequestSizeMetricsChannel.java
@@ -47,13 +47,20 @@ final class RequestSizeMetricsChannel implements EndpointChannel {
             EndpointChannel delegate, String channelName, Endpoint endpoint, TaggedMetricRegistry registry) {
         this.delegate = delegate;
         DialogueClientMetrics dialogueClientMetrics = DialogueClientMetrics.of(registry);
-        DialogueClientMetrics.RequestsSizeBuilderRetryableStage requestSize = dialogueClientMetrics
+        this.retryableRequestSize = dialogueClientMetrics
                 .requestsSize()
                 .channelName(channelName)
                 .serviceName(endpoint.serviceName())
-                .endpoint(endpoint.endpointName());
-        this.retryableRequestSize = requestSize.retryable("true").build();
-        this.nonretryableRequestSize = requestSize.retryable("false").build();
+                .endpoint(endpoint.endpointName())
+                .retryable("true")
+                .build();
+        this.nonretryableRequestSize = dialogueClientMetrics
+                .requestsSize()
+                .channelName(channelName)
+                .serviceName(endpoint.serviceName())
+                .endpoint(endpoint.endpointName())
+                .retryable("false")
+                .build();
     }
 
     @Override

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -58,7 +58,7 @@ namespaces:
         docs: Time spent waiting in the sticky queue before execution attempt.
       requests.size:
         type: histogram
-        tags: [service-name, endpoint]
+        tags: [channel-name, service-name, endpoint, retryable]
         docs: Size of requests
       # Note: the 'dialogue.client.create' metric is also defined in the apache metrics.
       create:

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -64,7 +64,7 @@ namespaces:
         - name: channel-name
         - name: service-name
         - name: endpoint
-        docs: Size of requests
+        docs: Histogram of the sizes of requests larger than a threshold (1 MiB).
       # Note: the 'dialogue.client.create' metric is also defined in the apache metrics.
       create:
         type: meter

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -56,6 +56,10 @@ namespaces:
         type: timer
         tags: [ channel-name ]
         docs: Time spent waiting in the sticky queue before execution attempt.
+      requests.size:
+        type: histogram
+        tags: [service-name, endpoint]
+        docs: Size of requests
       # Note: the 'dialogue.client.create' metric is also defined in the apache metrics.
       create:
         type: meter

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -58,7 +58,12 @@ namespaces:
         docs: Time spent waiting in the sticky queue before execution attempt.
       requests.size:
         type: histogram
-        tags: [channel-name, service-name, endpoint, retryable]
+        tags:
+        - name: repeatable
+          values: [ 'true', 'false' ]
+        - name: channel-name
+        - name: service-name
+        - name: endpoint
         docs: Size of requests
       # Note: the 'dialogue.client.create' metric is also defined in the apache metrics.
       create:

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RequestSizeMetricsChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RequestSizeMetricsChannelTest.java
@@ -40,10 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.OptionalLong;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 public class RequestSizeMetricsChannelTest {
 
     private static final DialogueChannelFactory STUB_FACTORY = _ignored -> {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RequestSizeMetricsChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RequestSizeMetricsChannelTest.java
@@ -101,8 +101,10 @@ public class RequestSizeMetricsChannelTest {
         assertThat(response.get().code()).isEqualTo(200);
         Snapshot snapshot = DialogueClientMetrics.of(registry)
                 .requestsSize()
+                .channelName("channelName")
                 .serviceName("service")
                 .endpoint("endpoint")
+                .retryable("true")
                 .build()
                 .getSnapshot();
         assertThat(snapshot.size()).isEqualTo(1);

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RequestSizeMetricsChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RequestSizeMetricsChannelTest.java
@@ -1,0 +1,119 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Snapshot;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestBody;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TestConfigurations;
+import com.palantir.dialogue.TestEndpoint;
+import com.palantir.dialogue.TestResponse;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.OptionalLong;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestSizeMetricsChannelTest {
+    @Mock
+    DialogueChannelFactory factory;
+
+    @Test
+    public void records_request_size_metrics() throws ExecutionException, InterruptedException {
+        TaggedMetricRegistry registry = DefaultTaggedMetricRegistry.getDefault();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] expected = "test request body".getBytes(StandardCharsets.UTF_8);
+        Request request = Request.builder()
+                .body(new RequestBody() {
+                    @Override
+                    public void writeTo(OutputStream output) throws IOException {
+                        output.write(expected);
+                    }
+
+                    @Override
+                    public String contentType() {
+                        return "text/plain";
+                    }
+
+                    @Override
+                    public boolean repeatable() {
+                        return true;
+                    }
+
+                    @Override
+                    public OptionalLong contentLength() {
+                        return OptionalLong.of(expected.length);
+                    }
+
+                    @Override
+                    public void close() {}
+                })
+                .build();
+
+        EndpointChannel channel = RequestSizeMetricsChannel.create(
+                config(ClientConfiguration.builder()
+                        .from(TestConfigurations.create("https://foo:10001"))
+                        .taggedMetricRegistry(registry)
+                        .build()),
+                r -> {
+                    try {
+                        RequestBody body = r.body().get();
+                        body.writeTo(baos);
+                        body.close();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return Futures.immediateFuture(new TestResponse().code(200));
+                },
+                TestEndpoint.GET);
+        ListenableFuture<Response> response = channel.execute(request);
+
+        assertThat(response.get().code()).isEqualTo(200);
+        Snapshot snapshot = DialogueClientMetrics.of(registry)
+                .requestsSize()
+                .serviceName("service")
+                .endpoint("endpoint")
+                .build()
+                .getSnapshot();
+        assertThat(snapshot.size()).isEqualTo(1);
+        assertThat(snapshot.get99thPercentile()).isEqualTo(expected.length);
+    }
+
+    private ImmutableConfig config(ClientConfiguration rawConfig) {
+        return ImmutableConfig.builder()
+                .channelName("channelName")
+                .channelFactory(factory)
+                .rawConfig(rawConfig)
+                .build();
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Currently, the best way to understand the size of requests made by a particular client is to analyze server request logs. While this does provide some high-level insight into the behavior of a client, it doesn't provide any information about the clients understanding of if a request is "repeatable" or not. This is important as not all retry approaches will have the same opinion on the repeatability of a request (e.g. envoy has a payload size constraint), so we need to know which large requests dialogue currently believes would get retried. 

## After this PR
==COMMIT_MSG==
Add a request size metric channel, which records the size of payloads written by the client. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This is currently as histogram, but I don't believe we need all of the metrics that would come out of it, and it's likely quite expensive to add this metric to all clients. I think we probably only care about the `p99` or `max` values here, as average request size is largely irrelevant.