### PR TITLE
Memoize some sticky channel metrics

### DIFF
--- a/changelog/@unreleased/pr-2026.v2.yml
+++ b/changelog/@unreleased/pr-2026.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Memoize some sticky channel metrics
+  links:
+  - https://github.com/palantir/dialogue/pull/2026


### PR DESCRIPTION
## Before this PR

Allocations in constructors for some metrics that may not be used, so lazily create and memoize them as needed:

![image](https://github.com/palantir/dialogue/assets/54594/6af7f312-94f3-444c-85f9-56f98c09128d)


## After this PR
==COMMIT_MSG==
Memoize some sticky channel metrics
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
