### PR TITLE
improvement: Avoid logging at INFO on each DNS request

### DIFF
--- a/changelog/@unreleased/pr-2180.v2.yml
+++ b/changelog/@unreleased/pr-2180.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid logging at INFO on each DNS request
+  links:
+  - https://github.com/palantir/dialogue/pull/2180

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ProtocolVersionFilteringDialogueDnsResolver.java
@@ -86,7 +86,7 @@ class ProtocolVersionFilteringDialogueDnsResolver implements DialogueDnsResolver
                     onlyIpv4Addresses.add(address);
                 }
             }
-            log.info(
+            log.debug(
                     "using only resolved IPv4 addresses for host to avoid double-counting",
                     SafeArg.of("numIpv4", numIpv4),
                     SafeArg.of("numIpv6", numIpv6),


### PR DESCRIPTION
I noticed that this log line is getting logged often in my service, most likely every time a DNS resolution is happening, which results in a lot of noise in the logs, making it more difficult to debug production issues.

It doesn't look like this log line belongs at the INFO level, so downgrading it to DEBUG.