### PR TITLE
Add reason to propagated QoS errors

### DIFF
--- a/changelog/@unreleased/pr-2093.v2.yml
+++ b/changelog/@unreleased/pr-2093.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Propagated QoS exceptions now include a reason.
+  links:
+  - https://github.com/palantir/dialogue/pull/2093

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoderTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoderTest.java
@@ -96,7 +96,9 @@ public final class ErrorDecoderTest {
         assertThat(decoder.isError(response)).isTrue();
 
         RuntimeException result = decoder.decode(response);
-        assertThat(result).isInstanceOf(QosException.Unavailable.class);
+        assertThat(result).isInstanceOfSatisfying(QosException.Unavailable.class, exception -> {
+            assertThat(exception.getReason()).isEqualTo(ErrorDecoder.QOS_REASON);
+        });
     }
 
     @Test
@@ -105,9 +107,10 @@ public final class ErrorDecoderTest {
         assertThat(decoder.isError(response)).isTrue();
 
         RuntimeException result = decoder.decode(response);
-        assertThat(result)
-                .isInstanceOfSatisfying(QosException.Throttle.class, exception -> assertThat(exception.getRetryAfter())
-                        .isEmpty());
+        assertThat(result).isInstanceOfSatisfying(QosException.Throttle.class, exception -> {
+            assertThat(exception.getReason()).isEqualTo(ErrorDecoder.QOS_REASON);
+            assertThat(exception.getRetryAfter()).isEmpty();
+        });
     }
 
     @Test
@@ -117,9 +120,10 @@ public final class ErrorDecoderTest {
         assertThat(decoder.isError(response)).isTrue();
 
         RuntimeException result = decoder.decode(response);
-        assertThat(result)
-                .isInstanceOfSatisfying(QosException.Throttle.class, exception -> assertThat(exception.getRetryAfter())
-                        .hasValue(Duration.ofSeconds(3)));
+        assertThat(result).isInstanceOfSatisfying(QosException.Throttle.class, exception -> {
+            assertThat(exception.getReason()).isEqualTo(ErrorDecoder.QOS_REASON);
+            assertThat(exception.getRetryAfter()).hasValue(Duration.ofSeconds(3));
+        });
     }
 
     @Test
@@ -129,9 +133,10 @@ public final class ErrorDecoderTest {
         assertThat(decoder.isError(response)).isTrue();
 
         RuntimeException result = decoder.decode(response);
-        assertThat(result)
-                .isInstanceOfSatisfying(QosException.Throttle.class, exception -> assertThat(exception.getRetryAfter())
-                        .isEmpty());
+        assertThat(result).isInstanceOfSatisfying(QosException.Throttle.class, exception -> {
+            assertThat(exception.getReason()).isEqualTo(ErrorDecoder.QOS_REASON);
+            assertThat(exception.getRetryAfter()).isEmpty();
+        });
     }
 
     @Test
@@ -169,10 +174,10 @@ public final class ErrorDecoderTest {
         assertThat(result)
                 .isInstanceOf(UnknownRemoteException.class)
                 .getRootCause()
-                .isInstanceOfSatisfying(
-                        QosException.RetryOther.class,
-                        exception ->
-                                assertThat(exception.getRedirectTo()).asString().isEqualTo(expectedLocation));
+                .isInstanceOfSatisfying(QosException.RetryOther.class, exception -> {
+                    assertThat(exception.getReason()).isEqualTo(ErrorDecoder.QOS_REASON);
+                    assertThat(exception.getRedirectTo()).asString().isEqualTo(expectedLocation);
+                });
     }
 
     @Test


### PR DESCRIPTION
When QoS exceptions are propagated, it would be helpful for the reason to indicate the source of the `QosException`. 