### PR TITLE
Implement a tag to opt out of per-endpoint limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ Sticky Request +-->+Per Sticky Channel queue+-->+Per Sticky Channel Limiter+-->+
 Each sticky channel gets its own queue. If a sticky channel has no requests in-flight, ``Host Limiter`` is sidestepped (the request is let through regardless of current concurrency limits).
 This means there is a potential for many low-bandwidth sticky channels to compete with regular channels.
 
+## Supported Per-Endpoint Conjure Tags
+
+* `dialogue-no-endpoint-limit`: Opts a single endpoint out of per-endpoint concurrency limiting, however per-host concurrency limiting continues to apply!
+* `prefer-compressed-response`: Forces requests to always include `Accept-Encoding: gzip`, rather than attempting to opt out of response compression for in-environment requests. This usually shouldn't be used because compression can be much more expensive than network transfer.
+* `compress-request`: Request bodies are gzip compressed. This requires prior knowledge that the receiving server handles `Content-Encoding: gzip` request bodies.
+
 ## Alternative HTTP clients
 
 Dialogue is not coupled to a single HTTP client library - this repo contains implementations based on [OkHttp](https://square.github.io/okhttp/), Java's [HttpURLConnection](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html), the new Java11 HttpClient as well as the aforementioned [Apache HttpClient](https://hc.apache.org/httpcomponents-client-ga/).  We endorse the Apache client because as it performed best in our benchmarks and affords granular control over connection pools.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ This means there is a potential for many low-bandwidth sticky channels to compet
 
 ## Supported Per-Endpoint Conjure Tags
 
-* `dialogue-no-endpoint-limit`: Opts a single endpoint out of per-endpoint concurrency limiting, however per-host concurrency limiting continues to apply!
+* `dialogue-disable-endpoint-concurrency-limiting`: Opts a single endpoint out of per-endpoint concurrency limiting, however per-host concurrency limiting continues to apply!
 * `prefer-compressed-response`: Forces requests to always include `Accept-Encoding: gzip`, rather than attempting to opt out of response compression for in-environment requests. This usually shouldn't be used because compression can be much more expensive than network transfer.
 * `compress-request`: Request bodies are gzip compressed. This requires prior knowledge that the receiving server handles `Content-Encoding: gzip` request bodies.
 

--- a/changelog/@unreleased/pr-2252.v2.yml
+++ b/changelog/@unreleased/pr-2252.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement a tag to opt out of per-endpoint limits
+  links:
+  - https://github.com/palantir/dialogue/pull/2252

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -165,6 +165,9 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                         new TraceEnrichingChannel(channel, DialogueTracing.tracingTags(cf, uriIndexForInstrumentation));
                 channel = cf.isConcurrencyLimitingEnabled()
                         ? new ChannelToEndpointChannel(endpoint -> {
+                            if (endpoint.tags().contains("dialogue-no-endpoint-limit")) {
+                                return tracingChannel;
+                            }
                             LimitedChannel limited = ConcurrencyLimitedChannel.createForEndpoint(
                                     tracingChannel, cf.channelName(), uriIndexForInstrumentation, endpoint);
                             return QueuedChannel.create(cf, endpoint, limited);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -165,7 +165,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                         new TraceEnrichingChannel(channel, DialogueTracing.tracingTags(cf, uriIndexForInstrumentation));
                 channel = cf.isConcurrencyLimitingEnabled()
                         ? new ChannelToEndpointChannel(endpoint -> {
-                            if (endpoint.tags().contains("dialogue-no-endpoint-limit")) {
+                            if (endpoint.tags().contains("dialogue-disable-endpoint-concurrency-limiting")) {
                                 return tracingChannel;
                             }
                             LimitedChannel limited = ConcurrencyLimitedChannel.createForEndpoint(

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/NoEndpointLimitTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/NoEndpointLimitTest.java
@@ -1,0 +1,136 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
+import com.palantir.conjure.java.api.config.service.UserAgent;
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.client.config.ClientConfigurations;
+import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TestEndpoint;
+import com.palantir.dialogue.TestResponse;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class NoEndpointLimitTest {
+
+    public static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of("foo", "1.0.0"));
+    private static final SslConfiguration SSL_CONFIG = SslConfiguration.of(
+            Paths.get("src/test/resources/trustStore.jks"), Paths.get("src/test/resources/keyStore.jks"), "keystore");
+    private static final ClientConfiguration stubConfig = ClientConfiguration.builder()
+            .from(ClientConfigurations.of(ServiceConfiguration.builder()
+                    .addUris("http://localhost")
+                    .security(SSL_CONFIG)
+                    .build()))
+            .nodeSelectionStrategy(NodeSelectionStrategy.ROUND_ROBIN)
+            .userAgent(USER_AGENT)
+            .backoffSlotSize(Duration.ZERO)
+            .build();
+
+    private final Endpoint defaultEndpoint = TestEndpoint.POST;
+    private final Endpoint noEndpointQueueEndpoint = new Endpoint() {
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "noEndpointQueue";
+        }
+
+        @Override
+        public String endpointName() {
+            return "noEndpointQueue";
+        }
+
+        @Override
+        public String version() {
+            return "0.0.0";
+        }
+
+        @Override
+        public Set<String> tags() {
+            return ImmutableSet.of("dialogue-no-endpoint-limit");
+        }
+    };
+
+    @Test
+    public void test_endpoint_concurrency_limit_opt_out() throws Exception {
+        AtomicInteger inFlight = new AtomicInteger();
+        SettableFuture<Response> responseFuture = SettableFuture.create();
+        Channel delegate = (_endpoint, request) -> {
+            // Respond 429 immediately for 'warmup' requests to drop the per-endpoint concurrency limit
+            if (request.queryParams().containsKey("warmup")) {
+                return Futures.immediateFuture(new TestResponse().code(429));
+            }
+            inFlight.incrementAndGet();
+            return responseFuture;
+        };
+
+        DialogueChannel channel = DialogueChannel.builder()
+                .channelName("my-channel")
+                .clientConfiguration(stubConfig)
+                .factory(_args -> delegate)
+                .build();
+
+        for (int i = 0; i < 100; i++) {
+            Request request = Request.builder().putQueryParams("warmup", "true").build();
+            ListenableFuture<Response> defaultFuture = channel.execute(defaultEndpoint, request);
+            assertThat(defaultFuture).succeedsWithin(Duration.ofSeconds(1));
+            assertThat(defaultFuture.get()).extracting(Response::code).isEqualTo(429);
+            ListenableFuture<Response> noEndpointQueueFuture = channel.execute(noEndpointQueueEndpoint, request);
+            assertThat(noEndpointQueueFuture).succeedsWithin(Duration.ofSeconds(1));
+            assertThat(noEndpointQueueFuture.get()).extracting(Response::code).isEqualTo(429);
+        }
+
+        Request request = Request.builder().build();
+        assertThat(inFlight).hasValue(0);
+        ListenableFuture<Response> defaultFirst = channel.execute(defaultEndpoint, request);
+        assertThat(inFlight).hasValue(1);
+        ListenableFuture<Response> defaultSecond = channel.execute(defaultEndpoint, request);
+        assertThat(inFlight)
+                .as("per-endpoint queue should prevent a second request from firing")
+                .hasValue(1);
+        ListenableFuture<Response> noEndpointQueueFirst = channel.execute(noEndpointQueueEndpoint, request);
+        assertThat(inFlight).hasValue(2);
+        ListenableFuture<Response> noEndpointQueueSecond = channel.execute(noEndpointQueueEndpoint, request);
+        assertThat(inFlight)
+                .as("per-endpoint queue should not be enabled, so this request should be sent immediately")
+                .hasValue(3);
+
+        assertThat(defaultFirst).isNotDone();
+        assertThat(defaultSecond).isNotDone();
+        assertThat(noEndpointQueueFirst).isNotDone();
+        assertThat(noEndpointQueueSecond).isNotDone();
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/NoEndpointLimitTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/NoEndpointLimitTest.java
@@ -80,7 +80,7 @@ public class NoEndpointLimitTest {
 
         @Override
         public Set<String> tags() {
-            return ImmutableSet.of("dialogue-no-endpoint-limit");
+            return ImmutableSet.of("dialogue-disable-endpoint-concurrency-limiting");
         }
     };
 


### PR DESCRIPTION
## Before this PR
No way to opt out of the per-endpoint concurrency limiters

## After this PR
==COMMIT_MSG==
Implement a tag to opt out of per-endpoint limits
==COMMIT_MSG==

## Possible downsides?
This could be misused, I suppose? I'd prefer to make the option available for the edge cases where it may be useful, rather than harm functionality due to one or two degenerate cases.
