### PR TITLE
Use the 'channel-name' tag to avoid overloading 'service'

### DIFF
--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -66,7 +66,7 @@ Dialogue DNS metrics.
 
 ### client.uri
 Dialogue URI parsing metrics.
-- `client.uri.invalid` tagged `service` (meter): Meter which is incremented any time an invalid URI is read.
+- `client.uri.invalid` tagged `channel-name` (meter): Meter which is incremented any time an invalid URI is read.
 
 ## Dialogue Core
 

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -7,7 +7,7 @@ namespaces:
     metrics:
       invalid:
         type: meter
-        tags: [service]
+        tags: [channel-name]
         docs: Meter which is incremented any time an invalid URI is read.
   client.dns:
     docs: Dialogue DNS metrics.


### PR DESCRIPTION
==COMMIT_MSG==
Use the 'channel-name' tag to avoid overloading 'service'
==COMMIT_MSG==