### PR TITLE
dns-based discovery handles mesh-mode similarly to existence of a proxy

### DIFF
--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -109,7 +109,7 @@ final class ChannelCache {
             OptionalInt overrideHostIndex) {
         ImmutableList<TargetUri> uris = serviceConf.uris().stream()
                 // Using a TargetUri with a uri and no resolvedAddress preserves the legacy Dialogue behavior.
-                .map(uri -> TargetUri.builder().uri(uri).build())
+                .map(TargetUri::of)
                 .collect(ImmutableList.toImmutableList());
         return getNonReloadingChannel(reloadingParams, serviceConf, uris, channelName, overrideHostIndex);
     }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueDnsResolutionWorker.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueDnsResolutionWorker.java
@@ -76,6 +76,9 @@ final class DialogueDnsResolutionWorker implements Runnable {
         if (inputState != null) {
             ImmutableSet<String> allHosts = inputState.services().values().stream()
                     .flatMap(psc -> psc.uris().stream()
+                            // n.b. we could filter out hosts with specify a proxy and mesh-mode
+                            // uris here, however it's simpler to resolve everything, and use what
+                            // we need when TargetUri instances are constructed.
                             .map(uriString -> {
                                 try {
                                     URI uri = new URI(uriString);

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
@@ -96,6 +96,16 @@ final class DnsSupport {
         return dnsResolutionResult;
     }
 
+    /**
+     * This prefix may reconfigure several aspects of the client to work better in a world where requests are routed
+     * through a service mesh like istio/envoy.
+     */
+    private static final String MESH_PREFIX = "mesh-";
+
+    static boolean isMeshMode(String uri) {
+        return uri.startsWith(MESH_PREFIX);
+    }
+
     private DnsSupport() {}
 
     // We define a concrete class here to avoid accidental lambda references to the

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -445,9 +445,11 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
             if (parsed == null || parsed.getHost() == null) {
                 continue;
             }
+            // Mesh mode does not require any form of dns updating because all dns results
+            // are considered equivalent.
             // When a proxy is used, pre-resolved IP addresses have no impact. In many cases the
             // proxy handles DNS resolution.
-            if (usesProxy(proxySelector, parsed)) {
+            if (DnsSupport.isMeshMode(uri) || usesProxy(proxySelector, parsed)) {
                 targetUris.add(TargetUri.builder().uri(uri).build());
             } else {
                 String host = parsed.getHost();

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -450,7 +450,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
             // When a proxy is used, pre-resolved IP addresses have no impact. In many cases the
             // proxy handles DNS resolution.
             if (DnsSupport.isMeshMode(uri) || usesProxy(proxySelector, parsed)) {
-                targetUris.add(TargetUri.builder().uri(uri).build());
+                targetUris.add(TargetUri.of(uri));
             } else {
                 String host = parsed.getHost();
                 Set<InetAddress> resolvedAddresses = resolvedHosts.get(host);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Config.java
@@ -44,10 +44,7 @@ interface Config {
 
     @Value.Default
     default List<TargetUri> uris() {
-        return rawConfig().uris().stream()
-                .map(MeshMode::stripMeshPrefix)
-                .map(uri -> TargetUri.builder().uri(uri).build())
-                .collect(Collectors.toList());
+        return rawConfig().uris().stream().map(TargetUri::of).collect(Collectors.toList());
     }
 
     @Value.Derived
@@ -99,7 +96,7 @@ interface Config {
                 rawConfig().retryOnSocketException() == ClientConfiguration.RetryOnSocketException.ENABLED,
                 "Retries on socket exceptions cannot be disabled without disabling retries entirely.");
 
-        if (rawConfig().uris().size() > 1 && overrideSingleHostIndex().isPresent()) {
+        if (uris().size() > 1 && overrideSingleHostIndex().isPresent()) {
             throw new SafeIllegalArgumentException(
                     "overrideHostIndex is only permitted when there is a single uri",
                     SafeArg.of("numUris", rawConfig().uris().size()));

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -77,8 +77,9 @@ final class ContentDecodingChannel implements EndpointChannel {
         // In mesh mode or environments which appear to be within an environment,
         // prefer not to request compressed responses. This heuristic assumes response
         // compression should not be used in a service mesh, nor when load balancing
-        // is handled by the client.
-        return cf.mesh() == MeshMode.DEFAULT_NO_MESH && cf.clientConf().uris().size() == 1;
+        // is handled by the client. Note that this will also opt out of response
+        // compression when the target host resolves to multiple IP addresses.
+        return cf.mesh() == MeshMode.DEFAULT_NO_MESH && cf.uris().size() == 1;
     }
 
     @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/TargetUri.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/TargetUri.java
@@ -69,6 +69,10 @@ public final class TargetUri {
         return result;
     }
 
+    public static TargetUri of(String uri) {
+        return builder().uri(uri).build();
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -83,8 +87,9 @@ public final class TargetUri {
 
         private Builder() {}
 
+        /** Sets the {@link #uri} field. Note that this does not retain service-mesh prefixes. */
         public Builder uri(String value) {
-            this.uri = Preconditions.checkNotNull(value, "uri");
+            this.uri = MeshMode.stripMeshPrefix(Preconditions.checkNotNull(value, "uri"));
             return this;
         }
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentDecodingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ContentDecodingChannelTest.java
@@ -36,6 +36,7 @@ import com.palantir.dialogue.TestResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 import javax.net.ssl.SSLContext;
@@ -57,12 +58,15 @@ public final class ContentDecodingChannelTest {
                 ImmutableList.of("https://localhost:8123"),
                 SSLContext.getDefault().getSocketFactory(),
                 tm);
+        List<TargetUri> targets = ImmutableList.of(TargetUri.of("https://localhost:8123"));
         standard = Mockito.mock(Config.class);
         Mockito.when(standard.mesh()).thenReturn(MeshMode.DEFAULT_NO_MESH);
         Mockito.when(standard.clientConf()).thenReturn(clientConfig);
+        Mockito.when(standard.uris()).thenReturn(targets);
         mesh = Mockito.mock(Config.class);
         Mockito.when(mesh.mesh()).thenReturn(MeshMode.USE_EXTERNAL_MESH);
         Mockito.when(mesh.clientConf()).thenReturn(clientConfig);
+        Mockito.when(mesh.uris()).thenReturn(targets);
     }
 
     @Test


### PR DESCRIPTION
==COMMIT_MSG==
dns-based discovery handles mesh-mode similarly to existence of a proxy
==COMMIT_MSG==