### PR TITLE
[Draft] Include ':' and '@' in pchar definition for url encoding

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -242,7 +242,7 @@ public final class BaseUrl {
         private static final CharMatcher UNRESERVED = DIGIT.or(ALPHA).or(CharMatcher.anyOf("-._~"));
         private static final CharMatcher SUB_DELIMS = CharMatcher.anyOf("!$&'()*+,;=");
         private static final CharMatcher IS_HOST = UNRESERVED.or(SUB_DELIMS);
-        private static final CharMatcher IS_P_CHAR = UNRESERVED;
+        private static final CharMatcher IS_P_CHAR = UNRESERVED.or(CharMatcher.anyOf(":@"));
         private static final CharMatcher IS_PATH = UNRESERVED.or(SUB_DELIMS).or(CharMatcher.anyOf("/"));
         // The RFC permits percent-encoding any character. We also percent encode sub-delimiters to avoid
         // incompatibilities with http specification beyond the general URI definition per

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -68,19 +68,20 @@ public final class UrlBuilderTest {
                 .isEqualTo("http://host:80/foo/bar");
         assertThat(minimalUrl().pathSegments(List.of("foo", "bar")).build().toString())
                 .isEqualTo("http://host:80/foo/bar");
-        assertThat(minimalUrl().pathSegment("foo/bar").build().toString()).isEqualTo("http://host:80/foo%2Fbar");
+        assertThat(minimalUrl().pathSegment("foo/bar:baz@qux").build().toString())
+                .isEqualTo("http://host:80/foo%2Fbar:baz@qux");
         assertThat(minimalUrl()
-                        .pathSegment("!@#$%^&*()_+{}[]|\\|\"':;/?.>,<~`")
+                        .pathSegment("!#$%^&*()_+{}[]|\\|\"';/?.>,<~`")
                         .build()
                         .toString())
-                .isEqualTo("http://host:80/%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
-                        + "%5B%5D%7C%5C%7C%22%27%3A%3B%2F%3F.%3E%2C%3C~%60");
+                .isEqualTo("http://host:80/%21%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
+                        + "%5B%5D%7C%5C%7C%22%27%3B%2F%3F.%3E%2C%3C~%60");
         assertThat(minimalUrl()
-                        .pathSegments(List.of("!@#$%^&*()_+{}", "[]|\\|\"':;/?.>,<~`"))
+                        .pathSegments(List.of("!#$%^&*()_+{}", "[]|\\|\"';/?.>,<~`"))
                         .build()
                         .toString())
-                .isEqualTo("http://host:80/%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
-                        + "/%5B%5D%7C%5C%7C%22%27%3A%3B%2F%3F.%3E%2C%3C~%60");
+                .isEqualTo("http://host:80/%21%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
+                        + "/%5B%5D%7C%5C%7C%22%27%3B%2F%3F.%3E%2C%3C~%60");
     }
 
     @Test
@@ -181,10 +182,9 @@ public final class UrlBuilderTest {
 
     @Test
     public void urlEncoder_encodeQuery_onlyEncodesNonReservedChars() {
-        String nonReserved = "aAzZ09/?";
+        String nonReserved = "aAzZ09/?@:";
         assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue(nonReserved)).isEqualTo(nonReserved);
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("@[]{}ßçö"))
-                .isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("[]{}ßçö")).isEqualTo("%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
         assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("=&+")).isEqualTo("%3D%26%2B");
     }
 


### PR DESCRIPTION
## Before this PR

Putting this up for potential discussion - not sure if we actually want to make this change.

**Context:** We ran into the case where requests of a dialogue client get rejected by google-container-registry because dialogue would url encode the colon `:` in path segments (e.g. `sha256:c48bxxx`) while GCR only accepts non-encoded `:` in path segments.

Looking into Dialogue's url encoding, I noticed that Dialogue's implementation doesn't fully match the referenced [RFC-3986](https://www.rfc-editor.org/rfc/rfc3986). Most notably, Dialogue is defining the pchar matcher as `pchar = unreserved`, while the RFC is a bit more permissive here and also includes sub-delims, `:`, and `@`:

```
pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
```

Note that we have another explicit divergence for query params but this one is well documented and for compatibility reasons:

https://github.com/palantir/dialogue/blob/05ea07174aa8d9ea77cd09585f0852ea3554b354/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java#L247-L251

**Unclear points:**
* In the RFC, `pchar` also includes sub-delims. But given the comment above, it seems like we want to purposfully encode sub-delims?
* This logic has been around since early 2019 ([PR](https://github.com/palantir/dialogue/pull/49)). Given this never came up as an issue, maybe we don't feel like its worth touching this code?
* This is just a spec, and it's hard for me to judge the impact of such a change across all the consumers.

## After this PR

Extend the pchar matcher to also include `:` and `@`. This will result in those characters no longer being url encoded in path segments.

==COMMIT_MSG==
Include ':' and '@' in pchar definition for url encoding
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
