### PR TITLE
Reduce deprecation logging to debug

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
@@ -88,8 +88,8 @@ final class DeprecationWarningChannel implements EndpointChannel {
             }
 
             meterSupplier.get().mark();
-            if (log.isWarnEnabled() && tryAcquire(channelName, endpoint)) {
-                log.warn(
+            if (log.isDebugEnabled() && tryAcquire(channelName, endpoint)) {
+                log.debug(
                         "Using a deprecated endpoint when connecting to service",
                         SafeArg.of("channelName", channelName),
                         SafeArg.of("serviceName", endpoint.serviceName()),
@@ -111,11 +111,7 @@ final class DeprecationWarningChannel implements EndpointChannel {
     private boolean tryAcquire(String channelName, Endpoint endpoint) {
         LoggingRateLimiterKey key =
                 LoggingRateLimiterKey.of(channelName, endpoint.serviceName(), endpoint.endpointName());
-        if (loggingRateLimiter.getIfPresent(key) == null) {
-            loggingRateLimiter.put(key, SENTINEL);
-            return true;
-        }
-        return false;
+        return loggingRateLimiter.asMap().putIfAbsent(key, SENTINEL) == null;
     }
 
     @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeprecationWarningChannel.java
@@ -37,10 +37,10 @@ import java.util.function.Supplier;
 import org.immutables.value.Value;
 
 /**
- * A channel that logs warnings when the response from a server contains the "deprecation" header. Logs include the
+ * A channel that records when the response from a server contains the "deprecation" header. Logs include the
  * content of the "server" header when it is provided, and always include endpoint details.
  *
- * <p>Deprecation warnings are produced at most once per minute per service. The {@code client.deprecations} meter may
+ * <p>Deprecation debug logs are produced at most once per minute per service. The {@code client.deprecations} meter may
  * be used to understand more granular rates of deprecated calls against a particular service using the
  * {@code service-name} tag.
  */


### PR DESCRIPTION
These logs are quite noisy given that:
- We have a metric
- Clients already know where they are using deprecated endpoints because the endpoints are marked `@Deprecated` (we should encourage repos to enable `-Xlint:deprecation`).

These logs do not proactively alert service owners. I posit that no one actively looks at these logs.

This PR reduces the log level to `DEBUG`. If clients want to get more information about exactly what requests are triggering the deprecation metric, they can enable debug logs.