### PR TITLE
Enable DNS node discovery by default

### DIFF
--- a/changelog/@unreleased/pr-2182.v2.yml
+++ b/changelog/@unreleased/pr-2182.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Enable DNS node discovery by default
+  links:
+  - https://github.com/palantir/dialogue/pull/2182

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -127,12 +127,6 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
                 params.runtime().clients());
     }
 
-    // allow enabling dns node discovery by setting an environment variable
-    // note that this can still be disabled explicitly via the factory, but having a global flag
-    // that overrides the default value allows for enabling this behavior without explicit code
-    // changes
-    private static final String ENABLE_DNS_NODE_DISCOVERY_ENV_VAR = "DIALOGUE_ENABLE_EXPERIMENTAL_DNS_NODE_DISCOVERY";
-
     @Value.Immutable
     interface ReloadingParams extends AugmentClientConfig {
 
@@ -172,7 +166,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
         @Value.Default
         default boolean dnsNodeDiscovery() {
-            return "true".equalsIgnoreCase(System.getenv(ENABLE_DNS_NODE_DISCOVERY_ENV_VAR));
+            return true;
         }
 
         Optional<ExecutorService> blockingExecutor();


### PR DESCRIPTION
==COMMIT_MSG==
Enable DNS node discovery by default
==COMMIT_MSG==

In previous releases, we kept this off by default, behind a feature flag. We've run significant testing, and are ready to enable by default at this point.