### PR TITLE
Add methods to obtain named per-host clients

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -289,6 +289,16 @@ acceptedBreaks:
       new: "method com.palantir.dialogue.clients.DialogueClients.ReloadingFactory\
         \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory::withDnsNodeDiscovery(boolean)"
       justification: "interface is consumed, not implemented"
+  "3.121.0":
+    com.palantir.dialogue:dialogue-clients:
+    - code: "java.method.addedToInterface"
+      new: "method <T> com.palantir.refreshable.Refreshable<java.util.Map<com.palantir.dialogue.clients.PerHostTarget,\
+        \ T>> com.palantir.dialogue.clients.DialogueClients.PerHostClientFactory::getNamedPerHost(java.lang.Class<T>)"
+      justification: "Adding new client factory methods"
+    - code: "java.method.addedToInterface"
+      new: "method com.palantir.refreshable.Refreshable<java.util.Map<com.palantir.dialogue.clients.PerHostTarget,\
+        \ com.palantir.dialogue.Channel>> com.palantir.dialogue.clients.DialogueClients.PerHostClientFactory::getNamedPerHostChannels()"
+      justification: "Adding new client factory methods"
   "3.2.0":
     com.palantir.dialogue:dialogue-clients:
     - code: "java.method.addedToInterface"

--- a/changelog/@unreleased/pr-2192.v2.yml
+++ b/changelog/@unreleased/pr-2192.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: |-
+    `PerHostClientFactory` now provides methods to obtain per-host clients keyed by a target identifier.
+    Add methods to obtain named per-host clients.
+  links:
+  - https://github.com/palantir/dialogue/pull/2192

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -17,6 +17,7 @@
 package com.palantir.dialogue.clients;
 
 import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
@@ -159,15 +160,19 @@ public final class DialogueClients {
          * Returns a list of channels where each channel will route requests to a single, unique host, even if that host
          * returns some 429s.
          */
-        Refreshable<List<Channel>> getPerHostChannels();
+        default Refreshable<List<Channel>> getPerHostChannels() {
+            return getNamedPerHostChannels().map(channels -> ImmutableList.copyOf(channels.values()));
+        }
+
+        default <T> Refreshable<List<T>> getPerHost(Class<T> clientInterface) {
+            return getNamedPerHost(clientInterface).map(channels -> ImmutableList.copyOf(channels.values()));
+        }
 
         /**
          * Returns a list of channels where each channel will route requests to a single, unique host, even if that host
          * returns some 429s. The channels are uniquely identified by a stable, opaque key.
          */
         Refreshable<Map<PerHostTarget, Channel>> getNamedPerHostChannels();
-
-        <T> Refreshable<List<T>> getPerHost(Class<T> clientInterface);
 
         <T> Refreshable<Map<PerHostTarget, T>> getNamedPerHost(Class<T> clientInterface);
     }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -29,6 +29,7 @@ import com.palantir.dialogue.core.DialogueDnsResolver;
 import com.palantir.refreshable.Refreshable;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -154,10 +155,21 @@ public final class DialogueClients {
 
     public interface PerHostClientFactory {
 
-        /** Single-uri channels. */
+        /**
+         * Returns a list of channels where each channel will route requests to a single, unique host, even if that host
+         * returns some 429s.
+         */
         Refreshable<List<Channel>> getPerHostChannels();
 
+        /**
+         * Returns a list of channels where each channel will route requests to a single, unique host, even if that host
+         * returns some 429s. The channels are uniquely identified by a stable, opaque key.
+         */
+        Refreshable<Map<PerHostTarget, Channel>> getNamedPerHostChannels();
+
         <T> Refreshable<List<T>> getPerHost(Class<T> clientInterface);
+
+        <T> Refreshable<Map<PerHostTarget, T>> getNamedPerHost(Class<T> clientInterface);
     }
 
     public interface ReloadingFactory

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/PerHostTarget.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/PerHostTarget.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.palantir.dialogue.core.TargetUri;
+
+public final class PerHostTarget {
+
+    private final TargetUri targetUri;
+    private final boolean isSelf;
+
+    PerHostTarget(TargetUri targetUri, boolean isSelf) {
+        this.targetUri = targetUri;
+        this.isSelf = isSelf;
+    }
+
+    public TargetUri targetUri() {
+        return targetUri;
+    }
+
+    public boolean isSelf() {
+        return isSelf;
+    }
+
+    @Override
+    public String toString() {
+        return "Target{targetUri='" + targetUri + "', isSelf=" + isSelf + '}';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        PerHostTarget perHostTarget = (PerHostTarget) other;
+        return targetUri.equals(perHostTarget.targetUri) && isSelf == perHostTarget.isSelf;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = targetUri.hashCode();
+        result = 31 * result + Boolean.hashCode(isSelf);
+        return result;
+    }
+}

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/PerHostTarget.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/PerHostTarget.java
@@ -21,24 +21,18 @@ import com.palantir.dialogue.core.TargetUri;
 public final class PerHostTarget {
 
     private final TargetUri targetUri;
-    private final boolean isSelf;
 
-    PerHostTarget(TargetUri targetUri, boolean isSelf) {
+    PerHostTarget(TargetUri targetUri) {
         this.targetUri = targetUri;
-        this.isSelf = isSelf;
     }
 
     public TargetUri targetUri() {
         return targetUri;
     }
 
-    public boolean isSelf() {
-        return isSelf;
-    }
-
     @Override
     public String toString() {
-        return "Target{targetUri='" + targetUri + "', isSelf=" + isSelf + '}';
+        return "Target{targetUri='" + targetUri + '}';
     }
 
     @Override
@@ -50,13 +44,11 @@ public final class PerHostTarget {
             return false;
         }
         PerHostTarget perHostTarget = (PerHostTarget) other;
-        return targetUri.equals(perHostTarget.targetUri) && isSelf == perHostTarget.isSelf;
+        return targetUri.equals(perHostTarget.targetUri);
     }
 
     @Override
     public int hashCode() {
-        int result = targetUri.hashCode();
-        result = 31 * result + Boolean.hashCode(isSelf);
-        return result;
+        return targetUri.hashCode();
     }
 }

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DialogueClientsDnsIntegrationTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/DialogueClientsDnsIntegrationTest.java
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -278,7 +279,7 @@ public class DialogueClientsDnsIntegrationTest {
         DialogueDnsResolver resolver = new MapBasedDnsResolver(ImmutableSetMultimap.<String, InetAddress>builder()
                 .putAll(host, addresses)
                 .build());
-        Refreshable<List<Channel>> perHostChannels = DialogueClients.create(
+        Refreshable<Map<PerHostTarget, Channel>> perHostChannels = DialogueClients.create(
                         Refreshable.only(ServicesConfigBlock.builder()
                                 .defaultSecurity(TestConfigurations.SSL_CONFIG)
                                 .putServices(
@@ -291,7 +292,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .withDnsResolver(resolver)
                 .withUserAgent(TestConfigurations.AGENT)
                 .perHost(service)
-                .getPerHostChannels();
+                .getNamedPerHostChannels();
         assertThat(perHostChannels.get())
                 .as("Expect one node per resolved address")
                 .hasSameSizeAs(addresses);
@@ -307,7 +308,7 @@ public class DialogueClientsDnsIntegrationTest {
                         InetAddress.getByAddress(host, new byte[] {127, 0, 0, 1}),
                         InetAddress.getByAddress(host, new byte[] {127, 0, 0, 2}))
                 .build());
-        Refreshable<List<Channel>> perHostChannels = DialogueClients.create(
+        Refreshable<Map<PerHostTarget, Channel>> perHostChannels = DialogueClients.create(
                         Refreshable.only(ServicesConfigBlock.builder()
                                 .defaultSecurity(TestConfigurations.SSL_CONFIG)
                                 .putServices(
@@ -320,7 +321,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .withDnsResolver(resolver)
                 .withUserAgent(TestConfigurations.AGENT)
                 .perHost(service)
-                .getPerHostChannels();
+                .getNamedPerHostChannels();
         assertThat(perHostChannels.get())
                 .as("Mesh-mode URIs should result in a single channel")
                 .hasSize(1);
@@ -336,7 +337,7 @@ public class DialogueClientsDnsIntegrationTest {
                         InetAddress.getByAddress(host, new byte[] {127, 0, 0, 1}),
                         InetAddress.getByAddress(host, new byte[] {127, 0, 0, 2}))
                 .build());
-        Refreshable<List<Channel>> perHostChannels = DialogueClients.create(
+        Refreshable<Map<PerHostTarget, Channel>> perHostChannels = DialogueClients.create(
                         Refreshable.only(ServicesConfigBlock.builder()
                                 .defaultSecurity(TestConfigurations.SSL_CONFIG)
                                 .putServices(
@@ -350,7 +351,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .withDnsResolver(resolver)
                 .withUserAgent(TestConfigurations.AGENT)
                 .perHost(service)
-                .getPerHostChannels();
+                .getNamedPerHostChannels();
         assertThat(perHostChannels.get())
                 .as("Configurations using a proxy must not use dns node discovery")
                 .hasSize(1);
@@ -368,7 +369,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .build());
         TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
         Counter activeTasks = ClientDnsMetrics.of(metrics).tasks(DnsPollingSpec.RELOADING_FACTORY.kind());
-        Refreshable<List<Channel>> perHostChannels = DialogueClients.create(
+        Refreshable<Map<PerHostTarget, Channel>> perHostChannels = DialogueClients.create(
                         Refreshable.only(ServicesConfigBlock.builder()
                                 .defaultSecurity(TestConfigurations.SSL_CONFIG)
                                 .putServices(
@@ -381,7 +382,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .withUserAgent(TestConfigurations.AGENT)
                 .withDnsNodeDiscovery(false)
                 .perHost(service)
-                .getPerHostChannels();
+                .getNamedPerHostChannels();
         assertThat(perHostChannels.get())
                 .as("DNS node discovery shouldn't work when it's not enabled")
                 .hasSize(1);
@@ -403,7 +404,7 @@ public class DialogueClientsDnsIntegrationTest {
         TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
         Counter activeTasks = ClientDnsMetrics.of(metrics).tasks(DnsPollingSpec.RELOADING_FACTORY.kind());
         Meter invalidUris = ClientUriMetrics.of(metrics).invalid("service");
-        Refreshable<List<Channel>> perHostChannels = DialogueClients.create(
+        Refreshable<Map<PerHostTarget, Channel>> perHostChannels = DialogueClients.create(
                         Refreshable.only(ServicesConfigBlock.builder()
                                 .defaultSecurity(TestConfigurations.SSL_CONFIG)
                                 .putServices(
@@ -417,7 +418,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .withTaggedMetrics(metrics)
                 .withDnsNodeDiscovery(false)
                 .perHost(service)
-                .getPerHostChannels();
+                .getNamedPerHostChannels();
         assertThat(perHostChannels.get())
                 .as("Host cannot be parsed from this URI, but it should still be handled")
                 .hasSize(1);
@@ -439,7 +440,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .build());
         TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
         Counter activeTasks = ClientDnsMetrics.of(metrics).tasks(DnsPollingSpec.RELOADING_FACTORY.kind());
-        Refreshable<List<Channel>> perHostChannels = DialogueClients.create(
+        Refreshable<Map<PerHostTarget, Channel>> perHostChannels = DialogueClients.create(
                         Refreshable.only(ServicesConfigBlock.builder()
                                 .defaultSecurity(TestConfigurations.SSL_CONFIG)
                                 .putServices(
@@ -453,7 +454,7 @@ public class DialogueClientsDnsIntegrationTest {
                 .withUserAgent(TestConfigurations.AGENT)
                 .withDnsNodeDiscovery(true)
                 .perHost(service)
-                .getPerHostChannels();
+                .getNamedPerHostChannels();
         assertThat(perHostChannels.get())
                 .as("Host cannot be parsed from this URI, but it should "
                         + "still be handled using the legacy dns-lookup path")

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/TargetUri.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/TargetUri.java
@@ -19,10 +19,11 @@ package com.palantir.dialogue.core;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.Preconditions;
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
-public final class TargetUri {
+public final class TargetUri implements Comparable<TargetUri> {
 
     private final String uri;
     private final Optional<InetAddress> resolvedAddress;
@@ -43,6 +44,23 @@ public final class TargetUri {
     }
 
     @Override
+    public int compareTo(TargetUri other) {
+        int result = uri.compareTo(other.uri);
+        if (result != 0) {
+            return result;
+        }
+
+        result = Arrays.compare(
+                resolvedAddress.map(InetAddress::getAddress).orElse(null),
+                other.resolvedAddress.map(InetAddress::getAddress).orElse(null));
+        if (result != 0) {
+            return result;
+        }
+
+        return 0;
+    }
+
+    @Override
     public String toString() {
         return "TargetUri{uri='" + uri + "', resolvedAddress=" + resolvedAddress + '}';
     }
@@ -56,10 +74,7 @@ public final class TargetUri {
             return false;
         }
         TargetUri targetUri = (TargetUri) other;
-        if (!uri.equals(targetUri.uri)) {
-            return false;
-        }
-        return resolvedAddress.equals(targetUri.resolvedAddress);
+        return uri.equals(targetUri.uri) && resolvedAddress.equals(targetUri.resolvedAddress);
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
There are some useful capabilities not currently supported by the per-host channels:
- The ability to order the channels, in a way that is consistent across node and Dialogue versions
- The ability to compare channel targets before and after a configuration reload
- The ability to determine if a channel target is ourselves

## After this PR
The `PerHostClientFactory` now provides two additional methods, `getNamedPerHostChannels` and `getNamedPerHost`, that return channels keyed by `PerHostTarget`. `PerHostTarget` allows callers to introspect the target and determine whether that target refers to themselves.
