### PR TITLE
[feature/dns] metric for timing dns polling sweep

### DIFF
--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -55,7 +55,7 @@ Connection pool metrics from the dialogue Apache client.
 Dialogue DNS metrics.
 - `client.dns.tasks` (counter): Number of active Dialogue DNS update background tasks currently scheduled.
   - `kind`: Describes the type of component polling for DNS updates.
-- `client.dns.resolveTime` (timer): Measures the time taken to complete a full pass polling for DNS updates.
+- `client.dns.refresh` (timer): Measures the time taken to complete a full pass polling for DNS updates.
   - `kind`: Describes the type of component polling for DNS updates.
 
 ## Dialogue Core

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -55,6 +55,7 @@ Connection pool metrics from the dialogue Apache client.
 Dialogue DNS metrics.
 - `client.dns.tasks` (counter): Number of active Dialogue DNS update background tasks currently scheduled.
   - `kind`: Describes the type of component polling for DNS updates.
+- `client.dns.resolveTime` (timer): Measures the time taken to complete a full pass polling for DNS updates.
 
 ## Dialogue Core
 

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -56,6 +56,7 @@ Dialogue DNS metrics.
 - `client.dns.tasks` (counter): Number of active Dialogue DNS update background tasks currently scheduled.
   - `kind`: Describes the type of component polling for DNS updates.
 - `client.dns.resolveTime` (timer): Measures the time taken to complete a full pass polling for DNS updates.
+  - `kind`: Describes the type of component polling for DNS updates.
 
 ## Dialogue Core
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueDnsResolutionWorker.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueDnsResolutionWorker.java
@@ -29,6 +29,7 @@ import java.lang.ref.WeakReference;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -69,7 +70,7 @@ final class DialogueDnsResolutionWorker<INPUT> implements Runnable {
                 // this logging may be helpful in informing us of problems in the system.
                 log.info("Output refreshable has been garbage collected, no need to continue polling");
             } else {
-                updateTimer.time(() -> doUpdate(null));
+                doUpdate(null);
             }
         } catch (Throwable t) {
             log.error("Scheduled DNS update failed", t);
@@ -77,6 +78,7 @@ final class DialogueDnsResolutionWorker<INPUT> implements Runnable {
     }
 
     private synchronized void doUpdate(@Nullable INPUT updatedInputState) {
+        long start = System.nanoTime();
         if (updatedInputState != null && !updatedInputState.equals(inputState)) {
             inputState = updatedInputState;
         }
@@ -109,5 +111,7 @@ final class DialogueDnsResolutionWorker<INPUT> implements Runnable {
                 log.info("Attempted to update DNS output refreshable which has already been garbage collected");
             }
         }
+        long end = System.nanoTime();
+        updateTimer.update(Duration.ofNanos(end - start));
     }
 }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueDnsResolutionWorker.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueDnsResolutionWorker.java
@@ -28,9 +28,9 @@ import java.lang.ref.WeakReference;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 final class DialogueDnsResolutionWorker<INPUT> implements Runnable {
@@ -110,7 +110,7 @@ final class DialogueDnsResolutionWorker<INPUT> implements Runnable {
                 log.info("Attempted to update DNS output refreshable which has already been garbage collected");
             }
             long end = System.nanoTime();
-            updateTimer.update(Duration.ofNanos(end - start));
+            updateTimer.update(end - start, TimeUnit.NANOSECONDS);
         }
     }
 }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue.clients;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.dialogue.core.DialogueDnsResolver;
@@ -89,8 +90,9 @@ final class DnsSupport {
         @SuppressWarnings("NullAway")
         SettableRefreshable<DnsResolutionResults<I>> dnsResolutionResult = Refreshable.create(null);
 
+        Timer workerUpdateTimer = ClientDnsMetrics.of(metrics).resolveTime(spec.kind());
         DialogueDnsResolutionWorker<I> dnsResolutionWorker =
-                new DialogueDnsResolutionWorker<>(spec, dnsResolver, dnsResolutionResult, metrics);
+                new DialogueDnsResolutionWorker<>(spec, dnsResolver, dnsResolutionResult, workerUpdateTimer);
 
         ScheduledFuture<?> future = executor.scheduleWithFixedDelay(
                 dnsResolutionWorker,

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
@@ -90,7 +90,7 @@ final class DnsSupport {
         SettableRefreshable<DnsResolutionResults<I>> dnsResolutionResult = Refreshable.create(null);
 
         DialogueDnsResolutionWorker<I> dnsResolutionWorker =
-                new DialogueDnsResolutionWorker<>(spec, dnsResolver, dnsResolutionResult);
+                new DialogueDnsResolutionWorker<>(spec, dnsResolver, dnsResolutionResult, metrics);
 
         ScheduledFuture<?> future = executor.scheduleWithFixedDelay(
                 dnsResolutionWorker,

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DnsSupport.java
@@ -90,7 +90,7 @@ final class DnsSupport {
         @SuppressWarnings("NullAway")
         SettableRefreshable<DnsResolutionResults<I>> dnsResolutionResult = Refreshable.create(null);
 
-        Timer workerUpdateTimer = ClientDnsMetrics.of(metrics).resolveTime(spec.kind());
+        Timer workerUpdateTimer = ClientDnsMetrics.of(metrics).refresh(spec.kind());
         DialogueDnsResolutionWorker<I> dnsResolutionWorker =
                 new DialogueDnsResolutionWorker<>(spec, dnsResolver, dnsResolutionResult, workerUpdateTimer);
 

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -13,4 +13,7 @@ namespaces:
         docs: Number of active Dialogue DNS update background tasks currently scheduled.
       resolveTime:
         type: timer
+        tags:
+          - name: kind
+            docs: Describes the type of component polling for DNS updates.
         docs: Measures the time taken to complete a full pass polling for DNS updates.

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -11,7 +11,7 @@ namespaces:
           - name: kind
             docs: Describes the type of component polling for DNS updates.
         docs: Number of active Dialogue DNS update background tasks currently scheduled.
-      resolveTime:
+      refresh:
         type: timer
         tags:
           - name: kind

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -11,3 +11,6 @@ namespaces:
           - name: kind
             docs: Describes the type of component polling for DNS updates.
         docs: Number of active Dialogue DNS update background tasks currently scheduled.
+      resolveTime:
+        type: timer
+        docs: Measures the time taken to complete a full pass polling for DNS updates.


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
metric for timing dns polling sweep
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
