### PR TITLE
Support enum types including optional & list enums

### DIFF
--- a/changelog/@unreleased/pr-2076.v2.yml
+++ b/changelog/@unreleased/pr-2076.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support enum parameter types
+  links:
+  - https://github.com/palantir/dialogue/pull/2076

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyEnumType.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyEnumType.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.example;
+
+public final class MyEnumType {
+
+    public static final MyEnumType VALUE_1 = new MyEnumType(Value.VALUE_1, "VALUE_1");
+    public static final MyEnumType VALUE_2 = new MyEnumType(Value.VALUE_2, "VALUE_2");
+    private final Value value;
+    private final String string;
+
+    private MyEnumType(Value value, String string) {
+        this.value = value;
+        this.string = string;
+    }
+
+    public Value get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return string;
+    }
+
+    public enum Value {
+        VALUE_1,
+        VALUE_2
+    }
+}

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -76,6 +76,7 @@ public interface MyService {
             @Request.QueryParam("q3") Optional<String> query3,
             // Alias types are supported for @QueryParam and @Header
             @Request.QueryParam("q4") MyAliasType query4,
+            @Request.QueryParam("q5") MyEnumType query5,
             // Path parameter variable name must match the request path component
             @Request.PathParam UUID path1,
             @Request.PathParam(encoder = MyCustomTypeParamEncoder.class) MyCustomType path2,
@@ -83,6 +84,7 @@ public interface MyService {
             @Request.Header("h2") List<String> header2,
             @Request.Header("h3") Optional<String> header3,
             @Request.Header("h4") MyAliasType header4,
+            @Request.Header("h5") MyEnumType header5,
             // Can supply a map to fill in arbitrary query values
             @Request.QueryMap(encoder = MapToMultimapParamEncoder.class) Map<String, String> queryParams,
             // Custom encoding classes may be provided for the request and response.

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -77,6 +77,7 @@ public interface MyService {
             // Alias types are supported for @QueryParam and @Header
             @Request.QueryParam("q4") MyAliasType query4,
             @Request.QueryParam("q5") MyEnumType query5,
+            @Request.QueryParam("q6") List<MyAliasType> query6,
             // Path parameter variable name must match the request path component
             @Request.PathParam UUID path1,
             @Request.PathParam(encoder = MyCustomTypeParamEncoder.class) MyCustomType path2,
@@ -85,6 +86,7 @@ public interface MyService {
             @Request.Header("h3") Optional<String> header3,
             @Request.Header("h4") MyAliasType header4,
             @Request.Header("h5") MyEnumType header5,
+            @Request.Header("h6") List<MyAliasType> header6,
             // Can supply a map to fill in arbitrary query values
             @Request.QueryMap(encoder = MapToMultimapParamEncoder.class) Map<String, String> queryParams,
             // Custom encoding classes may be provided for the request and response.

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -77,7 +77,8 @@ public interface MyService {
             // Alias types are supported for @QueryParam and @Header
             @Request.QueryParam("q4") MyAliasType query4,
             @Request.QueryParam("q5") MyEnumType query5,
-            @Request.QueryParam("q6") List<MyAliasType> query6,
+            @Request.QueryParam("q6") Optional<MyEnumType> query6,
+            @Request.QueryParam("q7") List<MyAliasType> query7,
             // Path parameter variable name must match the request path component
             @Request.PathParam UUID path1,
             @Request.PathParam(encoder = MyCustomTypeParamEncoder.class) MyCustomType path2,
@@ -86,7 +87,8 @@ public interface MyService {
             @Request.Header("h3") Optional<String> header3,
             @Request.Header("h4") MyAliasType header4,
             @Request.Header("h5") MyEnumType header5,
-            @Request.Header("h6") List<MyAliasType> header6,
+            @Request.Header("h6") Optional<MyEnumType> header6,
+            @Request.Header("h7") List<MyAliasType> header7,
             // Can supply a map to fill in arbitrary query values
             @Request.QueryMap(encoder = MapToMultimapParamEncoder.class) Map<String, String> queryParams,
             // Custom encoding classes may be provided for the request and response.

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -262,11 +262,12 @@ public final class MyServiceIntegrationTest {
             exchange.assertMethod(HttpMethod.POST);
             exchange.assertPath("/params/90a8481a-2ef5-4c64-83fc-04a9b369e2b8/my-custom-param-value");
 
-            assertThat(exchange.exchange.getQueryParameters()).containsOnlyKeys("q1", "q2", "q3", "q4", "varq1");
+            assertThat(exchange.exchange.getQueryParameters()).containsOnlyKeys("q1", "q2", "q3", "q4", "q5", "varq1");
             assertThat(exchange.exchange.getQueryParameters().get("q1")).containsOnly("query1");
             assertThat(exchange.exchange.getQueryParameters().get("q2")).containsOnly("query2-1", "query2-2");
             assertThat(exchange.exchange.getQueryParameters().get("q3")).containsOnly("query3");
             assertThat(exchange.exchange.getQueryParameters().get("q4")).containsOnly("query4");
+            assertThat(exchange.exchange.getQueryParameters().get("q5")).containsOnly("VALUE_1");
             assertThat(exchange.exchange.getQueryParameters().get("varq1")).containsOnly("varvar1");
             exchange.assertAccept().isNull();
             exchange.assertContentType().isEqualTo("application/json");
@@ -275,6 +276,7 @@ public final class MyServiceIntegrationTest {
                     .hasValueSatisfying(values -> assertThat(values).containsExactly("header2-1", "header2-2"));
             exchange.assertSingleValueHeader(HttpString.tryFromString("h3")).isEqualTo("header3");
             exchange.assertSingleValueHeader(HttpString.tryFromString("h4")).isEqualTo("header4");
+            exchange.assertSingleValueHeader(HttpString.tryFromString("h5")).isEqualTo("VALUE_2");
             exchange.assertBodyUtf8().isEqualTo("{\n  \"value\" : \"my-serializable-type-value\"\n}");
 
             exchange.exchange.setStatusCode(200);
@@ -291,12 +293,14 @@ public final class MyServiceIntegrationTest {
                 Arrays.asList("query2-1", "query2-2"),
                 Optional.of("query3"),
                 ImmutableMyAliasType.of("query4"),
+                MyEnumType.VALUE_1,
                 uuid,
                 new MyCustomType("my-custom-param-value"),
                 "header1",
                 Arrays.asList("header2-1", "header2-2"),
                 Optional.of("header3"),
                 ImmutableMyAliasType.of("header4"),
+                MyEnumType.VALUE_2,
                 ImmutableMap.of("varq1", "varvar1"),
                 ImmutableMySerializableType.of("my-serializable-type-value"));
     }

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -263,13 +263,14 @@ public final class MyServiceIntegrationTest {
             exchange.assertPath("/params/90a8481a-2ef5-4c64-83fc-04a9b369e2b8/my-custom-param-value");
 
             assertThat(exchange.exchange.getQueryParameters())
-                    .containsOnlyKeys("q1", "q2", "q3", "q4", "q5", "q6", "varq1");
+                    .containsOnlyKeys("q1", "q2", "q3", "q4", "q5", "q6", "q7", "varq1");
             assertThat(exchange.exchange.getQueryParameters().get("q1")).containsOnly("query1");
             assertThat(exchange.exchange.getQueryParameters().get("q2")).containsOnly("query2-1", "query2-2");
             assertThat(exchange.exchange.getQueryParameters().get("q3")).containsOnly("query3");
             assertThat(exchange.exchange.getQueryParameters().get("q4")).containsOnly("query4");
             assertThat(exchange.exchange.getQueryParameters().get("q5")).containsOnly("VALUE_1");
-            assertThat(exchange.exchange.getQueryParameters().get("q6")).containsOnly("query6-1", "query6-2");
+            assertThat(exchange.exchange.getQueryParameters().get("q6")).containsOnly("VALUE_1");
+            assertThat(exchange.exchange.getQueryParameters().get("q7")).containsOnly("query7-1", "query7-2");
             assertThat(exchange.exchange.getQueryParameters().get("varq1")).containsOnly("varvar1");
             exchange.assertAccept().isNull();
             exchange.assertContentType().isEqualTo("application/json");
@@ -279,8 +280,9 @@ public final class MyServiceIntegrationTest {
             exchange.assertSingleValueHeader(HttpString.tryFromString("h3")).isEqualTo("header3");
             exchange.assertSingleValueHeader(HttpString.tryFromString("h4")).isEqualTo("header4");
             exchange.assertSingleValueHeader(HttpString.tryFromString("h5")).isEqualTo("VALUE_2");
-            exchange.assertMultiValueHeader("h6")
-                    .hasValueSatisfying(values -> assertThat(values).containsExactly("header6-1", "header6-2"));
+            exchange.assertSingleValueHeader(HttpString.tryFromString("h6")).isEqualTo("VALUE_2");
+            exchange.assertMultiValueHeader("h7")
+                    .hasValueSatisfying(values -> assertThat(values).containsExactly("header7-1", "header7-2"));
 
             exchange.assertBodyUtf8().isEqualTo("{\n  \"value\" : \"my-serializable-type-value\"\n}");
 
@@ -299,7 +301,8 @@ public final class MyServiceIntegrationTest {
                 Optional.of("query3"),
                 ImmutableMyAliasType.of("query4"),
                 MyEnumType.VALUE_1,
-                List.of(ImmutableMyAliasType.of("query6-1"), ImmutableMyAliasType.of("query6-2")),
+                Optional.of(MyEnumType.VALUE_1),
+                List.of(ImmutableMyAliasType.of("query7-1"), ImmutableMyAliasType.of("query7-2")),
                 uuid,
                 new MyCustomType("my-custom-param-value"),
                 "header1",
@@ -307,7 +310,8 @@ public final class MyServiceIntegrationTest {
                 Optional.of("header3"),
                 ImmutableMyAliasType.of("header4"),
                 MyEnumType.VALUE_2,
-                List.of(ImmutableMyAliasType.of("header6-1"), ImmutableMyAliasType.of("header6-2")),
+                Optional.of(MyEnumType.VALUE_2),
+                List.of(ImmutableMyAliasType.of("header7-1"), ImmutableMyAliasType.of("header7-2")),
                 ImmutableMap.of("varq1", "varvar1"),
                 ImmutableMySerializableType.of("my-serializable-type-value"));
     }

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -262,12 +262,14 @@ public final class MyServiceIntegrationTest {
             exchange.assertMethod(HttpMethod.POST);
             exchange.assertPath("/params/90a8481a-2ef5-4c64-83fc-04a9b369e2b8/my-custom-param-value");
 
-            assertThat(exchange.exchange.getQueryParameters()).containsOnlyKeys("q1", "q2", "q3", "q4", "q5", "varq1");
+            assertThat(exchange.exchange.getQueryParameters())
+                    .containsOnlyKeys("q1", "q2", "q3", "q4", "q5", "q6", "varq1");
             assertThat(exchange.exchange.getQueryParameters().get("q1")).containsOnly("query1");
             assertThat(exchange.exchange.getQueryParameters().get("q2")).containsOnly("query2-1", "query2-2");
             assertThat(exchange.exchange.getQueryParameters().get("q3")).containsOnly("query3");
             assertThat(exchange.exchange.getQueryParameters().get("q4")).containsOnly("query4");
             assertThat(exchange.exchange.getQueryParameters().get("q5")).containsOnly("VALUE_1");
+            assertThat(exchange.exchange.getQueryParameters().get("q6")).containsOnly("query6-1", "query6-2");
             assertThat(exchange.exchange.getQueryParameters().get("varq1")).containsOnly("varvar1");
             exchange.assertAccept().isNull();
             exchange.assertContentType().isEqualTo("application/json");
@@ -277,6 +279,9 @@ public final class MyServiceIntegrationTest {
             exchange.assertSingleValueHeader(HttpString.tryFromString("h3")).isEqualTo("header3");
             exchange.assertSingleValueHeader(HttpString.tryFromString("h4")).isEqualTo("header4");
             exchange.assertSingleValueHeader(HttpString.tryFromString("h5")).isEqualTo("VALUE_2");
+            exchange.assertMultiValueHeader("h6")
+                    .hasValueSatisfying(values -> assertThat(values).containsExactly("header6-1", "header6-2"));
+
             exchange.assertBodyUtf8().isEqualTo("{\n  \"value\" : \"my-serializable-type-value\"\n}");
 
             exchange.exchange.setStatusCode(200);
@@ -294,6 +299,7 @@ public final class MyServiceIntegrationTest {
                 Optional.of("query3"),
                 ImmutableMyAliasType.of("query4"),
                 MyEnumType.VALUE_1,
+                List.of(ImmutableMyAliasType.of("query6-1"), ImmutableMyAliasType.of("query6-2")),
                 uuid,
                 new MyCustomType("my-custom-param-value"),
                 "header1",
@@ -301,6 +307,7 @@ public final class MyServiceIntegrationTest {
                 Optional.of("header3"),
                 ImmutableMyAliasType.of("header4"),
                 MyEnumType.VALUE_2,
+                List.of(ImmutableMyAliasType.of("header6-1"), ImmutableMyAliasType.of("header6-2")),
                 ImmutableMap.of("varq1", "varvar1"),
                 ImmutableMySerializableType.of("my-serializable-type-value"));
     }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
@@ -26,7 +26,7 @@ public interface ArgumentType {
         /** Should be handled by {@link com.palantir.dialogue.annotations.ParameterSerializer}. */
         R primitive(TypeName javaTypeName, String parameterSerializerMethodName);
 
-        R list(TypeName javaTypeName, String parameterSerializerMethodName);
+        R list(TypeName javaTypeName, ListType listType);
 
         R alias(TypeName javaTypeName, String parameterSerializerMethodName);
 
@@ -46,6 +46,12 @@ public interface ArgumentType {
 
         String valueGetMethodName();
 
+        ArgumentType innerType();
+    }
+
+    @Value.Immutable
+    @StagedBuilder
+    interface ListType {
         ArgumentType innerType();
     }
 }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentType.java
@@ -32,6 +32,8 @@ public interface ArgumentType {
 
         R optional(TypeName optionalJavaType, OptionalType optionalType);
 
+        R enumType(TypeName javaTypeName, String parameterSerializerMethodName);
+
         R rawRequestBody(TypeName requestBodyType);
 
         R customType(TypeName customTypeName);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentTypesResolver.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ArgumentTypesResolver.java
@@ -152,6 +152,7 @@ public final class ArgumentTypesResolver {
         return context.getGenericInnerType(Optional.class, typeMirror)
                 .map(innerType -> getPrimitiveType(innerType)
                         .or(() -> getAliasType(innerType))
+                        .or(() -> getEnumType(innerType))
                         .orElseGet(() -> getCustomType(typeMirror)))
                 .map(innerType -> ArgumentTypes.optional(
                         typeName,

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -99,7 +99,7 @@ public final class ServiceImplementationGenerator {
                                         .list((typeName, _parameterSerializerMethodName) -> typeName)
                                         .alias((typeName, _aliasType) -> typeName)
                                         .optional((typeName, _optionalType) -> typeName)
-                                        .enumType((typeName, _optionalType) -> typeName)
+                                        .enumType((typeName, _enumType) -> typeName)
                                         .rawRequestBody(typeName -> typeName)
                                         .customType(typeName -> typeName),
                                 arg.argName().get())
@@ -298,7 +298,7 @@ public final class ServiceImplementationGenerator {
             @Override
             public CodeBlock list(TypeName _typeName, ListType listType) {
                 return maybeParameterEncoderType.map(this::parameterEncoderType).orElseGet(() -> {
-                    CodeBlock elementName = CodeBlock.of(argName + "Element");
+                    CodeBlock elementName = CodeBlock.of("$L$L", argName, "Element");
                     CodeBlock elementCodeBlock = generatePlainSerializer(
                             singleValueMethod,
                             multiValueMethod,

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -98,6 +98,7 @@ public final class ServiceImplementationGenerator {
                                         .list((typeName, _parameterSerializerMethodName) -> typeName)
                                         .alias((typeName, _aliasType) -> typeName)
                                         .optional((typeName, _optionalType) -> typeName)
+                                        .enumType((typeName, _optionalType) -> typeName)
                                         .rawRequestBody(typeName -> typeName)
                                         .customType(typeName -> typeName),
                                 arg.argName().get())
@@ -338,6 +339,20 @@ public final class ServiceImplementationGenerator {
                         .add(inner)
                         .endControlFlow()
                         .build();
+            }
+
+            @Override
+            public CodeBlock enumType(TypeName _typeName, String parameterSerializerMethodName) {
+                return maybeParameterEncoderType.map(this::parameterEncoderType).orElseGet(() -> {
+                    return CodeBlock.of(
+                            "$L.$L($S, $L.$L($L.toString()));",
+                            REQUEST,
+                            singleValueMethod,
+                            key,
+                            PARAMETER_SERIALIZER,
+                            parameterSerializerMethodName,
+                            argName);
+                });
             }
 
             @Override

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -32,7 +32,6 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.dialogue.annotations.processor.generate.DialogueServiceFactoryGenerator")
@@ -165,11 +164,9 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                 if (query5.isPresent()) {
                     _request.putQueryParams("q5", _parameterSerializer.serializeDouble(query5.getAsDouble()));
                 }
-                _request.putAllQueryParams(
-                        "q6",
-                        query6.stream()
-                                .map(_parameterSerializer::serializeString)
-                                .collect(Collectors.toList()));
+                query6.forEach(query6Element -> {
+                    _request.putQueryParams("q6", _parameterSerializer.serializeString(query6Element));
+                });
                 _request.putQueryParams("q7", _parameterSerializer.serializeString(query7.get()));
                 _request.putAllQueryParams("q8", paramsQuery8Encoder.toParamValues(query8));
                 if (query9.isPresent()) {
@@ -194,11 +191,9 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                 if (header5.isPresent()) {
                     _request.putHeaderParams("h5", _parameterSerializer.serializeDouble(header5.getAsDouble()));
                 }
-                _request.putAllHeaderParams(
-                        "h6",
-                        header6.stream()
-                                .map(_parameterSerializer::serializeString)
-                                .collect(Collectors.toList()));
+                header6.forEach(header6Element -> {
+                    _request.putHeaderParams("h6", _parameterSerializer.serializeString(header6Element));
+                });
                 _request.putHeaderParams("h7", _parameterSerializer.serializeString(header7.get()));
                 _request.putAllHeaderParams("h8", paramsHeader8Encoder.toParamValues(header8));
                 if (header9.isPresent()) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Conjure-style enums are not supported in particular for Dialogue annotations. This would result in an error like the following

```
Parameter '<name>' with custom type '<EnumClassName>' must declare an encoder
```
## After this PR
==COMMIT_MSG==
Support enum parameter types
==COMMIT_MSG==

Implemented a similar mechanism as https://github.com/palantir/dialogue/pull/1782 to support the following:
- `MyEnum` type
- `Optional<MyEnum>` type
- `List<MyEnum>` type and `List<MyAlias>` type

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
