### PR TITLE
fix #1076: Dialogue allows colons in http paths and query parameters

### DIFF
--- a/changelog/@unreleased/pr-2360.v2.yml
+++ b/changelog/@unreleased/pr-2360.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'fix #1076: Dialogue allows colons in http paths and query parameters'
+  links:
+  - https://github.com/palantir/dialogue/pull/2360

--- a/changelog/@unreleased/pr-2360.v2.yml
+++ b/changelog/@unreleased/pr-2360.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: break
+break:
   description: |-
     Dialogue more closely follows the URI specification as defined in [rfc3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3), and allows colons in http paths and query parameters.
 

--- a/changelog/@unreleased/pr-2360.v2.yml
+++ b/changelog/@unreleased/pr-2360.v2.yml
@@ -1,7 +1,11 @@
 type: improvement
 improvement:
   description: |-
-    Dialogue more closely follows the URI specification as defined in [rfc3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3), and allows colons in http paths and query parameters. Previously the `:` character would be encoded as `%3A`, which is also allowed by rfc3986, however not required. Some server implementations, GCP APIs in particular, require colons in path strings not to be encoded.
-    This encoding is an implementation detail within dialogue, where either way is valid for servers which are compliant with the rfc. It is possible, though unlikely, that some custom servers or proxies do not handle unencoded colons correctly. Please reach out to us if you find cases where servers do not behave as expected!
+    Dialogue more closely follows the URI specification as defined in [rfc3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3), and allows colons in http paths and query parameters.
+
+    Previously the `:` character would be encoded as `%3A`, which is also allowed by rfc3986, however not required. Some server implementations, GCP APIs in particular, require colons in path strings not to be encoded.
+    This encoding is an implementation detail within dialogue, where either way is valid for servers which are compliant with the rfc.
+
+    It is possible, though unlikely, that some custom servers or proxies do not handle unencoded colons correctly. Please reach out to us if you find cases where servers do not behave as expected!
   links:
   - https://github.com/palantir/dialogue/pull/2360

--- a/changelog/@unreleased/pr-2360.v2.yml
+++ b/changelog/@unreleased/pr-2360.v2.yml
@@ -3,6 +3,8 @@ improvement:
   description: |-
     Dialogue more closely follows the URI specification as defined in [rfc3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3), and allows colons in http paths and query parameters.
 
+    Note that this is not an API break, however we're using a breaking changelog entry for visibility in case of unknown non-compliant servers.
+
     Previously the `:` character would be encoded as `%3A`, which is also allowed by rfc3986, however not required. Some server implementations, GCP APIs in particular, require colons in path strings not to be encoded.
     This encoding is an implementation detail within dialogue, where either way is valid for servers which are compliant with the rfc.
 

--- a/changelog/@unreleased/pr-2360.v2.yml
+++ b/changelog/@unreleased/pr-2360.v2.yml
@@ -1,5 +1,7 @@
 type: improvement
 improvement:
-  description: 'fix #1076: Dialogue allows colons in http paths and query parameters'
+  description: |-
+    Dialogue more closely follows the URI specification as defined in [rfc3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3), and allows colons in http paths and query parameters. Previously the `:` character would be encoded as `%3A`, which is also allowed by rfc3986, however not required. Some server implementations, GCP APIs in particular, require colons in path strings not to be encoded.
+    This encoding is an implementation detail within dialogue, where either way is valid for servers which are compliant with the rfc. It is possible, though unlikely, that some custom servers or proxies do not handle unencoded colons correctly. Please reach out to us if you find cases where servers do not behave as expected!
   links:
   - https://github.com/palantir/dialogue/pull/2360

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -74,13 +74,13 @@ public final class UrlBuilderTest {
                         .build()
                         .toString())
                 .isEqualTo("http://host:80/%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
-                        + "%5B%5D%7C%5C%7C%22%27%3A%3B%2F%3F.%3E%2C%3C~%60");
+                        + "%5B%5D%7C%5C%7C%22%27:%3B%2F%3F.%3E%2C%3C~%60");
         assertThat(minimalUrl()
                         .pathSegments(List.of("!@#$%^&*()_+{}", "[]|\\|\"':;/?.>,<~`"))
                         .build()
                         .toString())
                 .isEqualTo("http://host:80/%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D"
-                        + "/%5B%5D%7C%5C%7C%22%27%3A%3B%2F%3F.%3E%2C%3C~%60");
+                        + "/%5B%5D%7C%5C%7C%22%27:%3B%2F%3F.%3E%2C%3C~%60");
     }
 
     @Test
@@ -190,7 +190,24 @@ public final class UrlBuilderTest {
 
     @Test
     public void urlEncoder_encodeQuery_encodesPlusSign() {
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("+")).isEqualTo("%2B");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("+"))
+                .as("'+' must be encoded, otherwise many servers will interpret it as a url encoded space")
+                .isEqualTo("%2B");
+    }
+
+    @Test
+    public void urlEncoder_encodePath_encodesSemicolon() {
+        assertThat(BaseUrl.UrlEncoder.encodePathSegment(";"))
+                .as("';' must be encoded, otherwise many servers will "
+                        + "interpret as a delimiter for matrix parameters")
+                .isEqualTo("%3B");
+    }
+
+    @Test
+    public void urlEncoder_encodePath_allowsColon() {
+        assertThat(BaseUrl.UrlEncoder.encodePathSegment(":"))
+                .as("Several GCP APIs use ':' within paths, and do not handle encoded colons")
+                .isEqualTo(":");
     }
 
     @Test

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -135,6 +135,7 @@ public final class UrlBuilderTest {
         assertThat(minimalUrl().queryParam("foo", "bar").build().toString()).isEqualTo("http://host:80?foo=bar");
         assertThat(minimalUrl().queryParam("question?&", "answer!&").build().toString())
                 .isEqualTo("http://host:80?question?%26=answer%21%26");
+        assertThat(minimalUrl().queryParam("q", ":").build().toString()).isEqualTo("http://host:80?q=:");
     }
 
     @Test

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -166,6 +166,15 @@ public abstract class AbstractChannelTest {
     }
 
     @Test
+    public void allowsColonPathParameter() throws InterruptedException {
+        endpoint.renderPath = (_params, url) -> url.pathSegment("foo:bar");
+        channel.execute(endpoint, request);
+        assertThat(server.takeRequest().getRequestUrl())
+                .as("Several GCP APIs require colons in url paths")
+                .isEqualTo(server.url("foo:bar"));
+    }
+
+    @Test
     public void fillsHeaders() throws Exception {
         request = Request.builder()
                 .from(request)

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractChannelTest {
         channel.execute(endpoint, request);
         assertThat(server.takeRequest().getRequestUrl())
                 .as("Several GCP APIs require colons in url paths")
-                .isEqualTo(server.url("foo:bar"));
+                .isEqualTo(server.url("/foo:bar"));
     }
 
     @Test


### PR DESCRIPTION
This is required by some GCP APIs, where encoded colons are not respected.

Most places where we'd end up with colons in URIs are within path variable values, where we'd expect values to be handled correctly regardless of percent encoding. For the most part, percent encoding should work fine unless a server uses precise matching on uri segments, where we run into issues.

[rfc3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3) clearly allows colon as a pchar, however not all servers are necessarily fully compliant with the rfc. We've had issues with specific sub-delimiters in the past. This shouldn't be terribly risky, esepcially given this implementaiton has never allowed unencoded colons before, and we have no evidence to suggest they should be problematic.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
fix #1076: Dialogue allows colons in http paths and query parameters
==COMMIT_MSG==

## Possible downsides?
It's possible that some servers, proxies, etc do not handle unencoded colons well in paths.

## Behavior of common http clients:

Note that the default behavior of these clients doesn't necessarily mean that it's unsafe to do otherwise, however we should tread carefully around nonstandard behavior.

### 🔴 Python 3.9.6 urllib.parse
```python
import urllib.parse
urllib.parse.quote('foo:bar')
'foo%3Abar'
```

### 🔴 Apache HttpComponents (httpcore-5.3) UriBuilder

```java
System.out.println(new org.apache.hc.core5.net.URIBuilder()
        .setScheme("https")
        .setHost("localhost")
        .setPort(8443)
        .appendPathSegments(Collections.singletonList("foo:bar"))
        .toString());
// Produces: https://localhost:8443/foo%3Abar
```

### 🟢 Curl 8.10.1

caveat -- curl sends what you give it with the exception of unicode characters. Not clear that this is a reasonable test, since the raw URI is provided as an input.

```bash
curl 'http://localhost:8443/foo:bar'

GET /foo:bar HTTP/1.1
Host: localhost:8443
User-Agent: curl/8.10.1
Accept: */*
```

### 🟢 OkHttp

similar to curl, the uri is provided as an input, and it doesn't further escape colons
