### PR TITLE
[feature/dns] DNS polling occurs on an instrumented shared scheduled executor

### DIFF
--- a/dialogue-clients/build.gradle
+++ b/dialogue-clients/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.revapi'
+apply plugin: 'com.palantir.metric-schema'
 apply plugin: 'com.palantir.metric-schema-markdown'
 
 dependencies {
@@ -21,6 +22,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.palantir.tritium:tritium-registry'
+    implementation 'com.palantir.tritium:tritium-metrics'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/dialogue-clients/build.gradle
+++ b/dialogue-clients/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.palantir.tritium:tritium-registry'
     implementation 'com.palantir.tritium:tritium-metrics'
+    implementation 'io.dropwizard.metrics:metrics-core'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -47,6 +47,14 @@ Dialogue client response metrics provided by the Apache client channel.
 Connection pool metrics from the dialogue Apache client.
 - `dialogue.client.pool.size` tagged `client-name`, `state` (gauge): Number of connections in the client connection pool in states `idle`, `pending`, and `leased`.
 
+## Dialogue Clients
+
+`com.palantir.dialogue:dialogue-clients`
+
+### client.dns
+Dialogue DNS metrics.
+- `client.dns.tasks` (counter): Number of active Dialogue DNS update background tasks currently scheduled.
+
 ## Dialogue Core
 
 `com.palantir.dialogue:dialogue-core`

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.codahale.metrics.Counter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
+import com.palantir.dialogue.core.DialogueDnsResolver;
+import com.palantir.dialogue.core.DialogueExecutors;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.refreshable.Disposable;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import com.palantir.tritium.metrics.MetricRegistries;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.lang.ref.Cleaner;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+final class DnsSupport {
+
+    private static final String SCHEDULER_NAME = "dialogue-client-dns-scheduler";
+
+    private static final Cleaner cleaner = Cleaner.create(new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("dialogue-client-dns-%d")
+            .build());
+
+    /*
+     * Shared single thread executor is reused between all DNS polling components. If it becomes oversaturated
+     * we may wait slightly longer than expected before refreshing DNS info, but this is an
+     * edge case where services are already operating in a degraded state.
+     */
+    @SuppressWarnings("deprecation") // Singleton registry for a singleton executor
+    private static final Supplier<ScheduledExecutorService> sharedScheduler =
+            Suppliers.memoize(() -> DialogueExecutors.newSharedSingleThreadScheduler(MetricRegistries.instrument(
+                    SharedTaggedMetricRegistries.getSingleton(),
+                    new ThreadFactoryBuilder()
+                            .setNameFormat(SCHEDULER_NAME + "-%d")
+                            .setDaemon(true)
+                            .build(),
+                    SCHEDULER_NAME)));
+
+    static Refreshable<ServicesConfigBlockWithResolvedHosts> pollForChanges(
+            DialogueDnsResolver dnsResolver,
+            Duration dnsRefreshInterval,
+            TaggedMetricRegistry metrics,
+            Refreshable<ServicesConfigBlock> input) {
+        return pollForChanges(sharedScheduler.get(), dnsResolver, dnsRefreshInterval, metrics, input);
+    }
+
+    @VisibleForTesting
+    static Refreshable<ServicesConfigBlockWithResolvedHosts> pollForChanges(
+            ScheduledExecutorService executor,
+            DialogueDnsResolver dnsResolver,
+            Duration dnsRefreshInterval,
+            TaggedMetricRegistry metrics,
+            Refreshable<ServicesConfigBlock> input) {
+        SettableRefreshable<ServicesConfigBlockWithResolvedHosts> dnsResolutionResult =
+                Refreshable.create(ServicesConfigBlockWithResolvedHosts.empty());
+
+        DialogueDnsResolutionWorker dnsResolutionWorker =
+                new DialogueDnsResolutionWorker(dnsResolver, dnsResolutionResult);
+
+        ScheduledFuture<?> future = executor.scheduleWithFixedDelay(
+                dnsResolutionWorker,
+                dnsRefreshInterval.toMillis(),
+                dnsRefreshInterval.toMillis(),
+                TimeUnit.MILLISECONDS);
+        Counter counter = ClientDnsMetrics.of(metrics).tasks();
+        counter.inc();
+        Disposable disposable = input.subscribe(dnsResolutionWorker::update);
+        cleaner.register(dnsResolutionResult, new CleanupTask(disposable, future, counter));
+        return dnsResolutionResult;
+    }
+
+    private DnsSupport() {}
+
+    // We define a concrete class here to avoid accidental lambda references to the
+    // cleaner target.
+    private static final class CleanupTask implements Runnable {
+
+        private static final SafeLogger log = SafeLoggerFactory.get(CleanupTask.class);
+
+        private final AtomicBoolean executed = new AtomicBoolean();
+        private final Disposable disposable;
+        private final ScheduledFuture<?> scheduledFuture;
+        private final Counter activeTasks;
+
+        private CleanupTask(Disposable disposable, ScheduledFuture<?> scheduledFuture, Counter activeTasks) {
+            this.disposable = disposable;
+            this.scheduledFuture = scheduledFuture;
+            this.activeTasks = activeTasks;
+        }
+
+        @Override
+        public void run() {
+            if (!executed.getAndSet(true)) {
+                log.debug("Unregistering dns update background worker");
+                disposable.dispose();
+                scheduledFuture.cancel(false);
+                activeTasks.dec();
+            }
+        }
+    }
+}

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -1,0 +1,10 @@
+options:
+  javaPackage: com.palantir.dialogue.clients
+  javaVisibility: packagePrivate
+namespaces:
+  client.dns:
+    docs: Dialogue DNS metrics.
+    metrics:
+      tasks:
+        type: counter
+        docs: Number of active Dialogue DNS update background tasks currently scheduled.


### PR DESCRIPTION
This removes some code cruft from ReloadingClientFactory, and carves out space to support "non-reloadable" client implementations with helper utils in the `DnsSupport` class.

Using a scheduled executor allows us to avoid thread explosion even in the face of dialogue factory misuse.

==COMMIT_MSG==
DNS polling occurs on an instrumented shared scheduled executor
==COMMIT_MSG==
