### PR TITLE
Increment a metric when URIs fail to parse

### DIFF
--- a/changelog/@unreleased/pr-2173.v2.yml
+++ b/changelog/@unreleased/pr-2173.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increment a metric when URIs fail to parse
+  links:
+  - https://github.com/palantir/dialogue/pull/2173

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -64,6 +64,10 @@ Dialogue DNS metrics.
 - `client.dns.refresh` (timer): Measures the time taken to complete a full pass polling for DNS updates.
   - `kind`: Describes the type of component polling for DNS updates.
 
+### client.uri
+Dialogue URI parsing metrics.
+- `client.uri.invalid` tagged `service` (meter): Meter which is incremented any time an invalid URI is read.
+
 ## Dialogue Core
 
 `com.palantir.dialogue:dialogue-core`

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -2,6 +2,13 @@ options:
   javaPackage: com.palantir.dialogue.clients
   javaVisibility: packagePrivate
 namespaces:
+  client.uri:
+    docs: Dialogue URI parsing metrics.
+    metrics:
+      invalid:
+        type: meter
+        tags: [service]
+        docs: Meter which is incremented any time an invalid URI is read.
   client.dns:
     docs: Dialogue DNS metrics.
     metrics:

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DialogueClientsDnsIntegrationTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DialogueClientsDnsIntegrationTest.java
@@ -19,6 +19,7 @@ package com.palantir.dialogue.clients;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -401,6 +402,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .build());
         TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
         Counter activeTasks = ClientDnsMetrics.of(metrics).tasks(DnsPollingSpec.RELOADING_FACTORY.kind());
+        Meter invalidUris = ClientUriMetrics.of(metrics).invalid("service");
         Refreshable<List<Channel>> perHostChannels = DialogueClients.create(
                         Refreshable.only(ServicesConfigBlock.builder()
                                 .defaultSecurity(TestConfigurations.SSL_CONFIG)
@@ -422,6 +424,7 @@ public class DialogueClientsDnsIntegrationTest {
         assertThat(activeTasks.getCount())
                 .as("Background dns refreshing should not be scheduled when the feature is disabled")
                 .isZero();
+        assertThat(invalidUris.getCount()).isGreaterThan(0);
     }
 
     @Test


### PR DESCRIPTION
This includes additional logging in the port=-1 case as well, since URI parsing doesn't in fact fail, but produces a uri with no host component.

We'll add a default monitor on this, letting folks know things are going sideways

==COMMIT_MSG==
Increment a metric when URIs fail to parse
==COMMIT_MSG==
