### PR TITLE
CachingFallbackDnsResolver logs at debug level

### DIFF
--- a/changelog/@unreleased/pr-2283.v2.yml
+++ b/changelog/@unreleased/pr-2283.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: CachingFallbackDnsResolver logs at debug level
+  links:
+  - https://github.com/palantir/dialogue/pull/2283

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/CachingFallbackDnsResolver.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/CachingFallbackDnsResolver.java
@@ -58,9 +58,11 @@ final class CachingFallbackDnsResolver implements DialogueDnsResolver {
             ImmutableSet<InetAddress> maybeFallback = fallbackCache.getIfPresent(hostname);
             if (maybeFallback != null) {
                 lookupFallback.mark();
-                log.info(
-                        "DNS resolution failed for host '{}', however fallback addresses are present in the cache",
-                        UnsafeArg.of("hostname", hostname));
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "DNS resolution failed for host '{}', however fallback addresses are present in the cache",
+                            UnsafeArg.of("hostname", hostname));
+                }
                 return maybeFallback;
             } else {
                 lookupFailure.mark();


### PR DESCRIPTION
This can be fairly noisy, without providing much value at this point.

==COMMIT_MSG==
CachingFallbackDnsResolver logs at debug level
==COMMIT_MSG==