### PR TITLE
Expose a TypeMarker factory to wrap an arbitrary Type

### DIFF
--- a/changelog/@unreleased/pr-2221.v2.yml
+++ b/changelog/@unreleased/pr-2221.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose a TypeMarker factory to wrap an arbitrary Type
+  links:
+  - https://github.com/palantir/dialogue/pull/2221

--- a/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
@@ -16,6 +16,7 @@
 
 package com.palantir.dialogue;
 
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.lang.reflect.ParameterizedType;
@@ -45,6 +46,10 @@ public abstract class TypeMarker<T> {
         }
     }
 
+    private TypeMarker(Type type) {
+        this.type = Preconditions.checkNotNull(type, "Type is required");
+    }
+
     public final Type getType() {
         return type;
     }
@@ -69,5 +74,16 @@ public abstract class TypeMarker<T> {
     @Override
     public final String toString() {
         return "TypeMarker{type=" + type + '}';
+    }
+
+    /** Create a new {@link TypeMarker} instance wrapping the provided {@link Type}. */
+    public static TypeMarker<?> of(Type type) {
+        return new WrappingTypeMarker(type);
+    }
+
+    private static final class WrappingTypeMarker extends TypeMarker<Object> {
+        private WrappingTypeMarker(Type type) {
+            super(type);
+        }
     }
 }


### PR DESCRIPTION
This mirrors a change we've just introduced to conjure-undertow here: https://github.com/palantir/conjure-java/pull/2264

Dialogue takes advantage of this new factory method in ConjureBodySerDe to avoid holding class references in serializer caches, which introduced some friction in our dns-polling lifecycle management. I haven't reverted the change to specify `weakKeys` in the caches, however the keys should never be freed unless classes are unloaded (e.g. plugins).

==COMMIT_MSG==
Expose a TypeMarker factory to wrap an arbitrary Type
==COMMIT_MSG==