### PR TITLE
Allow non-constant endpoints to opt-in to timings

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -253,7 +253,8 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = new RangeAcceptsIdentityEncodingChannel(channel);
                 channel = ContentEncodingChannel.of(channel, endpoint);
                 channel = TracedChannel.create(cf, channel, endpoint);
-                if (ChannelToEndpointChannel.isConstant(endpoint)) {
+                if (ChannelToEndpointChannel.isConstant(endpoint)
+                        || endpoint.tags().contains("dialogue-enable-endpoint-timing")) {
                     // Avoid producing metrics for non-constant endpoints which may produce
                     // high cardinality.
                     channel = TimingEndpointChannel.create(cf, channel, endpoint);


### PR DESCRIPTION
Related to https://github.com/palantir/dialogue/pull/1414

Motivated by https://github.com/palantir/conjure-java-runtime/pull/2973#discussion_r1781356606

There may be `Endpoint` implementation that are not constant, but whose cardinality is bounded through other means. This allows those `Endpoint` implementation to opt-in to timing metrics.