### PR TITLE
Suppress deprecation warning in generated Dialogue factory if needed

### DIFF
--- a/changelog/@unreleased/pr-2489.v2.yml
+++ b/changelog/@unreleased/pr-2489.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The Dialogue annotation processor propagates deprecation into generated
+    implementation methods
+  links:
+  - https://github.com/palantir/dialogue/pull/2489

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/EndpointDefinition.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/EndpointDefinition.java
@@ -34,6 +34,11 @@ public interface EndpointDefinition {
 
     ReturnType returns();
 
+    @Value.Default
+    default boolean deprecated() {
+        return false;
+    }
+
     @Value.Derived
     default String channelFieldName() {
         return endpointName().get() + "Channel";

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/EndpointDefinitions.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/EndpointDefinitions.java
@@ -71,6 +71,8 @@ public final class EndpointDefinitions {
                 .map(arg -> getArgumentDefinition(endpointName, arg))
                 .<ArgumentDefinition>mapMulti(Optional::ifPresent)
                 .collect(Collectors.toList());
+        boolean deprecated = MoreElements.isAnnotationPresent(element, Deprecated.class)
+                || MoreElements.isAnnotationPresent(element.getEnclosingElement(), Deprecated.class);
 
         if (httpPath.isEmpty()
                 || returnType.isEmpty()
@@ -99,6 +101,7 @@ public final class EndpointDefinitions {
                 .httpPath(httpPath.get())
                 .returns(returnType.get())
                 .addAllArguments(argumentDefinitions)
+                .deprecated(deprecated)
                 .build());
     }
 

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -114,9 +114,7 @@ public final class ServiceImplementationGenerator {
                 .addAnnotation(Override.class);
 
         if (def.deprecated()) {
-            methodBuilder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                    .addMember("value", "$S", "deprecation")
-                    .build());
+            methodBuilder.addAnnotation(AnnotationSpec.builder(Deprecated.class).build());
         }
 
         methodBuilder.addCode("$T $L = $T.builder();", Request.Builder.class, REQUEST, Request.class);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -37,6 +37,7 @@ import com.palantir.dialogue.annotations.processor.data.ParameterType.Cases;
 import com.palantir.dialogue.annotations.processor.data.ParameterTypes;
 import com.palantir.dialogue.annotations.processor.data.ReturnType;
 import com.palantir.dialogue.annotations.processor.data.ServiceDefinition;
+import com.palantir.javapoet.AnnotationSpec;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.FieldSpec;
@@ -111,6 +112,12 @@ public final class ServiceImplementationGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameters(params)
                 .addAnnotation(Override.class);
+
+        if (def.deprecated()) {
+            methodBuilder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
+                    .addMember("value", "$S", "deprecation")
+                    .build());
+        }
 
         methodBuilder.addCode("$T $L = $T.builder();", Request.Builder.class, REQUEST, Request.class);
 

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -112,8 +112,14 @@ public final class DialogueRequestAnnotationsProcessorTest {
         String generatedFqnClassName = clazz.getPackage().getName() + "." + generatedClassName;
         String generatedClassFileRelativePath = generatedFqnClassName.replaceAll("\\.", "/") + ".java";
         assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, generatedClassFileRelativePath))
-                .hasValueSatisfying(
-                        javaFileObject -> assertContentsMatch(javaFileObject, generatedClassFileRelativePath));
+                .hasValueSatisfying(javaFileObject -> {
+                    assertContentsMatch(javaFileObject, generatedClassFileRelativePath);
+
+                    assertThat(Compiler.javac()
+                                    .withOptions("-source", "11", "-Werror", "-Xlint:deprecation", "-Xlint:unchecked")
+                                    .compile(javaFileObject))
+                            .succeededWithoutWarnings();
+                });
     }
 
     private Compilation compileTestClass(Path basePath, Class<?> clazz) {
@@ -123,9 +129,7 @@ public final class DialogueRequestAnnotationsProcessorTest {
         try {
             return Compiler.javac()
                     // This is required because this tool does not know about our gradle setting.
-                    .withOptions("-source", "11")
-                    .withOptions("-Werror")
-                    .withOptions("-Xlint:unchecked")
+                    .withOptions("-source", "11", "-Werror", "-Xlint:deprecation", "-Xlint:unchecked")
                     .withProcessors(new DialogueRequestAnnotationsProcessor())
                     .compile(JavaFileObjects.forResource(clazzPath.toUri().toURL()));
         } catch (MalformedURLException e) {

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/MyService.java
@@ -103,4 +103,8 @@ public interface MyService {
             @Request.Header("h12") List<MyAliasType> header12,
             @Request.HeaderMap Multimap<String, String> headerMap,
             @Request.Body(MySerializableTypeBodySerializer.class) MySerializableType body);
+
+    @Deprecated
+    @Request(method = HttpMethod.GET, path = "/deprecated")
+    void deprecated();
 }

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -27,9 +27,9 @@ import com.palantir.dialogue.annotations.ParameterSerializer;
 import com.palantir.dialogue.annotations.ResponseDeserializer;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.SuppressWarnings;
 import java.lang.Void;
 import java.util.List;
 import java.util.Optional;
@@ -268,7 +268,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             }
 
             @Override
-            @SuppressWarnings("deprecation")
+            @Deprecated
             public void deprecated() {
                 Request.Builder _request = Request.builder();
                 runtime.clients().callBlocking(deprecatedChannel, _request.build(), deprecatedDeserializer);

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -29,6 +29,7 @@ import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import java.lang.Void;
 import java.util.List;
 import java.util.Optional;
@@ -114,6 +115,11 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             private final EndpointChannel paramsChannel = endpointChannelFactory.endpoint(Endpoints.params);
 
             private final Deserializer<Void> paramsDeserializer = new ErrorHandlingVoidDeserializer(
+                    runtime.bodySerDe().emptyBodyDeserializer(), new ConjureErrorDecoder());
+
+            private final EndpointChannel deprecatedChannel = endpointChannelFactory.endpoint(Endpoints.deprecated);
+
+            private final Deserializer<Void> deprecatedDeserializer = new ErrorHandlingVoidDeserializer(
                     runtime.bodySerDe().emptyBodyDeserializer(), new ConjureErrorDecoder());
 
             @Override
@@ -259,6 +265,13 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
                 _request.putAllHeaderParams(paramsHeaderMapEncoder.toParamValues(headerMap));
                 _request.body(paramsSerializer.serialize(body));
                 runtime.clients().callBlocking(paramsChannel, _request.build(), paramsDeserializer);
+            }
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public void deprecated() {
+                Request.Builder _request = Request.builder();
+                runtime.clients().callBlocking(deprecatedChannel, _request.build(), deprecatedDeserializer);
             }
         };
     }
@@ -469,6 +482,36 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             @Override
             public String endpointName() {
                 return "params";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        },
+
+        deprecated {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("deprecated").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "MyService";
+            }
+
+            @Override
+            public String endpointName() {
+                return "deprecated";
             }
 
             @Override


### PR DESCRIPTION
## Before this PR
Declaring a Dialogue service with a deprecated method like
```
@DialogueService(MyBlockingDialogueServiceFactory.class)
public interface MyServiceBlocking {
    @Request(method = HttpMethod.GET, path = "/path")
    @Deprecated
    void foo();
```
will fail compilation with `-Xlint:deprecation` for the generated DialogueServiceFactory:
```
...Factory.java: warning: [deprecation] foo(AuthHeader) in MyServiceBlocking has been deprecated
            public void foo(
                    ^
```

## After this PR
`@SuppressWarnings("deprecation")` is now included in the generated DialogueServiceFactory:
```
@Override
@SuppressWarnings("deprecation")
public void foo() {
    Request.Builder _request = Request.builder();
    ...
}
```
The implementation in this PR is basically the same as for Conjure, [here](https://github.com/palantir/conjure-java/blob/4114c4142b2d513e988640629c4a3cc12a0aaf6a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java#L142-L143) and [here](https://github.com/palantir/conjure-java/blob/4114c4142b2d513e988640629c4a3cc12a0aaf6a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java#L248-L253).

==COMMIT_MSG==
Suppress deprecation warning in generated Dialogue factory if needed
==COMMIT_MSG==
