### PR TITLE
Avoid expensive refreshable creation in a potentially hot path

### DIFF
--- a/changelog/@unreleased/pr-2274.v2.yml
+++ b/changelog/@unreleased/pr-2274.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid expensive refreshable creation in a potentially hot path
+  links:
+  - https://github.com/palantir/dialogue/pull/2274

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -482,10 +482,15 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         public Supplier<Channel> stickyChannels() {
             return () -> this;
         }
+
+        @Override
+        public EndpointChannel endpoint(Endpoint _endpoint) {
+            return _request -> Futures.immediateFailedFuture(exceptionSupplier.get());
+        }
     }
 
     /* Abstracts away DialogueChannel so that we can handle no-service/no-uri case in #getInternalDialogueChannel. */
-    private interface InternalDialogueChannel extends Channel {
+    private interface InternalDialogueChannel extends Channel, EndpointChannelFactory {
         Supplier<Channel> stickyChannels();
     }
 
@@ -500,6 +505,11 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         @Override
         public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
             return dialogueChannel.execute(endpoint, request);
+        }
+
+        @Override
+        public EndpointChannel endpoint(Endpoint endpoint) {
+            return dialogueChannel.endpoint(endpoint);
         }
 
         @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ContentDecodingChannel.java
@@ -81,7 +81,9 @@ final class ContentDecodingChannel implements EndpointChannel {
         // is handled by the client. Note that this will also opt out of response
         // compression when the target host resolves to multiple IP addresses.
         if (cf.mesh() == MeshMode.DEFAULT_NO_MESH) {
-            return cf.uris().map(targets -> targets.size() == 1)::get;
+            // Avoid using refreshable here, as this can be called very frequently, and
+            // refreshable.map can be expensive.
+            return () -> cf.uris().get().size() == 1;
         }
 
         return () -> false;


### PR DESCRIPTION
==COMMIT_MSG==
Avoid expensive refreshable creation in a potentially hot path
==COMMIT_MSG==
