### PR TITLE
feature: add support for HeaderMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ public interface MyService {
             // Headers can be optional
             @Request.Header("Custom-Optional-Header") OptionalInt maybeRequestHeaderValue,
             // converts a custom type in a Multimap<String, String>
-            @Request.HeaderMap(encoder = MyCustomTypeEncoder.class) Multimap<String, String> myCustomHeaderParam,
+            @Request.HeaderMap(encoder = MyCustomTypeEncoder.class) MyCustomQueryParamType myCustomHeaderParam,
             // Custom encoding classes may be provided for the request and response.
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);
 }

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ public interface MyService {
             @Request.PathParam UUID myPathParam,
             @Request.PathParam(encoder = MyCustomParamTypeEncoder.class) MyCustomParamType myPathParam2,
             // converts a custom type into a Multimap<String, String>
-            @Request.QueryMap(encoder = MyCustomTypeEncoder.class) MyCustomQueryParamType myCustomQueryParam,
+            @Request.QueryMap(encoder = MyCustomQueryTypeEncoder.class) MyCustomQueryParamType myCustomQueryParam,
             @Request.Header("Custom-Header") int requestHeaderValue,
             // Headers can be optional
             @Request.Header("Custom-Optional-Header") OptionalInt maybeRequestHeaderValue,
             // converts a custom type into a Multimap<String, String>
-            @Request.HeaderMap(encoder = MyCustomTypeEncoder.class) MyCustomQueryParamType myCustomHeaderParam,
+            @Request.HeaderMap(encoder = MyCustomHeaderTypeEncoder.class) MyCustomHeaderParamType myCustomHeaderParam,
             // Custom encoding classes may be provided for the request and response.
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Dialogue is a client-side library for HTTP-based RPC, designed to work well wit
 ## Observability
 
 - **Zipkin-style tracing**: internal operations are instrumented using Zipkin-style [tracing-java spans](https://github.com/palantir/tracing-java), and `X-B3-TraceId` headers are propagated
-- **Metrics**: Timers, meters and gauges are defined using [metric-schema](https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/metrics/dialogue-core-metrics.yml) and stored in a [Tritium TaggedMetricRegistry](https://github.com/palantir/tritium).
+- **Metrics**: Timers, meters, and gauges are defined using [metric-schema](https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/metrics/dialogue-core-metrics.yml) and stored in a [Tritium TaggedMetricRegistry](https://github.com/palantir/tritium).
 - **Structured logging**: SLF4J logs are designed to be rendered as JSON, with every parameter declaratively named.
 
 ## Usage
@@ -31,9 +31,9 @@ details.
 
 ### Production usage
 
-Your server framework should provide an abstraction to create clients that handle uri live-reloading and reuse connection pools. For example in Witchcraft, you can create a `FooServiceBlocking` like so:
+Your server framework should provide an abstraction to create clients that handle uri live-reloading and reuse connection pools. For example, in Witchcraft, you can create a `FooServiceBlocking` like so:
 
-```groovy
+```java
 FooServiceBlocking fooService = witchcraft.conjureClients().client(FooServiceBlocking.class, "foo-service").get();
 
 // network call:
@@ -42,7 +42,7 @@ List<Item> items = fooService.getItems();
 
 The non-blocking instance can be constructed similarly:
 
-```groovy
+```java
 FooServiceAsync fooService = witchcraft.conjureClients().client(FooServiceAsync.class, "foo-service").get();
 
 ListenableFuture<List<Item>> items = fooService.getItems();
@@ -92,7 +92,7 @@ public ListenableFuture<Thing> getThing(
 
 ## Blocking or async
 
-Of the two generated interfaces `FooServiceBlocking` and `FooServiceAync`, the blocking version is usually appropriate for 98% of use-cases, and results in much simpler control flow and error-handling. The async version returns Guava [`ListenableFutures`](https://github.com/google/guava/wiki/ListenableFutureExplained) so is a lot more fiddly to use. `Futures.addCallback` and `FluentFuture` are your friend here.
+Of the two generated interfaces `FooServiceBlocking` and `FooServiceAync`, the blocking version is usually appropriate for 98% of use-cases, and results in much simpler control flow and error-handling. The async version returns Guava [`ListenableFutures`](https://github.com/google/guava/wiki/ListenableFutureExplained), making it a lot more fiddly to use. `Futures.addCallback` and `FluentFuture` are your friends here.
 
 [dialogue-annotations-processor generated client bindings]: #dialogue-annotations-processor-generated-client-bindings
 
@@ -101,7 +101,7 @@ Of the two generated interfaces `FooServiceBlocking` and `FooServiceAync`, the b
 ``dialogue-annotations-processor`` is a retrofit replacement for use-cases where a service needs to talk to a
 non-conjure server.
 
-To setup the annotation simply add (make sure you are
+To set up the annotation, simply add (make sure you are
 using [gradle-processors](https://github.com/palantir/gradle-processors)):
 
 ```gradle
@@ -111,7 +111,7 @@ dependencies {
 }
 ```
 
-Next create an annotated interface that describes the service you need to talk to, appropriately annotated
+Next, create an annotated interface that describes the service you need to talk to, appropriately annotated
 with ``@DialogueService``:
 
 ```java
@@ -150,8 +150,8 @@ Features:
 * Custom parameter types: ```@Request.(Header|PathParam|QueryParam)(encoder=MyCustomParamTypeEncoder.class)```.
 * Custom serialization/deserialization: add ```@Request.Body(MySerializableTypeBodySerializer.class)```
   or ```@Request(accept=MyCustomResponseDeserializer.class)```.
-* Custom serialization from ```Map```, ```Multimap``` and custom types into query parameters and header parameters. This functions
-  similarly to the Feign ```QueryMap``` feature, but with added control of customizing the serialization to query parameters and also with support for header parameters as well.
+* Custom serialization from ```Map```, ```Multimap```, and custom types into query parameters and header parameters. This functions
+  similarly to the Feign ```QueryMap``` and ```HeaderMap``` features, but with added control of customizing the serialization.
 * Authentication: builtin ```Authorization``` header handling if an annotated method has an ```AuthHeader``` parameter.
 
 See more examples [on how to define clients](dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java) and [use the generated code](dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java).
@@ -166,7 +166,7 @@ public interface Channel {
 }
 ```
 
-For example, the [TraceEnrichingChannel](dialogue-core/src/main/java/com/palantir/dialogue/core/TraceEnrichingChannel.java) just augments the request with a zipkin-style tracing headers and then calls a delegate.
+For example, the [TraceEnrichingChannel](dialogue-core/src/main/java/com/palantir/dialogue/core/TraceEnrichingChannel.java) just augments the request with zipkin-style tracing headers and then calls a delegate.
 
 _This API is influenced by gRPC's [Java library](https://github.com/grpc/grpc-java), which has a similar [Channel](https://github.com/grpc/grpc-java/blob/master/api/src/main/java/io/grpc/Channel.java) concept._
 
@@ -176,8 +176,8 @@ _This API is influenced by gRPC's [Java library](https://github.com/grpc/grpc-ja
 
 Every request passes through a pair of [AIMD](https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease)
 concurrency limiters.
-There are two types of concurrency limiter: per-host, and per-endpoint. The former based on failures that
-indicate the target host is in a degraded state, and the latter based on failures that are coupled to
+There are two types of concurrency limiter: per-host, and per-endpoint. The former is based on failures that
+indicate the target host is in a degraded state, and the latter is based on failures that are coupled to
 an individual endpoint.
 Each concurrency limiter operates in conjunction with a queue to stage pending requests until a
 permit becomes available.
@@ -206,7 +206,7 @@ permit becomes available.
 #### Host limits
 
 Each host has a concurrency limiter which protects servers by stopping requests getting out the door on the client-side.
-Permits are decreased after receiving 308 or 501-599 response, or encounting a network error (`IOException`).
+Permits are decreased after receiving 308 or 501-599 response, or encountering a network error (`IOException`).
 Otherwise, they are increased.
 
 #### Endpoint limits
@@ -237,17 +237,17 @@ default PIN_UNTIL_ERROR. The actual algorithm has evolved from naive Round Robin
 makes smarter decisions based on stats about each host (see
 [BalancedNodeSelectionStrategyChannel.java](dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedNodeSelectionStrategyChannel.java)). This fixes a dramatic failure
 mode when a single server is very slow (this can be seen empirically in the simulations). Note that unlike concurrency limiters, this node selection strategy never *prevents* a request getting out the door,
-it just *ranks* hosts to try to deliver the best possive client-perceived response time (and success rate).
+it just *ranks* hosts to try to deliver the best possible client-perceived response time (and success rate).
 
 Specifically, it keeps track of the number of in flight requests for each host, and also records every failure it sees for each host. A
-request is then routed to the the host with the lowest `inflight + 10*recent_failures`.
+request is then routed to the host with the lowest `inflight + 10*recent_failures`.
 
 The ROUND_ROBIN strategy is _not_ appropriate for transactional use cases where successive requests must land on the
 same node, and it's also not optimal for use-cases where there are many nodes and cache affinity is very important.
 
 ### Sticky requests
 
-Dialogue channels can be configured to stick to a single host: after first request is successfully executed on a host,
+Dialogue channels can be configured to stick to a single host: after the first request is successfully executed on a host,
 all subsequent requests will be routed to the same host. This strategy is useful for transactional workflows,
 where all requests tied to a particular transaction may need to be executed on the same host.
 
@@ -268,7 +268,7 @@ This means there is a potential for many low-bandwidth sticky channels to compet
 
 ## Alternative HTTP clients
 
-Dialogue is not coupled to a single HTTP client library - this repo contains implementations based on [OkHttp](https://square.github.io/okhttp/), Java's [HttpURLConnection](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html), the new Java11 HttpClient as well as the aforementioned [Apache HttpClient](https://hc.apache.org/httpcomponents-client-ga/).  We endorse the Apache client because as it performed best in our benchmarks and affords granular control over connection pools.
+Dialogue is not coupled to a single HTTP client library - this repo contains implementations based on [OkHttp](https://square.github.io/okhttp/), Java's [HttpURLConnection](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html), the new Java11 HttpClient as well as the aforementioned [Apache HttpClient](https://hc.apache.org/httpcomponents-client-ga/).  We endorse the Apache client because it performed the best in our benchmarks and affords granular control over connection pools.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -132,11 +132,13 @@ public interface MyService {
             // Path parameter variable name must match the request path component
             @Request.PathParam UUID myPathParam,
             @Request.PathParam(encoder = MyCustomParamTypeEncoder.class) MyCustomParamType myPathParam2,
-            // converts an custom type into a Multimap<String, String>
+            // converts a custom type into a Multimap<String, String>
             @Request.QueryMap(encoder = MyCustomTypeEncoder.class) MyCustomQueryParamType myCustomQueryParam,
             @Request.Header("Custom-Header") int requestHeaderValue,
             // Headers can be optional
             @Request.Header("Custom-Optional-Header") OptionalInt maybeRequestHeaderValue,
+            // converts a custom type in a Multimap<String, String>
+            @Request.HeaderMap(encoder = MyCustomTypeEncoder.class) Multimap<String, String> myCustomHeaderParam,
             // Custom encoding classes may be provided for the request and response.
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);
 }
@@ -148,9 +150,8 @@ Features:
 * Custom parameter types: ```@Request.(Header|PathParam|QueryParam)(encoder=MyCustomParamTypeEncoder.class)```.
 * Custom serialization/deserialization: add ```@Request.Body(MySerializableTypeBodySerializer.class)```
   or ```@Request(accept=MyCustomResponseDeserializer.class)```.
-* Custom serialization from ```Map```, ```Multimap``` and custom types into query parameters. This functions
-  similarly to the Feign ```QueryMap``` feature, but with added control of customizing the serialization to
-  query parameters.
+* Custom serialization from ```Map```, ```Multimap``` and custom types into query parameters and header parameters. This functions
+  similarly to the Feign ```QueryMap``` feature, but with added control of customizing the serialization to query parameters and also with support for header parameters as well.
 * Authentication: builtin ```Authorization``` header handling if an annotated method has an ```AuthHeader``` parameter.
 
 See more examples [on how to define clients](dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java) and [use the generated code](dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java).

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public interface MyService {
             @Request.Header("Custom-Header") int requestHeaderValue,
             // Headers can be optional
             @Request.Header("Custom-Optional-Header") OptionalInt maybeRequestHeaderValue,
-            // converts a custom type in a Multimap<String, String>
+            // converts a custom type into a Multimap<String, String>
             @Request.HeaderMap(encoder = MyCustomTypeEncoder.class) MyCustomQueryParamType myCustomHeaderParam,
             // Custom encoding classes may be provided for the request and response.
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);

--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MyService.java
@@ -90,6 +90,7 @@ public interface MyService {
             @Request.Header("h3") Optional<String> header3,
             @Request.Header("h4") MyAliasType header4,
             @Request.Header("h5") List<MyAliasType> header5,
+            @Request.HeaderMap Multimap<String, String> headerMap,
             // Can supply a map to fill in arbitrary query values
             @Request.QueryMap(encoder = MapToMultimapParamEncoder.class) Map<String, String> queryParams,
             // Custom encoding classes may be provided for the request and response.

--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -296,6 +296,10 @@ public final class MyServiceIntegrationTest {
             exchange.assertSingleValueHeader(HttpString.tryFromString("h4")).isEqualTo("header4");
             exchange.assertMultiValueHeader("h5")
                     .hasValueSatisfying(values -> assertThat(values).containsExactly("header5-1", "header5-2"));
+            exchange.assertSingleValueHeader(HttpString.tryFromString("Custom-API-Key-0"))
+                    .isEqualTo("fake key 0");
+            exchange.assertSingleValueHeader(HttpString.tryFromString("Custom-API-Key-1"))
+                    .isEqualTo("fake key 1");
             exchange.assertBodyUtf8().isEqualTo("{\n  \"value\" : \"my-serializable-type-value\"\n}");
 
             exchange.exchange.setStatusCode(200);
@@ -320,6 +324,7 @@ public final class MyServiceIntegrationTest {
                 Optional.of("header3"),
                 ImmutableMyAliasType.of("header4"),
                 List.of(ImmutableMyAliasType.of("header5-1"), ImmutableMyAliasType.of("header5-2")),
+                ImmutableMultimap.of("Custom-API-Key-0", "fake key 0", "Custom-API-Key-1", "fake key 1"),
                 ImmutableMap.of("varq1", "varvar1"),
                 ImmutableMySerializableType.of("my-serializable-type-value"));
     }

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
@@ -28,6 +28,7 @@ import com.palantir.dialogue.annotations.ListParamEncoder;
 import com.palantir.dialogue.annotations.MultimapParamEncoder;
 import com.palantir.dialogue.annotations.ParamEncoder;
 import com.palantir.dialogue.annotations.Request;
+import com.palantir.dialogue.annotations.Request.HeaderMap;
 import com.palantir.dialogue.annotations.processor.data.ParameterEncoderType.EncoderType;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -49,7 +50,8 @@ public final class ParamTypesResolver {
             Request.PathParam.class,
             Request.QueryParam.class,
             Request.QueryMap.class,
-            Request.Header.class);
+            Request.Header.class,
+            HeaderMap.class);
     private static final ImmutableSet<String> PARAM_ANNOTATIONS =
             PARAM_ANNOTATION_CLASSES.stream().map(Class::getCanonicalName).collect(ImmutableSet.toImmutableSet());
     private static final String paramEncoderMethod;
@@ -157,6 +159,11 @@ public final class ParamTypesResolver {
                             endpointName, variableElement, annotationReflector, EncoderTypeAndMethod.MULTIMAP)
                     .orElseGet(() -> multimapDefaultEncoder(endpointName, variableElement));
             return Optional.of(ParameterTypes.queryMap(customEncoderType));
+        } else if (annotationReflector.isAnnotation(Request.HeaderMap.class)) {
+            ParameterEncoderType customEncoderType = getParameterEncoder(
+                            endpointName, variableElement, annotationReflector, EncoderTypeAndMethod.MULTIMAP)
+                    .orElseGet(() -> multimapDefaultEncoder(endpointName, variableElement));
+            return Optional.of(ParameterTypes.headerMap(customEncoderType));
         }
 
         throw new SafeIllegalStateException("Not possible");

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParamTypesResolver.java
@@ -28,7 +28,6 @@ import com.palantir.dialogue.annotations.ListParamEncoder;
 import com.palantir.dialogue.annotations.MultimapParamEncoder;
 import com.palantir.dialogue.annotations.ParamEncoder;
 import com.palantir.dialogue.annotations.Request;
-import com.palantir.dialogue.annotations.Request.HeaderMap;
 import com.palantir.dialogue.annotations.processor.data.ParameterEncoderType.EncoderType;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -51,7 +50,7 @@ public final class ParamTypesResolver {
             Request.QueryParam.class,
             Request.QueryMap.class,
             Request.Header.class,
-            HeaderMap.class);
+            Request.HeaderMap.class);
     private static final ImmutableSet<String> PARAM_ANNOTATIONS =
             PARAM_ANNOTATION_CLASSES.stream().map(Class::getCanonicalName).collect(ImmutableSet.toImmutableSet());
     private static final String paramEncoderMethod;

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ParameterType.java
@@ -30,6 +30,8 @@ public interface ParameterType {
 
         R header(String headerName, Optional<ParameterEncoderType> paramEncoderType);
 
+        R headerMap(ParameterEncoderType parameterEncoderType);
+
         R path(Optional<ParameterEncoderType> paramEncoderType);
 
         R query(String paramName, Optional<ParameterEncoderType> paramEncoderType);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -76,6 +76,7 @@ public final class ServiceImplementationGenerator {
                             .body((serializer, serializerFieldName) ->
                                     Optional.of(serializer(arg, serializer, serializerFieldName)))
                             .header((_headerName, maybeEncoder) -> maybeEncoder.map(this::encoder))
+                            .headerMap(encoder -> Optional.of(encoder(encoder)))
                             .path(maybeEncoder -> maybeEncoder.map(this::encoder))
                             .query((_paramName, maybeEncoder) -> maybeEncoder.map(this::encoder))
                             .queryMap(encoder -> Optional.of(encoder(encoder)))
@@ -214,6 +215,11 @@ public final class ServiceImplementationGenerator {
             }
 
             @Override
+            public CodeBlock headerMap(ParameterEncoderType parameterEncoderType) {
+                return generateHeaderMapParam(param, parameterEncoderType);
+            }
+
+            @Override
             public CodeBlock path(Optional<ParameterEncoderType> paramEncoderType) {
                 return generatePathParam(param, paramEncoderType);
             }
@@ -239,6 +245,16 @@ public final class ServiceImplementationGenerator {
                 CodeBlock.of(param.argName().get()),
                 param.argType(),
                 headerParamEncoder);
+    }
+
+    private CodeBlock generateHeaderMapParam(ArgumentDefinition param, ParameterEncoderType paramEncoder) {
+        return generatePlainSerializer(
+                "nope",
+                "putAllHeaderParams",
+                param.argName().get(),
+                CodeBlock.of("$L", param.argName().get()),
+                param.argType(),
+                Optional.of(paramEncoder));
     }
 
     private CodeBlock generatePathParam(ArgumentDefinition param, Optional<ParameterEncoderType> paramEncoder) {

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
@@ -16,6 +16,7 @@
 
 package com.palantir.myservice.service;
 
+import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.HttpMethod;
@@ -100,5 +101,6 @@ public interface MyService {
             @Request.Header(value = "h10", encoder = MyCustomStringParamEncoder.class) String header10,
             @Request.Header(value = "h11", encoder = MyCustomStringParamEncoder.class) Optional<String> header11,
             @Request.Header("h12") List<MyAliasType> header12,
+            @Request.HeaderMap Multimap<String, String> headerMap,
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);
 }

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -1,6 +1,7 @@
 package com.palantir.myservice.service;
 
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
@@ -16,6 +17,7 @@ import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.dialogue.UrlBuilder;
 import com.palantir.dialogue.annotations.ConjureErrorDecoder;
+import com.palantir.dialogue.annotations.DefaultMultimapParamEncoder;
 import com.palantir.dialogue.annotations.DefaultParameterSerializer;
 import com.palantir.dialogue.annotations.ErrorHandlingDeserializerFactory;
 import com.palantir.dialogue.annotations.ErrorHandlingVoidDeserializer;
@@ -104,6 +106,8 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
 
             private final MyCustomStringParamEncoder paramsHeader11Encoder = new MyCustomStringParamEncoder();
 
+            private final DefaultMultimapParamEncoder paramsHeaderMapEncoder = new DefaultMultimapParamEncoder();
+
             private final Serializer<MySerializableType> paramsSerializer =
                     new MySerializableTypeBodySerializer().serializerFor(new TypeMarker<MySerializableType>() {});
 
@@ -181,6 +185,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                     String header10,
                     Optional<String> header11,
                     List<MyAliasType> header12,
+                    Multimap<String, String> headerMap,
                     MySerializableType body) {
                 Request.Builder _request = Request.builder();
                 _request.putQueryParams("q1", _parameterSerializer.serializeString(query1));
@@ -251,6 +256,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                                 .map(MyAliasType::get)
                                 .map(_parameterSerializer::serializeString)
                                 .collect(Collectors.toList()));
+                _request.putAllHeaderParams(paramsHeaderMapEncoder.toParamValues(headerMap));
                 _request.body(paramsSerializer.serialize(body));
                 runtime.clients().callBlocking(paramsChannel, _request.build(), paramsDeserializer);
             }

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Request.java
@@ -84,6 +84,12 @@ public @interface Request {
 
     @Retention(RetentionPolicy.SOURCE)
     @Target(ElementType.PARAMETER)
+    @interface HeaderMap {
+        Class<? extends MultimapParamEncoder<?>> encoder() default DefaultMultimapParamEncoder.class;
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @Target(ElementType.PARAMETER)
     @interface PathParam {
         Class<? extends ParamEncoder<?>> encoder() default DefaultParamEncoder.class;
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Dialogue annotations do not support including headers dynamically to a request. This prevents the client from setting headers (e.g. auth headers) during runtime. The Dialogue client cannot accommodate custom auth header schemes unbeknownst at compile time.

## After this PR

We implement a `Request.HeaderMap` annotation that can decode a `MultiMap<String, String>` where the map key is the header key and the map value is the corresponding header value.

==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
feature: add support for HeaderMap
==COMMIT_MSG==
