### PR TITLE
Fix request request path to always include leading slash /

### DIFF
--- a/changelog/@unreleased/pr-2452.v2.yml
+++ b/changelog/@unreleased/pr-2452.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix request request path to always include leading slash /
+  links:
+  - https://github.com/palantir/dialogue/pull/2452

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -162,7 +162,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
                         endpoint.httpMethod().name())
                 .setScheme(target.getProtocol())
                 .setAuthority(parseAuthority(target))
-                .setPath(target.getFile());
+                .setPath(getPath(target));
 
         // Fill headers
         request.headerParams().forEach(builder::addHeader);
@@ -179,6 +179,15 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             builder.setEntity(EmptyHttpEntity.INSTANCE);
         }
         return builder.build();
+    }
+
+    @VisibleForTesting
+    static String getPath(URL target) {
+        String path = target.getFile();
+        if (path.startsWith("/")) {
+            return path;
+        }
+        return path.isEmpty() ? "/" : '/' + path;
     }
 
     @VisibleForTesting

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannelTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannelTest.java
@@ -33,6 +33,7 @@ import java.net.UnknownHostException;
 import java.util.Comparator;
 import java.util.Map;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.net.URIAuthority;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -116,9 +117,10 @@ class ApacheHttpClientBlockingChannelTest {
         "https://user@[0000:0000:0000:0000:0000:ffff:c0a8:0102]:8443/path/to/foo/bar?baz=quux&hello=world#an-octothorpe"
                 + " , 0000:0000:0000:0000:0000:ffff:c0a8:0102, 8443, user",
         "https://user:slash%2Fslash@www.example.local, www.example.local, -1, user:slash%2Fslash",
+        "http://localhost:59845/?REQUEST=GetCapabilities&SERVICE=WMS, localhost, 59845, ",
+        "http://localhost:59845?REQUEST=GetCapabilities&SERVICE=WMS, localhost, 59845, ",
     })
-    void parseAuthority(String input, String expectedHost, int expectedPort, String expectedUserInfo) throws Exception {
-        URL url = new URL(input);
+    void parseAuthority(URL url, String expectedHost, int expectedPort, String expectedUserInfo) throws Exception {
         assertThat(ApacheHttpClientBlockingChannel.parseAuthority(url))
                 .isEqualTo(URIAuthority.create(url.toURI().getRawAuthority()))
                 .isEqualTo(URIAuthority.create(url.getAuthority()))
@@ -132,6 +134,88 @@ class ApacheHttpClientBlockingChannelTest {
                             .isEqualTo(expectedUserInfo)
                             .isEqualTo(url.getUserInfo());
                 });
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "https://192.168.1.1",
+                "https://192.168.1.1/",
+                "https://localhost",
+                "https://localhost/",
+                "https://localhost/?REQUEST=GetCapabilities&SERVICE=WMS",
+                "https://localhost:12345",
+                "https://localhost:12345?REQUEST=GetCapabilities&SERVICE=WMS",
+                "https://localhost:12345/?REQUEST=GetCapabilities&SERVICE=WMS",
+                "https://www.example.local/path/to/foo/bar?baz=quux&hello=world",
+            })
+    void getPathStartsWithSlash(URL url) {
+        assertThat(ApacheHttpClientBlockingChannel.getPath(url))
+                .isNotNull()
+                .isNotEmpty()
+                .startsWith("/");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "http://localhost:12345/?REQUEST=GetCapabilities&SERVICE=WMS , http://localhost:12345 , ",
+        "https://localhost:12345/?REQUEST=GetCapabilities&SERVICE=WMS , https://localhost:12345/ ,  ",
+        "https://localhost:12345/api?REQUEST=GetCapabilities&SERVICE=WMS , https://localhost:12345/api ,  ",
+        "https://localhost:12345/api?REQUEST=GetCapabilities&SERVICE=WMS , https://localhost:12345/api/ , ",
+    })
+    void noPathQueryString(URL expectedUrl, String base) throws Exception {
+        Request wmsRequest = Request.builder()
+                .putQueryParams("REQUEST", "GetCapabilities")
+                .putQueryParams("SERVICE", "WMS")
+                .build();
+        BaseUrl baseUrl = BaseUrl.of(new URL(base));
+        Endpoint wmsEndpoint = new Endpoint() {
+            private final PathTemplate pathTemplate = PathTemplate.builder()
+                    .variable("REQUEST")
+                    .variable("SERVICE")
+                    .build();
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "testService";
+            }
+
+            @Override
+            public String endpointName() {
+                return "testEndpoint";
+            }
+
+            @Override
+            public String version() {
+                return "1.2.3";
+            }
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+        };
+        URL target = baseUrl.render(wmsEndpoint, wmsRequest);
+        assertThat(ApacheHttpClientBlockingChannel.getPath(target)).isNotEmpty().startsWith("/");
+
+        ClassicHttpRequest expectedRequest = ClassicRequestBuilder.create(
+                        wmsEndpoint.httpMethod().name())
+                .setUri(target.toString())
+                .build();
+
+        ClassicHttpRequest request = ApacheHttpClientBlockingChannel.createRequest(baseUrl, wmsEndpoint, wmsRequest);
+        assertThat(request.getMethod()).isEqualTo(wmsEndpoint.httpMethod().toString());
+        assertThat(request.getUri())
+                .isEqualTo(expectedUrl.toURI())
+                .isEqualTo(expectedRequest.getUri())
+                .asString()
+                .isEqualTo(expectedUrl.toString());
+        assertThat(request.getPath()).isEqualTo(expectedRequest.getPath());
     }
 
     @Test


### PR DESCRIPTION
## Before this PR

https://github.com/palantir/dialogue/pull/2437 introduced an issue where requests with an empty path were no longer rendered with a leading slash.

prior to 4.6.0 render URLs like:
`https://localhost:59845/?REQUEST=GetCapabilities&SERVICE=WMS`

4.6.0 renders them like:
`https://localhost:59845?REQUEST=GetCapabilities&SERVICE=WMS`

Specifically [see `org.apache.hc.core5.http.support.AbstractRequestBuilder#setUri(java.net.URI)`](https://github.com/apache/httpcomponents-core/blob/rel/v5.3.1/httpcore5/src/main/java/org/apache/hc/core5/http/support/AbstractRequestBuilder.java#L189-L193) 

## After this PR
==COMMIT_MSG==
Fix request request path to always include leading slash /
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
