### PR TITLE
Implement support for the Proxy-Upstream-Request-Attempts header

### DIFF
--- a/changelog/@unreleased/pr-2430.v2.yml
+++ b/changelog/@unreleased/pr-2430.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement support for the Proxy-Upstream-Request-Attempts header
+  links:
+  - https://github.com/palantir/dialogue/pull/2430

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -101,6 +101,9 @@ final class Responses {
                 if (parsed >= 0) {
                     return parsed;
                 }
+                log.warn(
+                        "Received an unexpected negative proxy upstream request attempts value, using zero",
+                        SafeArg.of("proxyUpstreamRequestAttempts", proxyUpstreamRequestAttempts));
             } catch (NumberFormatException e) {
                 log.warn(
                         "Failed to parse proxy upstream request attempts, assuming zero",

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/Responses.java
@@ -15,14 +15,23 @@
  */
 package com.palantir.dialogue.core;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HttpHeaders;
 import com.palantir.conjure.java.api.errors.QosReason;
 import com.palantir.conjure.java.api.errors.QosReason.DueTo;
 import com.palantir.conjure.java.api.errors.QosReason.RetryHint;
 import com.palantir.dialogue.Response;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.Optional;
 
 /** Utility functionality for {@link Response} handling. */
 final class Responses {
+    private static final SafeLogger log = SafeLoggerFactory.get(Responses.class);
+
+    @VisibleForTesting
+    static final String PROXY_UPSTREAM_REQUEST_ATTEMPTS = "Proxy-Upstream-Request-Attempts";
 
     static boolean isRetryOther(Response response) {
         // Note that a 308 status may be a non-retryable signal, for instance google sometimes
@@ -75,6 +84,31 @@ final class Responses {
 
     static boolean isClientError(Response response) {
         return response.code() / 100 == 4;
+    }
+
+    /**
+     * Returns the integer value of the {@link #PROXY_UPSTREAM_REQUEST_ATTEMPTS} {@link Response#headers() header}.
+     * When the value is missing, negative, or otherwise cannot be parsed, zero is returned.
+     * Rejecting negative values is critical because clients mustn't roll back retry counters based on
+     * responses from a remote server.
+     */
+    static int getProxyUpstreamRequestAttempts(Response response) {
+        Optional<String> maybeProxyUpstreamRequestAttempts = response.getFirstHeader(PROXY_UPSTREAM_REQUEST_ATTEMPTS);
+        if (maybeProxyUpstreamRequestAttempts.isPresent()) {
+            String proxyUpstreamRequestAttempts = maybeProxyUpstreamRequestAttempts.get();
+            try {
+                int parsed = Integer.parseInt(proxyUpstreamRequestAttempts.trim());
+                if (parsed >= 0) {
+                    return parsed;
+                }
+            } catch (NumberFormatException e) {
+                log.warn(
+                        "Failed to parse proxy upstream request attempts, assuming zero",
+                        SafeArg.of("proxyUpstreamRequestAttempts", proxyUpstreamRequestAttempts),
+                        e);
+            }
+        }
+        return 0;
     }
 
     private Responses() {}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -312,8 +312,14 @@ final class RetryingChannel implements EndpointChannel {
             // those are considered as well. When the proxy makes a single request, that is considered part of
             // our initial request to the proxy -- we're counting for total failures sending requests to
             // the upstream server.
-            int additionalAttempts = Math.max(1, Responses.getProxyUpstreamRequestAttempts(response));
-            failures = failures + additionalAttempts;
+            int proxyUpstreamRequestAttempts = Responses.getProxyUpstreamRequestAttempts(response);
+            if (proxyUpstreamRequestAttempts > 1) {
+                log.info(
+                        "Received a Proxy-Upstream-Request-Attempts response header "
+                                + "indicating retries have already occurred",
+                        SafeArg.of("proxyUpstreamRequestAttempts", proxyUpstreamRequestAttempts));
+            }
+            failures = failures + Math.max(1, proxyUpstreamRequestAttempts);
             if (failures <= maxRetries) {
                 response.close();
                 Throwable throwableToLog = log.isTraceEnabled() ? failureSupplier.apply(endpoint, response) : null;

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -307,7 +307,14 @@ final class RetryingChannel implements EndpointChannel {
 
         private ListenableFuture<Response> incrementFailuresAndMaybeRetry(
                 Response response, BiFunction<Endpoint, Response, Throwable> failureSupplier, Meter meter) {
-            if (++failures <= maxRetries) {
+            // We've made a request which has failed, so we apply a floor of a single failure if there are no
+            // proxy upstream request attempts. Otherwise, if the proxy has reported upstream request attempts,
+            // those are considered as well. When the proxy makes a single request, that is considered part of
+            // our initial request to the proxy -- we're counting for total failures sending requests to
+            // the upstream server.
+            int additionalAttempts = Math.max(1, Responses.getProxyUpstreamRequestAttempts(response));
+            failures = failures + additionalAttempts;
+            if (failures <= maxRetries) {
                 response.close();
                 Throwable throwableToLog = log.isTraceEnabled() ? failureSupplier.apply(endpoint, response) : null;
                 long backoffNanos = Responses.isRetryOther(response) ? 0 : getBackoffNanoseconds();

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ResponsesTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ResponsesTest.java
@@ -46,6 +46,13 @@ class ResponsesTest {
     }
 
     @Test
+    void proxyUpstreamRequestAttempts_trimmed() {
+        try (Response response = new TestResponse().withHeader(Responses.PROXY_UPSTREAM_REQUEST_ATTEMPTS, " 2 ")) {
+            assertThat(Responses.getProxyUpstreamRequestAttempts(response)).isEqualTo(2);
+        }
+    }
+
+    @Test
     void proxyUpstreamRequestAttempts_valid_default() {
         try (Response response = new TestResponse().withHeader(Responses.PROXY_UPSTREAM_REQUEST_ATTEMPTS, "0")) {
             assertThat(Responses.getProxyUpstreamRequestAttempts(response)).isZero();

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ResponsesTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ResponsesTest.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TestResponse;
+import org.junit.jupiter.api.Test;
+
+class ResponsesTest {
+
+    @Test
+    void proxyUpstreamRequestAttempts_missing() {
+        try (Response response = new TestResponse()) {
+            assertThat(Responses.getProxyUpstreamRequestAttempts(response)).isZero();
+        }
+    }
+
+    @Test
+    void proxyUpstreamRequestAttempts_malformed() {
+        try (Response response = new TestResponse().withHeader(Responses.PROXY_UPSTREAM_REQUEST_ATTEMPTS, "deadbeef")) {
+            assertThat(Responses.getProxyUpstreamRequestAttempts(response)).isZero();
+        }
+    }
+
+    @Test
+    void proxyUpstreamRequestAttempts_valid() {
+        try (Response response = new TestResponse().withHeader(Responses.PROXY_UPSTREAM_REQUEST_ATTEMPTS, "1")) {
+            assertThat(Responses.getProxyUpstreamRequestAttempts(response)).isOne();
+        }
+    }
+
+    @Test
+    void proxyUpstreamRequestAttempts_valid_default() {
+        try (Response response = new TestResponse().withHeader(Responses.PROXY_UPSTREAM_REQUEST_ATTEMPTS, "0")) {
+            assertThat(Responses.getProxyUpstreamRequestAttempts(response)).isZero();
+        }
+    }
+
+    @Test
+    void proxyUpstreamRequestAttempts_negative() {
+        try (Response response = new TestResponse().withHeader(Responses.PROXY_UPSTREAM_REQUEST_ATTEMPTS, "-1")) {
+            assertThat(Responses.getProxyUpstreamRequestAttempts(response)).isZero();
+        }
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -103,6 +103,37 @@ public class RetryingChannelTest {
     }
 
     @Test
+    public void testProxyUpstreamRequestAttemptsAccumulated() {
+        when(channel.execute(any()))
+                .thenAnswer((Answer<ListenableFuture<Response>>) _invocation -> Futures.immediateFuture(
+                        new TestResponse().code(503).withHeader(Responses.PROXY_UPSTREAM_REQUEST_ATTEMPTS, "2")))
+                .thenReturn(FAILED)
+                // the success case should never be reached
+                .thenReturn(SUCCESS);
+
+        // One retry allows an initial request (not a retry) and a single retry.
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                2,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response).isDone();
+        // Our first request failed (1 failure) and accumulated a second from the 'Proxy-Retry-Attempts: 2' response
+        // header, so the next request which results in a SafeIoException exceeds the limit and is not retried.
+        assertThat(response)
+                .failsWithin(Duration.ZERO)
+                .withThrowableThat()
+                // Bypass the outer ExecutionException implementation detail of Future
+                .havingCause()
+                .isInstanceOf(SafeIoException.class)
+                .withMessage("FAILED");
+    }
+
+    @Test
     public void testRetriesUpToMaxRetriesAndFails() throws ExecutionException, InterruptedException {
         when(channel.execute(any())).thenReturn(FAILED).thenReturn(FAILED).thenReturn(SUCCESS);
 


### PR DESCRIPTION
This aims to provide coordination between clients and reverse proxy servers which implement retries, allowing us to avoid multiplying out the total retry count.

When dialogue is configured with more retries than a proxy, we still may retry more than we want, but not DIALOGUE_ATTEMPTS * PROXY_ATTEMPTS. The worst case scenario should be when the proxy retry attempts don't quite reach the configured dialogue retry limit, and another full round of proxy retries must be accumulated. This should be a reaosnable trade-off because it allows the calling client to be configured with a larger value as needed for stability, without multiplying all retries across the board unnecessarily.

Note that when a Dialogue client receives a tcp error/closure, it can make no assumptions about proxy retry attempts, so this only applies to requests which successfully receive a response.

==COMMIT_MSG==
Implement support for the Proxy-Upstream-Request-Attempts header
==COMMIT_MSG==

Note this feature is meant to be used in tandem with #2434 for flexibility