### PR TITLE
Reduce the default DNS poll interval from 5 seconds to 1

### DIFF
--- a/changelog/@unreleased/pr-2273.v2.yml
+++ b/changelog/@unreleased/pr-2273.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce the default DNS poll interval from 5 seconds to 1
+  links:
+  - https://github.com/palantir/dialogue/pull/2273

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -164,7 +164,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
         @Value.Default
         default Duration dnsRefreshInterval() {
-            return Duration.ofSeconds(5);
+            return Duration.ofSeconds(1);
         }
 
         @Value.Default


### PR DESCRIPTION
This will reduce the worst case latency between DNS updates and the client reacting to changes. This shouldn't
put additional load on DNS because the JVM has a default dns cache with a ttl larger than either value, so we
should only be eliminating unnecessary slack before picking up new nodes.

==COMMIT_MSG==
Reduce the default DNS poll interval from 5 seconds to 1
==COMMIT_MSG==
