### PR TITLE
[feature/dns] don't tag changes with autorelease

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,1 +1,0 @@
-'autorelease': ['*/src/main/**/*.java']


### PR DESCRIPTION
We don't want to accidentally produce releases from a feature branch.

==COMMIT_MSG==
don't tag changes with autorelease
==COMMIT_MSG==
