### PR TITLE
handle invalid URIs

### DIFF
--- a/changelog/@unreleased/pr-2171.v2.yml
+++ b/changelog/@unreleased/pr-2171.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: handle invalid URIs
+  links:
+  - https://github.com/palantir/dialogue/pull/2171

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -498,6 +498,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         });
     }
 
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private ImmutableList<TargetUri> getTargetUris(
             @Safe String serviceNameForLogging,
             Collection<String> uris,
@@ -534,7 +535,10 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
             }
         }
         if (targetUris.isEmpty() && failedToParse) {
-            // Handle cases like "host:-1"
+            // Handle cases like "host:-1", but only when _all_ uris are invalid
+            log.warn(
+                    "Failed to parse all URIs, falling back to legacy DNS approach for service '{}'",
+                    SafeArg.of("service", serviceNameForLogging));
             return uris.stream().map(TargetUri::of).collect(ImmutableList.toImmutableList());
         }
         return ImmutableList.copyOf(targetUris);


### PR DESCRIPTION
## Before this PR
The DNS feature changed the way invalid URIs were handled, where -1 was supported.

## After this PR
==COMMIT_MSG==
handle invalid URIs
==COMMIT_MSG==
