### PR TITLE
Provide a consistent exception when no dns records are resolved

### DIFF
--- a/changelog/@unreleased/pr-2254.v2.yml
+++ b/changelog/@unreleased/pr-2254.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide a consistent exception when no dns records are resolved
+  links:
+  - https://github.com/palantir/dialogue/pull/2254

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/NodeSelectionStrategyChannel.java
@@ -74,7 +74,11 @@ final class NodeSelectionStrategyChannel implements LimitedChannel {
 
     static LimitedChannel create(Config cf, ImmutableList<LimitedChannel> channels) {
         if (channels.isEmpty()) {
-            return new StickyChannelHandler(new ZeroUriNodeSelectionChannel(cf.channelName()));
+            return new StickyChannelHandler(new ZeroUriNodeSelectionChannel(
+                    cf.channelName(),
+                    cf.rawConfig().uris().isEmpty()
+                            ? "There are no URIs configured to handle requests"
+                            : "Service not available (no addresses via DNS)"));
         }
 
         if (channels.size() == 1) {


### PR DESCRIPTION
==COMMIT_MSG==
Provide a consistent exception when no dns records are resolved
==COMMIT_MSG==
