### PR TITLE
Dialogue ChannelCache uses weak values to allow collection of old data

### DIFF
--- a/changelog/@unreleased/pr-2194.v2.yml
+++ b/changelog/@unreleased/pr-2194.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue ChannelCache uses weak values to allow collection of old data
+  links:
+  - https://github.com/palantir/dialogue/pull/2194


### PR DESCRIPTION
## Before this PR
The inclusion of resolved IP addresses in channels caused the cache to become full over time, when hosts are rotated naturally over time. This behavior is desirable, because we're able to account for individual nodes/routes in dialogue node selection, however the channel cache didn't have a way to forget old targets.

## After this PR
==COMMIT_MSG==
Dialogue ChannelCache uses weak values to allow collection of old data
==COMMIT_MSG==

## Possible downsides?
It's possible that creation of a single client in a loop will re-create the same data, and allow it to be collected, re-running the same work more than we'd like. This is unlikely, as clients are generally created and held via strong references, and hot re-creation of channels is an anti-pattern.
