### PR TITLE
[feature/dns] dns resolution uses only ipv4 or ipv6 addresses, but not both

### DIFF
--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolver.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.palantir.dialogue.core.DialogueDnsResolver;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class ProtocolVersionFilteringDialogueDnsResolver implements DialogueDnsResolver {
+    private final DialogueDnsResolver delegate;
+
+    ProtocolVersionFilteringDialogueDnsResolver(DialogueDnsResolver delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ImmutableSet<InetAddress> resolve(String hostname) {
+        return filter(delegate.resolve(hostname));
+    }
+
+    @Override
+    public ImmutableSetMultimap<String, InetAddress> resolve(Iterable<String> hostnames) {
+        ImmutableSetMultimap<String, InetAddress> resolved = delegate.resolve(hostnames);
+        ImmutableSetMultimap.Builder<String, InetAddress> result = ImmutableSetMultimap.builder();
+        resolved.asMap().forEach((host, addresses) -> result.putAll(host, filter(addresses)));
+        return result.build();
+    }
+
+    // TODO(dns): report metrics here
+    private static ImmutableSet<InetAddress> filter(Collection<InetAddress> addresses) {
+        // Assume that if resolved addresses contain a mix of ipv4 and ipv6 addresses, then they
+        // likely point to the same host, just using a different protocol. In that case, we discared the ipv6
+        // addresses and prefer only ipv4.
+        //
+        // If the set of resolved addresses contains only ipv4 or only ipv6 addresses, then it is left unmodified.
+
+        Set<InetAddress> ipv4Addresses =
+                addresses.stream().filter(addr -> addr instanceof Inet4Address).collect(Collectors.toUnmodifiableSet());
+        Set<InetAddress> ipv6Addresses =
+                addresses.stream().filter(addr -> addr instanceof Inet6Address).collect(Collectors.toUnmodifiableSet());
+
+        if (ipv4Addresses.isEmpty() && ipv6Addresses.isEmpty()) {
+            return ImmutableSet.of();
+        } else if (ipv6Addresses.isEmpty()) {
+            return ImmutableSet.copyOf(ipv4Addresses);
+        } else if (ipv4Addresses.isEmpty()) {
+            return ImmutableSet.copyOf(ipv6Addresses);
+        } else {
+            // only include ipv4 addresses
+            return ImmutableSet.copyOf(ipv4Addresses);
+        }
+    }
+}

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -184,7 +184,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
         @Value.Default
         default DialogueDnsResolver dnsResolver() {
-            return DefaultDialogueDnsResolver.INSTANCE;
+            return new ProtocolVersionFilteringDialogueDnsResolver(DefaultDialogueDnsResolver.INSTANCE);
         }
 
         @Value.Default

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolverTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolverTest.java
@@ -17,12 +17,10 @@
 package com.palantir.dialogue.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.palantir.dialogue.core.DialogueDnsResolver;
+import com.palantir.dialogue.util.MapBasedDnsResolver;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import org.junit.jupiter.api.Test;
@@ -31,48 +29,39 @@ class ProtocolVersionFilteringDialogueDnsResolverTest {
 
     @Test
     void returns_only_ipv4_when_input_contains_only_ipv4() throws UnknownHostException {
-        ImmutableSet<InetAddress> resolvedAddresses = ImmutableSet.of(
-                InetAddress.getByAddress(new byte[] {1, 1, 1, 1}), InetAddress.getByAddress(new byte[] {2, 2, 2, 2}));
+        InetAddress address1 = InetAddress.getByAddress(new byte[] {1, 1, 1, 1});
+        InetAddress address2 = InetAddress.getByAddress(new byte[] {2, 2, 2, 2});
 
-        DialogueDnsResolver delegate = mock(DialogueDnsResolver.class);
-        when(delegate.resolve(anyString())).thenReturn(resolvedAddresses);
-
+        DialogueDnsResolver delegate =
+                new MapBasedDnsResolver(ImmutableSetMultimap.of("foo.com", address1, "foo.com", address2));
         DialogueDnsResolver resolver = new ProtocolVersionFilteringDialogueDnsResolver(delegate);
 
-        assertThat(resolver.resolve("foo")).isEqualTo(resolvedAddresses);
+        assertThat(resolver.resolve("foo.com")).containsExactly(address1, address2);
     }
 
     @Test
     void returns_only_ipv6_when_input_contains_only_ipv6() throws UnknownHostException {
-        ImmutableSet<InetAddress> resolvedAddresses = ImmutableSet.of(
-                InetAddress.getByName("0fa7:be4f:a4d2:4e33:22d0:c4b6:7ddb:19f0"),
-                InetAddress.getByName("2b08:8eff:13b5:1246:5208:acb1:6b52:648a"));
+        InetAddress address1 = InetAddress.getByName("0fa7:be4f:a4d2:4e33:22d0:c4b6:7ddb:19f0");
+        InetAddress address2 = InetAddress.getByName("2b08:8eff:13b5:1246:5208:acb1:6b52:648a");
 
-        DialogueDnsResolver delegate = mock(DialogueDnsResolver.class);
-        when(delegate.resolve(anyString())).thenReturn(resolvedAddresses);
-
+        DialogueDnsResolver delegate =
+                new MapBasedDnsResolver(ImmutableSetMultimap.of("foo.com", address1, "foo.com", address2));
         DialogueDnsResolver resolver = new ProtocolVersionFilteringDialogueDnsResolver(delegate);
 
-        assertThat(resolver.resolve("foo")).isEqualTo(resolvedAddresses);
+        assertThat(resolver.resolve("foo.com")).containsExactly(address1, address2);
     }
 
     @Test
     void returns_only_ipv4_when_input_contains_mix_of_ipv4_and_ipv6() throws UnknownHostException {
-        ImmutableSet<InetAddress> resolvedIpv4Addresses = ImmutableSet.of(
-                InetAddress.getByAddress(new byte[] {1, 1, 1, 1}), InetAddress.getByAddress(new byte[] {2, 2, 2, 2}));
-        ImmutableSet<InetAddress> resolvedIpv6Addresses = ImmutableSet.of(
-                InetAddress.getByName("0fa7:be4f:a4d2:4e33:22d0:c4b6:7ddb:19f0"),
-                InetAddress.getByName("2b08:8eff:13b5:1246:5208:acb1:6b52:648a"));
-        ImmutableSet<InetAddress> resolvedAddresses = ImmutableSet.<InetAddress>builder()
-                .addAll(resolvedIpv4Addresses)
-                .addAll(resolvedIpv6Addresses)
-                .build();
+        InetAddress address1v4 = InetAddress.getByAddress(new byte[] {1, 1, 1, 1});
+        InetAddress address2v4 = InetAddress.getByAddress(new byte[] {2, 2, 2, 2});
+        InetAddress address1v6 = InetAddress.getByName("0fa7:be4f:a4d2:4e33:22d0:c4b6:7ddb:19f0");
+        InetAddress address2v6 = InetAddress.getByName("2b08:8eff:13b5:1246:5208:acb1:6b52:648a");
 
-        DialogueDnsResolver delegate = mock(DialogueDnsResolver.class);
-        when(delegate.resolve(anyString())).thenReturn(resolvedAddresses);
-
+        DialogueDnsResolver delegate = new MapBasedDnsResolver(ImmutableSetMultimap.of(
+                "foo.com", address1v4, "foo.com", address1v6, "foo.com", address2v4, "foo.com", address2v6));
         DialogueDnsResolver resolver = new ProtocolVersionFilteringDialogueDnsResolver(delegate);
 
-        assertThat(resolver.resolve("foo")).isEqualTo(resolvedIpv4Addresses);
+        assertThat(resolver.resolve("foo.com")).containsExactly(address1v4, address2v4);
     }
 }

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolverTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolverTest.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.dialogue.core.DialogueDnsResolver;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.junit.jupiter.api.Test;
+
+class ProtocolVersionFilteringDialogueDnsResolverTest {
+
+    @Test
+    void returns_only_ipv4_when_input_contains_only_ipv4() throws UnknownHostException {
+        ImmutableSet<InetAddress> resolvedAddresses = ImmutableSet.of(
+                InetAddress.getByAddress(new byte[] {1, 1, 1, 1}), InetAddress.getByAddress(new byte[] {2, 2, 2, 2}));
+
+        DialogueDnsResolver delegate = mock(DialogueDnsResolver.class);
+        when(delegate.resolve(anyString())).thenReturn(resolvedAddresses);
+
+        DialogueDnsResolver resolver = new ProtocolVersionFilteringDialogueDnsResolver(delegate);
+
+        assertThat(resolver.resolve("foo")).isEqualTo(resolvedAddresses);
+    }
+
+    @Test
+    void returns_only_ipv6_when_input_contains_only_ipv6() throws UnknownHostException {
+        ImmutableSet<InetAddress> resolvedAddresses = ImmutableSet.of(
+                InetAddress.getByName("0fa7:be4f:a4d2:4e33:22d0:c4b6:7ddb:19f0"),
+                InetAddress.getByName("2b08:8eff:13b5:1246:5208:acb1:6b52:648a"));
+
+        DialogueDnsResolver delegate = mock(DialogueDnsResolver.class);
+        when(delegate.resolve(anyString())).thenReturn(resolvedAddresses);
+
+        DialogueDnsResolver resolver = new ProtocolVersionFilteringDialogueDnsResolver(delegate);
+
+        assertThat(resolver.resolve("foo")).isEqualTo(resolvedAddresses);
+    }
+
+    @Test
+    void returns_only_ipv4_when_input_contains_mix_of_ipv4_and_ipv6() throws UnknownHostException {
+        ImmutableSet<InetAddress> resolvedIpv4Addresses = ImmutableSet.of(
+                InetAddress.getByAddress(new byte[] {1, 1, 1, 1}), InetAddress.getByAddress(new byte[] {2, 2, 2, 2}));
+        ImmutableSet<InetAddress> resolvedIpv6Addresses = ImmutableSet.of(
+                InetAddress.getByName("0fa7:be4f:a4d2:4e33:22d0:c4b6:7ddb:19f0"),
+                InetAddress.getByName("2b08:8eff:13b5:1246:5208:acb1:6b52:648a"));
+        ImmutableSet<InetAddress> resolvedAddresses = ImmutableSet.<InetAddress>builder()
+                .addAll(resolvedIpv4Addresses)
+                .addAll(resolvedIpv6Addresses)
+                .build();
+
+        DialogueDnsResolver delegate = mock(DialogueDnsResolver.class);
+        when(delegate.resolve(anyString())).thenReturn(resolvedAddresses);
+
+        DialogueDnsResolver resolver = new ProtocolVersionFilteringDialogueDnsResolver(delegate);
+
+        assertThat(resolver.resolve("foo")).isEqualTo(resolvedIpv4Addresses);
+    }
+}


### PR DESCRIPTION
## Before this PR
It was possible for DefaultDialogueDnsResolver to resolve a hostname to a Set<InetAddress> containing e.g. pairs of (Inet4Address, Inet6Address). This can lead to problems downstream as dialogue won't be able to distinguish them as possibly pointing at the same host, and instead will try to treat them as different nodes.

## After this PR
Filter DNS resolution results to either IPv4 or IPv6 addresses, but not both. We assume that if a resolution result contains a mix of both IPv4 and IPv6 addresses, then they correspond to the same physical node, and we ignore the IPv6 addresses.

==COMMIT_MSG==
dns resolution uses only ipv4 or ipv6 addresses, but not both
==COMMIT_MSG==

## Possible downsides?
It is possible a name resolves to a set of IPv4 and IPv6 addresses that actually point to two different nodes; in that case, we'd be ignoring a valid resolved address.
