### PR TITLE
Retain endpoint concurrency limits on node refresh

### DIFF
--- a/changelog/@unreleased/pr-2418.v2.yml
+++ b/changelog/@unreleased/pr-2418.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Proof of concept retaining endpoint concurrency limits on refresh
+  links:
+  - https://github.com/palantir/dialogue/pull/2418

--- a/changelog/@unreleased/pr-2418.v2.yml
+++ b/changelog/@unreleased/pr-2418.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Proof of concept retaining endpoint concurrency limits on refresh
+  description: Retain endpoint concurrency limits on node refresh
   links:
   - https://github.com/palantir/dialogue/pull/2418

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -44,7 +44,12 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
     static final ChannelState.Key<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter> HOST_SPECIFIC_STATE_KEY =
             new ChannelState.Key<>(
                     CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.class,
-                    ConcurrencyLimitedChannel::createHostSpecificState);
+                    () -> new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.HOST_LEVEL));
+
+    private static final ChannelState.Key<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter>
+            ENDPOINT_SPECIFIC_STATE_KEY = new ChannelState.Key<>(
+                    CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.class,
+                    () -> new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.ENDPOINT_LEVEL));
 
     private final NeverThrowChannel delegate;
     private final CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter;
@@ -63,10 +68,11 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
      * Creates a concurrency limited channel for per-endpoint limiting.
      * Metrics are not reported by this component per-endpoint, only by the per-endpoint queue.
      */
-    static LimitedChannel createForEndpoint(Channel channel, String channelName, int uriIndex, Endpoint endpoint) {
+    static LimitedChannel createForEndpoint(
+            Channel channel, String channelName, int uriIndex, Endpoint endpoint, ChannelState endpointChannelState) {
         return new ConcurrencyLimitedChannel(
                 channel,
-                new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.ENDPOINT_LEVEL),
+                endpointChannelState.getState(ENDPOINT_SPECIFIC_STATE_KEY),
                 new EndpointConcurrencyLimitedChannelInstrumentation(channelName, uriIndex, endpoint));
     }
 
@@ -77,10 +83,6 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
         this.delegate = new NeverThrowChannel(delegate);
         this.limiter = limiter;
         this.channelNameForLogging = instrumentation.channelNameForLogging();
-    }
-
-    static CautiousIncreaseAggressiveDecreaseConcurrencyLimiter createHostSpecificState() {
-        return new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.HOST_LEVEL);
     }
 
     @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -46,8 +46,9 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
                     CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.class,
                     () -> new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.HOST_LEVEL));
 
-    private static final ChannelState.Key<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter>
-            ENDPOINT_SPECIFIC_STATE_KEY = new ChannelState.Key<>(
+    @VisibleForTesting
+    static final ChannelState.Key<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter> ENDPOINT_SPECIFIC_STATE_KEY =
+            new ChannelState.Key<>(
                     CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.class,
                     () -> new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.ENDPOINT_LEVEL));
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -260,6 +260,9 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                                 uriIndexForInstrumentation,
                                 endpoint,
                                 endpointChannelState.get(endpoint));
+                        // Note that because the queue is recreated when nodes are refreshed, it's critical that
+                        // the queue can force at least one request through at a time using the behavior introduced
+                        // by https://github.com/palantir/dialogue/pull/2422
                         return QueuedChannel.create(cf, endpoint, limited);
                     });
                     limitedChannel = ConcurrencyLimitedChannel.createForHost(

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -17,6 +17,8 @@
 package com.palantir.dialogue.core;
 
 import com.codahale.metrics.Meter;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -247,12 +249,17 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 LimitedChannel limitedChannel;
                 if (cf.isConcurrencyLimitingEnabled()) {
                     Channel unlimited = channel;
+                    EndpointChannelState endpointChannelState = channelState.getState(EndpointChannelState.KEY);
                     channel = new ChannelToEndpointChannel(endpoint -> {
                         if (endpoint.tags().contains("dialogue-disable-endpoint-concurrency-limiting")) {
                             return unlimited;
                         }
                         LimitedChannel limited = ConcurrencyLimitedChannel.createForEndpoint(
-                                unlimited, cf.channelName(), uriIndexForInstrumentation, endpoint);
+                                unlimited,
+                                cf.channelName(),
+                                uriIndexForInstrumentation,
+                                endpoint,
+                                endpointChannelState.get(endpoint));
                         return QueuedChannel.create(cf, endpoint, limited);
                     });
                     limitedChannel = ConcurrencyLimitedChannel.createForHost(
@@ -264,6 +271,33 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 perUriChannels.add(limitedChannel);
             }
             return perUriChannels.build();
+        }
+
+        /**
+         * {@link ChannelState} provider for per-endpoint channels like the endpoint concurrency limiter.
+         * This object is held in the per-host state, and can be used to look up a {@link ChannelState}
+         * scoped to an individual {@link Endpoint}.
+         * {@link Endpoint} state is held in a weak-keyed cache, equivalent to the one used in
+         * {@link ChannelToEndpointChannel}.
+         * {@link Endpoint} objects are usually enums, which will never be garbage collected, however it's possible
+         * that callers may build an endpoint instances on a per-call basis, so the weak-keyed map is defensive
+         * against short-lived endpoints.
+         * We don't use the same map because the {@link ChannelToEndpointChannel} retains full channel state which
+         * may or may not be designed to be reused across reloads, and we aim to be more precise with state that is
+         * kept across uri changes.
+         */
+        private record EndpointChannelState(LoadingCache<Endpoint, ChannelState> cache) {
+            private static final ChannelState.Key<EndpointChannelState> KEY =
+                    new ChannelState.Key<>(EndpointChannelState.class, EndpointChannelState::create);
+
+            ChannelState get(Endpoint endpoint) {
+                return cache.get(endpoint);
+            }
+
+            private static EndpointChannelState create() {
+                return new EndpointChannelState(
+                        Caffeine.newBuilder().weakKeys().maximumSize(10_000).build(_key -> new ChannelState()));
+            }
         }
 
         private static EndpointChannelFactory createEndpointChannelFactory(Channel multiHostQueuedChannel, Config cf) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -119,6 +119,30 @@ public class ConcurrencyLimitedChannelTest {
     }
 
     @Test
+    public void testReuseCachedLimiterState_endpoint() {
+        String channelName = "channel";
+        ChannelState state = new ChannelState();
+
+        // create two channels for the same endpoint, which should re-use the same AIMD state
+        LimitedChannel forEndpoint =
+                ConcurrencyLimitedChannel.createForEndpoint(delegate, channelName, 0, endpoint, state);
+        CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter =
+                state.getState(ConcurrencyLimitedChannel.ENDPOINT_SPECIFIC_STATE_KEY);
+
+        assertThat(limiter.getInflight()).isEqualTo(0);
+
+        forEndpoint.maybeExecute(endpoint, request, LimitEnforcement.DEFAULT_ENABLED);
+        assertThat(limiter.getInflight()).isEqualTo(1);
+
+        // different uriIndex has no impact on whether state is shared, as indexes will shuffle when nodes go down
+        LimitedChannel forEndpoint2 =
+                ConcurrencyLimitedChannel.createForEndpoint(delegate, channelName, 1, endpoint, state);
+        forEndpoint2.maybeExecute(endpoint, request, LimitEnforcement.DEFAULT_ENABLED);
+
+        assertThat(limiter.getInflight()).isEqualTo(2);
+    }
+
+    @Test
     public void testLimiterAvailable_successfulRequest_host() {
         mockHostLimitAvailable();
         mockResponseCode(200);


### PR DESCRIPTION
==COMMIT_MSG==
Retain endpoint concurrency limits on refresh
==COMMIT_MSG==
