### PR TITLE
ProtocolVersionFilteringDialogueDnsResolver logs localhost at debug

### DIFF
--- a/changelog/@unreleased/pr-2181.v2.yml
+++ b/changelog/@unreleased/pr-2181.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ProtocolVersionFilteringDialogueDnsResolver logs localhost at debug
+  links:
+  - https://github.com/palantir/dialogue/pull/2181


### PR DESCRIPTION
We most often expect localhost dns resolution to produce both ipv4 and ipv6 addresses, so we can opt out of logging at info level in that case.
We will also reduce non-localhost to debug later on, however we bias toward observability during feature rollout.

==COMMIT_MSG==
ProtocolVersionFilteringDialogueDnsResolver logs localhost at debug
==COMMIT_MSG==
