### PR TITLE
Dialogue 'no addresses via DNS' exception is more standard

### DIFF
--- a/changelog/@unreleased/pr-2183.v2.yml
+++ b/changelog/@unreleased/pr-2183.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue 'no addresses via DNS' exception is more standard
+  links:
+  - https://github.com/palantir/dialogue/pull/2183

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -37,6 +37,7 @@ import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Clients;
 import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueException;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -572,8 +573,10 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
                     getTargetUris(serviceName, serviceConf.uris(), proxySelector(serviceConf.proxy()), resolvedHosts);
 
             if (targetUris.isEmpty()) {
-                return new EmptyInternalDialogueChannel(() -> new SafeIllegalStateException(
-                        "Service not available (no addresses via DNS)", SafeArg.of("serviceName", serviceName)));
+                return new EmptyInternalDialogueChannel(() -> new DialogueException(new SafeUnknownHostException(
+                        "Service not available (no addresses via DNS)",
+                        SafeArg.of("serviceName", serviceName),
+                        UnsafeArg.of("uris", serviceConf.uris()))));
             }
 
             DialogueChannel dialogueChannel =

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SafeUnknownHostException.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SafeUnknownHostException.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.exceptions.SafeExceptions;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+final class SafeUnknownHostException extends UnknownHostException implements SafeLoggable {
+    @CompileTimeConstant
+    private final String logMessage;
+
+    private final List<Arg<?>> arguments;
+
+    SafeUnknownHostException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        super(SafeExceptions.renderMessage(message, arguments));
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+    }
+
+    @Override
+    public @Safe String getLogMessage() {
+        return logMessage;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return arguments;
+    }
+}


### PR DESCRIPTION
Exception behavior matches legacy dns resolution mode

==COMMIT_MSG==
Dialogue 'no addresses via DNS' exception is more standard
==COMMIT_MSG==
