### PR TITLE
Add PerHostTarget builder

### DIFF
--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/PerHostTarget.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/PerHostTarget.java
@@ -16,13 +16,16 @@
 
 package com.palantir.dialogue.clients;
 
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.dialogue.core.TargetUri;
+import com.palantir.logsafe.Preconditions;
+import javax.annotation.Nullable;
 
 public final class PerHostTarget {
 
     private final TargetUri targetUri;
 
-    PerHostTarget(TargetUri targetUri) {
+    private PerHostTarget(TargetUri targetUri) {
         this.targetUri = targetUri;
     }
 
@@ -50,5 +53,27 @@ public final class PerHostTarget {
     @Override
     public int hashCode() {
         return targetUri.hashCode();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        @Nullable
+        private TargetUri targetUri;
+
+        private Builder() {}
+
+        public Builder targetUri(TargetUri value) {
+            this.targetUri = Preconditions.checkNotNull(value, "targetUri");
+            return this;
+        }
+
+        @CheckReturnValue
+        public PerHostTarget build() {
+            return new PerHostTarget(Preconditions.checkNotNull(targetUri, "targetUri"));
+        }
     }
 }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -255,7 +255,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
                         // subtle gotcha here is that every single one of these has the same channelName,
                         // which means metrics like the QueuedChannel counter will end up being the sum of all of them.
                         map.put(
-                                new PerHostTarget(targetUri),
+                                PerHostTarget.builder().targetUri(targetUri).build(),
                                 cache.getNonReloadingChannel(
                                         params,
                                         singleUriServiceConf,


### PR DESCRIPTION
Small follow-up from https://github.com/palantir/dialogue/pull/2192

Without providing a builder it's impossible to create an external implementation of `PerHostClientFactory`.