### PR TITLE
Add socket bind timing metrics

### DIFF
--- a/changelog/@unreleased/pr-2047.v2.yml
+++ b/changelog/@unreleased/pr-2047.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add socket bind timing metrics
+  links:
+  - https://github.com/palantir/dialogue/pull/2047

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpConnectionFactory.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpConnectionFactory.java
@@ -37,13 +37,15 @@ final class InstrumentedManagedHttpConnectionFactory implements HttpConnectionFa
             TaggedMetricRegistry metrics,
             String clientName) {
         this.delegate = delegate;
-        this.serverTimingOverhead = DialogueClientMetrics.of(metrics).serverTimingOverhead(clientName);
-        this.socketBindSuccessesTimer = DialogueClientMetrics.of(metrics)
+        DialogueClientMetrics dialogueClientMetrics = DialogueClientMetrics.of(metrics);
+
+        this.serverTimingOverhead = dialogueClientMetrics.serverTimingOverhead(clientName);
+        this.socketBindSuccessesTimer = dialogueClientMetrics
                 .connectionSocketBind()
                 .clientName(clientName)
                 .result(ConnectionSocketBind_Result.SUCCESS)
                 .build();
-        this.socketBindFailureTimer = DialogueClientMetrics.of(metrics)
+        this.socketBindFailureTimer = dialogueClientMetrics
                 .connectionSocketBind()
                 .clientName(clientName)
                 .result(ConnectionSocketBind_Result.FAILURE)

--- a/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
+++ b/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
@@ -49,6 +49,17 @@ namespaces:
             values: [ apache-hc5 ]
         docs: Marked every time an Apache client is successfully closed and any underlying resources released (e.g. connections and background threads).
 
+      connection.socket.bind:
+        type: timer
+        tags:
+          - name: client-name
+          - name: client-type
+            values: [ apache-hc5 ]
+          - name: result
+            values: [ success, failure ]
+            docs: Describes whether or not a connection was successfully established.
+        docs: Reports the time spent binding to the socket. This does not includes the TLS handshake.
+
       connection.create:
         type: timer
         tags:

--- a/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
+++ b/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
@@ -57,7 +57,7 @@ namespaces:
             values: [ apache-hc5 ]
           - name: result
             values: [ success, failure ]
-            docs: Describes whether or not a connection was successfully established.
+            docs: Describes whether or not the socket bind was successful.
         docs: Reports the time spent binding to the socket. This does not includes the TLS handshake.
 
       connection.create:

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -23,7 +23,7 @@ Dialogue client response metrics provided by the Apache client channel.
 - `dialogue.client.connection.socket.bind` (timer): Reports the time spent binding to the socket. This does not includes the TLS handshake.
   - `client-name`
   - `client-type` values (`apache-hc5`)
-  - `result` values (`success`,`failure`): Describes whether or not a connection was successfully established.
+  - `result` values (`success`,`failure`): Describes whether or not the socket bind was successful.
 - `dialogue.client.connection.create` (timer): Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.
   - `client-name`
   - `client-type` values (`apache-hc5`)

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -20,6 +20,10 @@ Dialogue client response metrics provided by the Apache client channel.
 - `dialogue.client.close` (meter): Marked every time an Apache client is successfully closed and any underlying resources released (e.g. connections and background threads).
   - `client-name`
   - `client-type` values (`apache-hc5`)
+- `dialogue.client.connection.socket.bind` (timer): Reports the time spent binding to the socket. This does not includes the TLS handshake.
+  - `client-name`
+  - `client-type` values (`apache-hc5`)
+  - `result` values (`success`,`failure`): Describes whether or not a connection was successfully established.
 - `dialogue.client.connection.create` (timer): Reports the time spent creating a new connection. This includes both connecting the socket and the full TLS handshake.
   - `client-name`
   - `client-type` values (`apache-hc5`)


### PR DESCRIPTION
This metric is helpful to understand networking latencies to help guide reducing connect timeouts. 

==COMMIT_MSG==
Add socket bind timing metrics
==COMMIT_MSG==


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
