### PR TITLE
DefaultDialogueDnsResolver logs UnknownHostException at debug

### DIFF
--- a/changelog/@unreleased/pr-2277.v2.yml
+++ b/changelog/@unreleased/pr-2277.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: DefaultDialogueDnsResolver logs UnknownHostException at debug
+  links:
+  - https://github.com/palantir/dialogue/pull/2277

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DefaultDialogueDnsResolver.java
@@ -51,19 +51,8 @@ final class DefaultDialogueDnsResolver implements DialogueDnsResolver {
             return ImmutableSet.copyOf(results);
         } catch (UnknownHostException e) {
             GaiError gaiError = extractGaiError(e, hostname);
-            if (gaiError == GaiError.CACHED) {
-                // Cached results can be fairly noisy, avoid heavy logging.
-                if (log.isDebugEnabled()) {
-                    log.debug(
-                            "Unknown host '{}'. {}: {}",
-                            SafeArg.of("gaiErrorType", gaiError.name()),
-                            SafeArg.of("gaiErrorMessage", gaiError.errorMessage()),
-                            UnsafeArg.of("hostname", hostname),
-                            e);
-                }
-            } else {
-                // Sometimes UnknownHostException is reasonable/expected, so we log at info rather than warn.
-                log.info(
+            if (log.isDebugEnabled()) {
+                log.debug(
                         "Unknown host '{}'. {}: {}",
                         SafeArg.of("gaiErrorType", gaiError.name()),
                         SafeArg.of("gaiErrorMessage", gaiError.errorMessage()),


### PR DESCRIPTION
==COMMIT_MSG==
DefaultDialogueDnsResolver logs UnknownHostException at debug
==COMMIT_MSG==

This logging can be noisy, and confuses folks. We provide better dns observability info elsewhere, and the metrics including `GaiError` are quite good~