### PR TITLE
Implement a DNS fallback cache to avoid failures in DNS outages

### DIFF
--- a/changelog/@unreleased/pr-2176.v2.yml
+++ b/changelog/@unreleased/pr-2176.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement a DNS fallback cache to avoid failures in DNS outages
+  links:
+  - https://github.com/palantir/dialogue/pull/2176

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -63,6 +63,11 @@ Dialogue DNS metrics.
   - `kind`: Describes the type of component polling for DNS updates.
 - `client.dns.refresh` (timer): Measures the time taken to complete a full pass polling for DNS updates.
   - `kind`: Describes the type of component polling for DNS updates.
+- `client.dns.lookup` (meter): DNS resolver query metrics, on a per-hostname basis.
+  - `result`
+    - `success`: DNS resolution succeeded using `InetAddress.getAllByName`.
+    - `fallback`: DNS resolution using the primary mechanism failed, however addresses were available in the fallback cache.
+    - `failure`: No addresses could be resolved for the given hostname.
 
 ### client.uri
 Dialogue URI parsing metrics.

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/CachingFallbackDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/CachingFallbackDnsResolver.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.codahale.metrics.Meter;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.dialogue.clients.ClientDnsMetrics.Lookup_Result;
+import com.palantir.dialogue.core.DialogueDnsResolver;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.net.InetAddress;
+import java.time.Duration;
+
+final class CachingFallbackDnsResolver implements DialogueDnsResolver {
+    private static final SafeLogger log = SafeLoggerFactory.get(CachingFallbackDnsResolver.class);
+
+    private final DialogueDnsResolver delegate;
+    private final Meter lookupSuccess;
+    private final Meter lookupFallback;
+    private final Meter lookupFailure;
+
+    private final Cache<String, ImmutableSet<InetAddress>> fallbackCache;
+
+    CachingFallbackDnsResolver(DialogueDnsResolver delegate, TaggedMetricRegistry registry) {
+        this.delegate = delegate;
+        this.fallbackCache = Caffeine.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(Duration.ofMinutes(10))
+                .build();
+        ClientDnsMetrics metrics = ClientDnsMetrics.of(registry);
+        this.lookupSuccess = metrics.lookup(Lookup_Result.SUCCESS);
+        this.lookupFallback = metrics.lookup(Lookup_Result.FALLBACK);
+        this.lookupFailure = metrics.lookup(Lookup_Result.FAILURE);
+    }
+
+    @Override
+    public ImmutableSet<InetAddress> resolve(String hostname) {
+        ImmutableSet<InetAddress> result = delegate.resolve(hostname);
+        if (result.isEmpty()) {
+            ImmutableSet<InetAddress> maybeFallback = fallbackCache.getIfPresent(hostname);
+            if (maybeFallback != null) {
+                lookupFallback.mark();
+                log.info(
+                        "DNS resolution failed for host '{}', however fallback addresses are present in the cache",
+                        UnsafeArg.of("hostname", hostname));
+                return maybeFallback;
+            } else {
+                lookupFailure.mark();
+            }
+        } else {
+            lookupSuccess.mark();
+            fallbackCache.put(hostname, result);
+        }
+        return result;
+    }
+}

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -160,7 +160,9 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
         @Value.Default
         default DialogueDnsResolver dnsResolver() {
-            return new ProtocolVersionFilteringDialogueDnsResolver(DefaultDialogueDnsResolver.INSTANCE);
+            return new CachingFallbackDnsResolver(
+                    new ProtocolVersionFilteringDialogueDnsResolver(DefaultDialogueDnsResolver.INSTANCE),
+                    taggedMetrics());
         }
 
         @Value.Default

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -24,3 +24,16 @@ namespaces:
           - name: kind
             docs: Describes the type of component polling for DNS updates.
         docs: Measures the time taken to complete a full pass polling for DNS updates.
+      lookup:
+        type: meter
+        tags:
+          - name: result
+            values:
+              - value: success
+                docs: DNS resolution succeeded using `InetAddress.getAllByName`.
+              - value: fallback
+                docs: DNS resolution using the primary mechanism failed, however
+                      addresses were available in the fallback cache.
+              - value: failure
+                docs: No addresses could be resolved for the given hostname.
+        docs: DNS resolver query metrics, on a per-hostname basis.

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/CachingFallbackDnsResolverTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/CachingFallbackDnsResolverTest.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Meter;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.MultimapBuilder.SetMultimapBuilder;
+import com.google.common.collect.SetMultimap;
+import com.palantir.dialogue.clients.ClientDnsMetrics.Lookup_Result;
+import com.palantir.dialogue.core.DialogueDnsResolver;
+import com.palantir.dialogue.util.MapBasedDnsResolver;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.junit.jupiter.api.Test;
+
+class CachingFallbackDnsResolverTest {
+
+    @Test
+    void successfulUpdate() throws UnknownHostException {
+        TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        Meter lookupSuccessMeter = ClientDnsMetrics.of(registry).lookup(Lookup_Result.SUCCESS);
+        SetMultimap<String, InetAddress> dnsEntries =
+                SetMultimapBuilder.linkedHashKeys().linkedHashSetValues().build();
+        InetAddress initialAddress = InetAddress.getByAddress("host", new byte[] {127, 0, 0, 1});
+        InetAddress updatedAddress = InetAddress.getByAddress("host", new byte[] {127, 0, 0, 2});
+        dnsEntries.put("host", initialAddress);
+        DialogueDnsResolver delegate = new MapBasedDnsResolver(dnsEntries);
+        DialogueDnsResolver cached = new CachingFallbackDnsResolver(delegate, registry);
+        assertThat(cached.resolve("host")).containsExactly(initialAddress);
+        assertThat(lookupSuccessMeter.getCount()).isEqualTo(1);
+        dnsEntries.clear();
+        dnsEntries.put("host", updatedAddress);
+        assertThat(cached.resolve("host")).containsExactly(updatedAddress);
+        assertThat(lookupSuccessMeter.getCount()).isEqualTo(2);
+    }
+
+    @Test
+    void failure() {
+        TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        Meter lookupFailureMeter = ClientDnsMetrics.of(registry).lookup(Lookup_Result.FAILURE);
+        DialogueDnsResolver delegate = new MapBasedDnsResolver(ImmutableSetMultimap.of());
+        DialogueDnsResolver cached = new CachingFallbackDnsResolver(delegate, registry);
+        assertThat(cached.resolve("host")).isEmpty();
+        assertThat(lookupFailureMeter.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void fallback() throws UnknownHostException {
+        TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        Meter lookupSuccessMeter = ClientDnsMetrics.of(registry).lookup(Lookup_Result.SUCCESS);
+        Meter lookupFallbackMeter = ClientDnsMetrics.of(registry).lookup(Lookup_Result.FALLBACK);
+        Meter lookupFailureMeter = ClientDnsMetrics.of(registry).lookup(Lookup_Result.FAILURE);
+        SetMultimap<String, InetAddress> dnsEntries =
+                SetMultimapBuilder.linkedHashKeys().linkedHashSetValues().build();
+        InetAddress address = InetAddress.getByAddress("host", new byte[] {127, 0, 0, 1});
+        dnsEntries.put("host", address);
+        DialogueDnsResolver delegate = new MapBasedDnsResolver(dnsEntries);
+        DialogueDnsResolver cached = new CachingFallbackDnsResolver(delegate, registry);
+        assertThat(cached.resolve("host")).containsExactly(address);
+        assertThat(lookupSuccessMeter.getCount()).isEqualTo(1);
+        assertThat(lookupFallbackMeter.getCount()).isEqualTo(0);
+        dnsEntries.clear();
+        assertThat(cached.resolve("host"))
+                .as("host should still resolve to 'address' using the fallback cache")
+                .containsExactly(address);
+        assertThat(lookupSuccessMeter.getCount()).isEqualTo(1);
+        assertThat(lookupFallbackMeter.getCount()).isEqualTo(1);
+        assertThat(lookupFailureMeter.getCount()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
==COMMIT_MSG==
Implement a DNS fallback cache to avoid failures in DNS outages
==COMMIT_MSG==