### PR TITLE
add more specific metrics and logging for DNS lookup failures

### DIFF
--- a/changelog/@unreleased/pr-2179.v2.yml
+++ b/changelog/@unreleased/pr-2179.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: try to log error messages when getaddrinfo fails
+  links:
+  - https://github.com/palantir/dialogue/pull/2179

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -68,6 +68,8 @@ Dialogue DNS metrics.
     - `success`: DNS resolution succeeded using `InetAddress.getAllByName`.
     - `fallback`: DNS resolution using the primary mechanism failed, however addresses were available in the fallback cache.
     - `failure`: No addresses could be resolved for the given hostname.
+- `client.dns.lookupError` (meter): DNS resolver query failures.
+  - `error-type`: Describes the error type returned by getaddrinfo() when lookup fails.
 
 ### client.uri
 Dialogue URI parsing metrics.

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -68,7 +68,7 @@ Dialogue DNS metrics.
     - `success`: DNS resolution succeeded using `InetAddress.getAllByName`.
     - `fallback`: DNS resolution using the primary mechanism failed, however addresses were available in the fallback cache.
     - `failure`: No addresses could be resolved for the given hostname.
-- `client.dns.lookupError` (meter): DNS resolver query failures.
+- `client.dns.failure` (meter): DNS resolver query failures.
   - `error-type`: Describes the error type returned by getaddrinfo() when lookup fails.
 
 ### client.uri

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
@@ -16,14 +16,18 @@
 
 package com.palantir.dialogue.clients;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.dialogue.core.DialogueDnsResolver;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
+import org.immutables.value.Value;
 
 enum DefaultDialogueDnsResolver implements DialogueDnsResolver {
     INSTANCE;
@@ -41,8 +45,60 @@ enum DefaultDialogueDnsResolver implements DialogueDnsResolver {
             }
             return ImmutableSet.copyOf(results);
         } catch (UnknownHostException e) {
-            log.warn("Unknown host '{}'", UnsafeArg.of("hostname", hostname), e);
+            ExtractedGaiError gaiError = extractGaiErrorString(e);
+            log.warn(
+                    "Unknown host '{}'",
+                    SafeArg.of("gaiErrorMessage", gaiError.getErrorMessage()),
+                    SafeArg.of("gaiErrorType", gaiError.getErrorType()),
+                    UnsafeArg.of("hostname", hostname),
+                    e);
             return ImmutableSet.of();
         }
+    }
+
+    // these strings were taken from glibc-2.39, but likely have not changed in quite a while
+    // strings may be different on BSD systems like macos
+    // TODO(dns): update this list to try to match against known strings on other platforms
+    private static final Map<String, String> EXPECTED_GAI_ERROR_STRINGS = ImmutableMap.<String, String>builder()
+            .put("Address family for hostname not supported", "EAI_ADDRFAMILY")
+            .put("Temporary failure in name resolution", "EAI_AGAIN")
+            .put("Bad value for ai_flags", "EAI_BADFLAGS")
+            .put("Non-recoverable failure in name resolution", "EAI_FAIL")
+            .put("ai_family not supported", "EAI_FAMILY")
+            .put("Memory allocation failure", "EAI_MEMORY")
+            .put("No address associated with hostname", "EAI_NODATA")
+            .put("Name or service not known", "EAI_NONAME")
+            .put("Servname not supported for ai_socktype", "EAI_SERVICE")
+            .put("ai_socktype not supported", "EAI_SOCKTYPE")
+            .put("System error", "EAI_SYSTEM")
+            .put("Processing request in progress", "EAI_INPROGRESS")
+            .put("Request canceled", "EAI_CANCELED")
+            .put("Request not canceled", "EAI_NOTCANCELED")
+            .put("All requests done", "EAI_ALLDONE")
+            .put("Interrupted by a signal", "EAI_INTR")
+            .put("Parameter string not correctly encoded", "EAI_IDN_ENCODE")
+            .put("Result too large for supplied buffer", "EAI_OVERFLOW")
+            .buildOrThrow();
+
+    @Value.Immutable
+    interface ExtractedGaiError {
+        @Value.Parameter
+        String getErrorMessage();
+
+        @Value.Parameter
+        String getErrorType();
+    }
+
+    private static ExtractedGaiError extractGaiErrorString(UnknownHostException exception) {
+        try {
+            for (Map.Entry<String, String> entry : EXPECTED_GAI_ERROR_STRINGS.entrySet()) {
+                if (exception.getMessage() != null && exception.getMessage().contains(entry.getKey())) {
+                    return ImmutableExtractedGaiError.of(entry.getKey(), entry.getValue());
+                }
+            }
+        } catch (Exception e) {
+            return ImmutableExtractedGaiError.of("unknown", "unknown");
+        }
+        return ImmutableExtractedGaiError.of("unknown", "unknown");
     }
 }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
@@ -45,7 +45,12 @@ enum DefaultDialogueDnsResolver implements DialogueDnsResolver {
             return ImmutableSet.copyOf(results);
         } catch (UnknownHostException e) {
             GaiError gaiError = extractGaiErrorString(e);
-            log.warn("Unknown host '{}'", SafeArg.of("gaiError", gaiError), UnsafeArg.of("hostname", hostname), e);
+            log.warn(
+                    "Unknown host '{}'",
+                    SafeArg.of("gaiErrorType", gaiError.name()),
+                    SafeArg.of("gaiErrorMessage", gaiError.errorMessage()),
+                    UnsafeArg.of("hostname", hostname),
+                    e);
             return ImmutableSet.of();
         }
     }
@@ -87,7 +92,7 @@ enum DefaultDialogueDnsResolver implements DialogueDnsResolver {
 
         @Safe
         String errorMessage() {
-            return errorMessage.orElse(name());
+            return errorMessage.orElseGet(this::name);
         }
     }
 
@@ -102,7 +107,8 @@ enum DefaultDialogueDnsResolver implements DialogueDnsResolver {
 
                 for (GaiError error : GaiError.values()) {
                     if (error.errorMessage.isPresent()) {
-                        if (exception.getMessage().contains(error.errorMessage.get())) {
+                        if (exception.getMessage() != null
+                                && exception.getMessage().contains(error.errorMessage.get())) {
                             return error;
                         }
                     }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
@@ -50,14 +50,14 @@ final class DefaultDialogueDnsResolver implements DialogueDnsResolver {
             }
             return ImmutableSet.copyOf(results);
         } catch (UnknownHostException e) {
-            GaiError gaiError = extractGaiErrorString(e, hostname);
+            GaiError gaiError = extractGaiError(e, hostname);
             log.warn(
                     "Unknown host '{}'",
                     SafeArg.of("gaiErrorType", gaiError.name()),
                     SafeArg.of("gaiErrorMessage", gaiError.errorMessage()),
                     UnsafeArg.of("hostname", hostname),
                     e);
-            metrics.lookupError(gaiError.name()).mark();
+            metrics.failure(gaiError.name()).mark();
             return ImmutableSet.of();
         }
     }
@@ -103,7 +103,7 @@ final class DefaultDialogueDnsResolver implements DialogueDnsResolver {
         }
     }
 
-    private static GaiError extractGaiErrorString(UnknownHostException exception, String requestedHostname) {
+    private static GaiError extractGaiError(UnknownHostException exception, String requestedHostname) {
         if (exception.getMessage() == null) {
             return GaiError.UNKNOWN;
         }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
@@ -77,7 +77,6 @@ enum DefaultDialogueDnsResolver implements DialogueDnsResolver {
         EAI_IDN_ENCODE("Parameter string not correctly encoded"),
         EAI_OVERFLOW("Result too large for supplied buffer"),
         CACHED(),
-        NULL(),
         UNKNOWN();
 
         private final Optional<String> errorMessage;
@@ -96,10 +95,6 @@ enum DefaultDialogueDnsResolver implements DialogueDnsResolver {
     }
 
     private static GaiError extractGaiErrorString(UnknownHostException exception) {
-        if (exception == null) {
-            return GaiError.NULL;
-        }
-
         try {
             StackTraceElement[] trace = exception.getStackTrace();
             if (trace.length > 0) {

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
@@ -52,7 +52,7 @@ final class DefaultDialogueDnsResolver implements DialogueDnsResolver {
         } catch (UnknownHostException e) {
             GaiError gaiError = extractGaiError(e, hostname);
             log.warn(
-                    "Unknown host '{}'",
+                    "Unknown host '{}'. {}: {}",
                     SafeArg.of("gaiErrorType", gaiError.name()),
                     SafeArg.of("gaiErrorMessage", gaiError.errorMessage()),
                     UnsafeArg.of("hostname", hostname),

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -161,7 +161,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         @Value.Default
         default DialogueDnsResolver dnsResolver() {
             return new CachingFallbackDnsResolver(
-                    new ProtocolVersionFilteringDialogueDnsResolver(DefaultDialogueDnsResolver.INSTANCE),
+                    new ProtocolVersionFilteringDialogueDnsResolver(new DefaultDialogueDnsResolver(taggedMetrics())),
                     taggedMetrics());
         }
 

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -37,7 +37,7 @@ namespaces:
               - value: failure
                 docs: No addresses could be resolved for the given hostname.
         docs: DNS resolver query metrics, on a per-hostname basis.
-      lookupError:
+      failure:
         type: meter
         tags: 
           - name: error-type

--- a/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-clients/src/main/metrics/dialogue-core-metrics.yml
@@ -37,3 +37,9 @@ namespaces:
               - value: failure
                 docs: No addresses could be resolved for the given hostname.
         docs: DNS resolver query metrics, on a per-hostname basis.
+      lookupError:
+        type: meter
+        tags: 
+          - name: error-type
+            docs: Describes the error type returned by getaddrinfo() when lookup fails.
+        docs: DNS resolver query failures.

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolverTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolverTest.java
@@ -103,7 +103,7 @@ class DefaultDialogueDnsResolverTest {
         // should resolve from cache
         ImmutableSet<InetAddress> result2 = resolver.resolve(badHost);
         assertThat(result2).isEmpty();
-        assertThat(metrics.failure("CACHED").getCount()).isGreaterThan(0);
+        assertThat(metrics.failure("CACHED").getCount()).isEqualTo(1);
     }
 
     private static ImmutableSet<InetAddress> resolve(String hostname) {

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolverTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolverTest.java
@@ -80,7 +80,7 @@ class DefaultDialogueDnsResolverTest {
         TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
         DialogueDnsResolver resolver = new DefaultDialogueDnsResolver(registry);
 
-        String badHost = "alksdjflajsdlkfjalksjflkadjsf.com";
+        String badHost = UUID.randomUUID() + ".palantir.com";
         ImmutableSet<InetAddress> result = resolver.resolve(badHost);
 
         assertThat(result).isEmpty();


### PR DESCRIPTION
## Before this PR
DNS lookups that result in an UnknownHostException are logged, but the exception message is logged unsafely which can make it hard to determine what the actual failure was. Under the hood, the error returned by `getaddrinfo()` is converted to a string via `gai_strerror` and used as the message for the generated `UnknownHostException`, which can be useful in determining what type of failure actually triggered the exception.

## After this PR
Try to match strings generated by `gai_strerror` against the exception message, and log only the `EAI_*` error types and corresponding messages from the operating system safely. Additionally we report a meter metric with the error type (e.g. `EAI_NONAME` for when a DNS lookup fails because the name is not actually known to the nameserver).

==COMMIT_MSG==
add more specific metrics and logging for DNS lookup failures
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
