### PR TITLE
Implement the `Client-Can-Retry: true` hint header for reverse proxies

### DIFF
--- a/changelog/@unreleased/pr-2434.v2.yml
+++ b/changelog/@unreleased/pr-2434.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Implement the `Client-Can-Retry: true` hint header for reverse proxies'
+  links:
+  - https://github.com/palantir/dialogue/pull/2434

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -314,6 +314,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                 channel = RetryingChannel.create(cf, channel, endpoint);
                 channel = DeprecationWarningChannel.create(cf, channel, endpoint);
                 channel = ContentDecodingChannel.create(cf, channel, endpoint);
+                channel = new RetryAdvertisementChannel(channel);
                 channel = new RangeAcceptsIdentityEncodingChannel(channel);
                 channel = ContentEncodingChannel.of(channel, endpoint);
                 channel = TracedChannel.create(cf, channel, endpoint);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryAdvertisementChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryAdvertisementChannel.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+
+/**
+ * Adds the {@code Client-Can-Retry: true} to inform proxies that this client is capable of retrying requests.
+ * Note that this channel does not check whether the request body itself is retryable, nor that the current
+ * configuration is configured to allow retries. This is intentional, because this flag is designed to inform
+ * the proxy of whether not the responsibility for retries can be left to the client, regardless of the current
+ * configuration.
+ * <p/>
+ * This feature functions in combination with {@code Proxy-Upstream-Request-Attempts} to allow negotiation for
+ * retries to occur based on proxy configuration, without requiring clients to be updated or reconfigured.
+ */
+final class RetryAdvertisementChannel implements EndpointChannel {
+
+    @VisibleForTesting
+    static final String CLIENT_CAN_RETRY_HEADER = "Client-Can-Retry";
+
+    private static final String CLIENT_CAN_RETRY_VALUE = "true";
+
+    private final EndpointChannel delegate;
+
+    RetryAdvertisementChannel(EndpointChannel delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Request request) {
+        return delegate.execute(augment(request));
+    }
+
+    private static Request augment(Request input) {
+        if (input.headerParams().containsKey(CLIENT_CAN_RETRY_HEADER)) {
+            return input;
+        }
+        return Request.builder()
+                .from(input)
+                .putHeaderParams(CLIENT_CAN_RETRY_HEADER, CLIENT_CAN_RETRY_VALUE)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "RetryAdvertisementChannel{" + delegate + '}';
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryAdvertisementChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryAdvertisementChannelTest.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RetryAdvertisementChannelTest {
+
+    @Test
+    void addsClientCanRetryHeader() {
+        List<Request> requests = new ArrayList<>();
+        EndpointChannel delegate = request -> {
+            requests.add(request);
+            return Futures.immediateCancelledFuture();
+        };
+        EndpointChannel channel = new RetryAdvertisementChannel(delegate);
+        assertThat(channel.execute(Request.builder().build())).isCancelled();
+
+        assertThat(requests).singleElement().satisfies(request -> assertThat(request.headerParams())
+                .isEqualTo(ImmutableListMultimap.of(RetryAdvertisementChannel.CLIENT_CAN_RETRY_HEADER, "true")));
+    }
+
+    @Test
+    void clientCanRetryHeaderAlreadyExists() {
+        List<Request> requests = new ArrayList<>();
+        EndpointChannel delegate = request -> {
+            requests.add(request);
+            return Futures.immediateCancelledFuture();
+        };
+        EndpointChannel channel = new RetryAdvertisementChannel(delegate);
+        Request inputRequest = Request.builder()
+                .putHeaderParams(RetryAdvertisementChannel.CLIENT_CAN_RETRY_HEADER, "false")
+                .build();
+        assertThat(channel.execute(inputRequest)).isCancelled();
+
+        // The existing header should not be mutated
+        assertThat(requests).singleElement().satisfies(request -> {
+            assertThat(request.headerParams())
+                    .isEqualTo(ImmutableListMultimap.of(RetryAdvertisementChannel.CLIENT_CAN_RETRY_HEADER, "false"));
+            assertThat(request)
+                    .as("the channel should not create a new request object unnecessarily")
+                    .isSameAs(inputRequest);
+        });
+    }
+}


### PR DESCRIPTION
This feature functions in combination with `Proxy-Upstream-Request-Attempts` (#2430) to allow negotiation for retries to occur based on proxy configuration, without requiring clients to be updated or reconfigured.

==COMMIT_MSG==
Implement the `Client-Can-Retry: true` hint header for reverse proxies
==COMMIT_MSG==