### PR TITLE
Don't mock `ErrorDecoder` in `ConjureBodySerDeTest`

### DIFF
--- a/changelog/@unreleased/pr-2459.v2.yml
+++ b/changelog/@unreleased/pr-2459.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Don't mock `ErrorDecoder` in `ConjureBodySerDeTest`
+  links:
+  - https://github.com/palantir/dialogue/pull/2459

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDeTest.java
@@ -19,14 +19,15 @@ package com.palantir.conjure.java.dialogue.serde;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.RequestBody;
@@ -47,6 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ConjureBodySerDeTest {
 
+    private static final ObjectMapper SERVER_MAPPER = ObjectMappers.newServerObjectMapper();
     private static final TypeMarker<String> TYPE = new TypeMarker<String>() {};
     private static final TypeMarker<Optional<String>> OPTIONAL_TYPE = new TypeMarker<Optional<String>>() {};
 
@@ -137,14 +139,12 @@ public class ConjureBodySerDeTest {
     }
 
     @Test
-    public void testErrorsDecoded() {
-        TestResponse response = new TestResponse().code(400);
-
+    public void testErrorsDecoded() throws JsonProcessingException {
         ServiceException serviceException = new ServiceException(ErrorType.INVALID_ARGUMENT);
         SerializableError serialized = SerializableError.forException(serviceException);
-        errorDecoder = mock(ErrorDecoder.class);
-        when(errorDecoder.isError(response)).thenReturn(true);
-        when(errorDecoder.decode(response)).thenReturn(new RemoteException(serialized, 400));
+        TestResponse response = TestResponse.withBody(SERVER_MAPPER.writeValueAsString(serialized))
+                .code(400)
+                .contentType("application/json");
 
         BodySerDe serializers = conjureBodySerDe("text/plain");
 
@@ -220,14 +220,12 @@ public class ConjureBodySerDeTest {
     }
 
     @Test
-    public void testEmptyResponse_failure() {
-        TestResponse response = new TestResponse().code(400);
-
+    public void testEmptyResponse_failure() throws JsonProcessingException {
         ServiceException serviceException = new ServiceException(ErrorType.INVALID_ARGUMENT);
         SerializableError serialized = SerializableError.forException(serviceException);
-        errorDecoder = mock(ErrorDecoder.class);
-        when(errorDecoder.isError(response)).thenReturn(true);
-        when(errorDecoder.decode(response)).thenReturn(new RemoteException(serialized, 400));
+        TestResponse response = TestResponse.withBody(SERVER_MAPPER.writeValueAsString(serialized))
+                .code(400)
+                .contentType("application/json");
 
         BodySerDe serializers = conjureBodySerDe("application/json");
 


### PR DESCRIPTION
## Before this PR
When testing `ConjureBodySerDe`, we mock the function calls to `ErrorEncoder`. When implementing #2443, I introduce a replacement for `ErrorDecoder`. I would like to be able to validate that we don't have regressions in the current error handling logic and not mocking `ErrorDecoder` will help: I can validate that the logic in `ErrorDecoder` is still valid with my changes in #2443 where I replace logic in `ErrorDecoder` with calls to a delegate `EndpointErrorDecoder`.

## After this PR
==COMMIT_MSG==
Don't mock `ErrorDecoder` in `ConjureBodySerDeTest`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
