### PR TITLE
Dialogue fails fast when existing channels are revoked from DNS

### DIFF
--- a/changelog/@unreleased/pr-2263.v2.yml
+++ b/changelog/@unreleased/pr-2263.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue fails fast when existing channels are revoked from DNS
+  links:
+  - https://github.com/palantir/dialogue/pull/2263

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.dialogue.hc5;
 
+import com.google.common.base.Strings;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
@@ -29,6 +31,7 @@ import com.palantir.dialogue.Response;
 import com.palantir.dialogue.ResponseAttachments;
 import com.palantir.dialogue.blocking.BlockingChannel;
 import com.palantir.dialogue.core.BaseUrl;
+import com.palantir.dialogue.core.DialogueDnsResolver;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -46,6 +49,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -56,6 +60,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import org.apache.hc.client5.http.ConnectTimeoutException;
 import org.apache.hc.client5.http.classic.ExecRuntime;
@@ -82,6 +87,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
     private final Optional<InetAddress> resolvedHost;
     private final ResponseLeakDetector responseLeakDetector;
     private final OptionalInt uriIndexForInstrumentation;
+    private final BooleanSupplier isValidTarget;
 
     ApacheHttpClientBlockingChannel(
             ApacheHttpClientChannels.CloseableClient client,
@@ -94,10 +100,32 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
         this.resolvedHost = resolvedHost;
         this.responseLeakDetector = responseLeakDetector;
         this.uriIndexForInstrumentation = uriIndexForInstrumentation;
+        if (resolvedHost.isPresent() && client.dnsResolver().isPresent()) {
+            BooleanSupplier validTargetPredicate = Suppliers.memoizeWithExpiration(
+                            () -> isTargetValid(client.dnsResolver().get(), baseUrl, resolvedHost.get()),
+                            Duration.ofSeconds(1))::get;
+            // If the bound address is not initially resolvable, this predicate will be ignored.
+            isValidTarget = validTargetPredicate.getAsBoolean() ? validTargetPredicate : () -> true;
+        } else {
+            isValidTarget = () -> true;
+        }
+    }
+
+    private static boolean isTargetValid(DialogueDnsResolver dnsResolver, URL baseUrl, InetAddress resolvedHost) {
+        String host = baseUrl.getHost();
+        if (Strings.isNullOrEmpty(host)) {
+            // we don't have enough confidence to prevent requests from flowing.
+            return true;
+        }
+        return dnsResolver.resolve(host).contains(resolvedHost);
     }
 
     @Override
     public Response execute(Endpoint endpoint, Request request) throws IOException {
+        if (!isValidTarget.getAsBoolean()) {
+            throw new SafeConnectException("Target address can no longer be resolved");
+        }
+
         // Create base request given the URL
         URL target = baseUrl.render(endpoint, request);
         ClassicRequestBuilder builder =

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/SafeConnectException.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/SafeConnectException.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.hc5;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.exceptions.SafeExceptions;
+import java.net.ConnectException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link SafeLoggable} variant of {@link ConnectException}.
+ */
+final class SafeConnectException extends ConnectException implements SafeLoggable {
+
+    @CompileTimeConstant
+    private final String message;
+
+    private final List<Arg<?>> arguments;
+
+    SafeConnectException(@CompileTimeConstant String message, Arg<?>... args) {
+        super(SafeExceptions.renderMessage(message, args));
+        this.message = message;
+        this.arguments = Collections.unmodifiableList(Arrays.asList(args));
+    }
+
+    @Override
+    public String getLogMessage() {
+        return message;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return arguments;
+    }
+}

--- a/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
+++ b/dialogue-apache-hc5-client/src/main/metrics/dialogue-apache-client-metrics.yml
@@ -121,3 +121,11 @@ namespaces:
           - name: cipher
             docs: The insecure cipher used to connect to this server
         docs: Meter describing the use of insecure ciphers to connect to this server.
+
+      short.circuit.unresolvable.target:
+        type: meter
+        tags:
+          - name: client-name
+          - name: client-type
+            values: [ apache-hc5 ]
+        docs: Rate that requests are immediately rejected due to an unresolvable target address.

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -48,6 +48,9 @@ Dialogue client response metrics provided by the Apache client channel.
   - `client-name`
   - `client-type` values (`apache-hc5`)
   - `cipher`: The insecure cipher used to connect to this server
+- `dialogue.client.short.circuit.unresolvable.target` (meter): Rate that requests are immediately rejected due to an unresolvable target address.
+  - `client-name`
+  - `client-type` values (`apache-hc5`)
 
 ### dialogue.client.pool
 Connection pool metrics from the dialogue Apache client.


### PR DESCRIPTION
We don't want to spend ages retrying requests to dead nodes, where we expect every attempt to result in a connect timeout. It's much better to fail quickly rather than retry+backoff for minutes.

==COMMIT_MSG==
Dialogue fails fast when existing channels are revoked from DNS
==COMMIT_MSG==

## Possible downsides?
if dns entries disappear and reappear, we may have failed requests for nothing. It's possible dns entires may be revoked while requests are still routable, but I don't think we should prioritize this case as it's generally not something we expect to support.