### PR TITLE
HTTP/1.0 does not support keep-alive

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategy.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategy.java
@@ -30,6 +30,8 @@ import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.HeaderElements;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.util.TimeValue;
@@ -86,6 +88,15 @@ final class InactivityValidationAwareConnectionKeepAliveStrategy implements Conn
                 }
             }
         }
+
+        ProtocolVersion responseVersion = response.getVersion();
+        if (responseVersion != null && responseVersion.lessEquals(HttpVersion.HTTP_1_0)) {
+            log.info(
+                    "HTTP/1.0 requires keep-alive negotiation, but no timeout was found",
+                    SafeArg.of("protocolVersion", responseVersion));
+            return TimeValue.ZERO_MILLISECONDS;
+        }
+
         HttpClientContext clientContext = HttpClientContext.adapt(context);
         RequestConfig requestConfig = clientContext.getRequestConfig();
         updateInactivityValidationInterval(response.getCode(), defaultValidateAfterInactivity);

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategyTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/InactivityValidationAwareConnectionKeepAliveStrategyTest.java
@@ -21,10 +21,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.apache.hc.core5.util.TimeValue;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,14 +60,41 @@ class InactivityValidationAwareConnectionKeepAliveStrategyTest {
     }
 
     @Test
+    void test_Http1_0_NoKeepAliveHeader() {
+        InactivityValidationAwareConnectionKeepAliveStrategy strategy =
+                new InactivityValidationAwareConnectionKeepAliveStrategy(manager, "name");
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(200);
+        response.setVersion(HttpVersion.HTTP_1_0);
+        TimeValue value = strategy.getKeepAliveDuration(response, CONTEXT);
+        assertThat(value).isEqualTo(TimeValue.ZERO_MILLISECONDS);
+        assertThat(response.getVersion()).isEqualTo(HttpVersion.HTTP_1_0);
+        verify(manager).getValidateAfterInactivity();
+        verifyNoMoreInteractions(manager);
+    }
+
+    @Test
+    void test_Http1_1_NoKeepAliveHeaderHttpVersion() {
+        InactivityValidationAwareConnectionKeepAliveStrategy strategy =
+                new InactivityValidationAwareConnectionKeepAliveStrategy(manager, "name");
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(200);
+        response.setVersion(HttpVersion.HTTP_1_1);
+        TimeValue value = strategy.getKeepAliveDuration(response, CONTEXT);
+        assertThat(value).isEqualTo(CONTEXT.getRequestConfig().getConnectionKeepAlive());
+        assertThat(response.getVersion()).isEqualTo(HttpVersion.HTTP_1_1);
+        verify(manager).setValidateAfterInactivity(eq(INITIAL_TIMEOUT));
+    }
+
+    @Test
     void testKeepAliveHeaderWithTimeout() {
         InactivityValidationAwareConnectionKeepAliveStrategy strategy =
                 new InactivityValidationAwareConnectionKeepAliveStrategy(manager, "name");
         BasicClassicHttpResponse response = new BasicClassicHttpResponse(200);
         response.addHeader("Keep-Alive", "timeout=60");
+        response.setVersion(HttpVersion.HTTP_1_1);
         TimeValue value = strategy.getKeepAliveDuration(response, CONTEXT);
         TimeValue expected = TimeValue.ofSeconds(60);
         assertThat(value).isEqualTo(expected);
+        assertThat(response.getVersion()).isEqualTo(HttpVersion.HTTP_1_1);
         verify(manager).setValidateAfterInactivity(eq(expected));
     }
 


### PR DESCRIPTION
## Before this PR

Dialogue would attempt to use default Apache HTTP client connection reuse timeout of 3 minutes for an HTTP/1.0 response. As HTTP/1.0 closes the connection after each request/response interaction by default, this would result in connection reuse failures resulting in retries and exponential backoff.

## After this PR
==COMMIT_MSG==

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Keep-Alive

> HTTP/1.0 closes the connection after each request/response interaction by
> default, so persistent connections in HTTP/1.0 must be explicitly negotiated.
> Some clients and servers might wish to be compatible with previous approaches
> to persistent connections, and can do this with a Connection: keep-alive
> request header. Additional parameters for the connection can be requested with
> the Keep-Alive header.
>
> Warning: Connection-specific header fields such as Connection and Keep-Alive
> are prohibited in HTTP/2 and HTTP/3. Chrome and Firefox ignore them in HTTP/2
> responses, but Safari conforms to the HTTP/2 specification requirements and
> does not load any response that contains them.

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
