### PR TITLE
Copy over existing request query params when creating a new request

### DIFF
--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -307,7 +307,12 @@ public final class Request {
         private ListMultimap<String, String> mutableQueryParams() {
             if (!isQueryMutable()) {
                 setQueryMutable();
-                queryParams = Multimaps.newListMultimap(new LinkedHashMap<>(), MAP_VALUE_FACTORY);
+                ListMultimap<String, String> mutable =
+                        Multimaps.newListMultimap(new LinkedHashMap<>(), MAP_VALUE_FACTORY);
+                if (!queryParams.isEmpty()) {
+                    queryParams.forEach(mutable::put);
+                }
+                queryParams = mutable;
             }
             return queryParams;
         }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -95,33 +95,33 @@ public final class RequestTest {
 
     @Test
     void copy_request_with_existing_params() {
-        Request request1 = Request.builder()
+        Request oldRequest = Request.builder()
                 .putQueryParams("query1", "queryVal1")
                 .putHeaderParams("header1", "headerVal1")
                 .putPathParams("path1", "pathVal1")
                 .build();
 
-        Request request2 = Request.builder()
-                .from(request1)
+        Request newRequest = Request.builder()
+                .from(oldRequest)
                 .putQueryParams("query2", "queryVal2")
                 .putHeaderParams("header2", "headerVal2")
                 .putPathParams("path2", "pathVal2")
                 .build();
 
         // make sure new query/header/path parameters were added in addition to whatever was in `request1`
-        assertThat(request2)
+        assertThat(newRequest)
                 .extracting(Request::queryParams)
                 .extracting(Multimap::entries, collection(Map.Entry.class))
                 .containsExactlyInAnyOrder(
                         MapEntry.entry("query1", "queryVal1"), MapEntry.entry("query2", "queryVal2"));
 
-        assertThat(request2)
+        assertThat(newRequest)
                 .extracting(Request::headerParams)
                 .extracting(Multimap::entries, collection(Map.Entry.class))
                 .containsExactlyInAnyOrder(
                         MapEntry.entry("header1", "headerVal1"), MapEntry.entry("header2", "headerVal2"));
 
-        assertThat(request2)
+        assertThat(newRequest)
                 .extracting(Request::pathParameters)
                 .extracting(Multimap::entries, collection(Map.Entry.class))
                 .containsExactlyInAnyOrder(MapEntry.entry("path1", "pathVal1"), MapEntry.entry("path2", "pathVal2"));

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -108,7 +108,7 @@ public final class RequestTest {
                 .putPathParams("path2", "pathVal2")
                 .build();
 
-        // make sure new query/header/path parameters were added in addition to whatever was in `request1`
+        // make sure new query/header/path parameters were added in addition to whatever was in `oldRequest`
         assertThat(newRequest)
                 .extracting(Request::queryParams)
                 .extracting(Multimap::entries, collection(Map.Entry.class))

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -17,12 +17,16 @@
 package com.palantir.dialogue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.collection;
 import static org.assertj.guava.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
+import java.util.Map;
+import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
 public final class RequestTest {
@@ -87,5 +91,39 @@ public final class RequestTest {
                 .build();
 
         System.out.println(request2.queryParams());
+    }
+
+    @Test
+    void copy_request_with_existing_params() {
+        Request request1 = Request.builder()
+                .putQueryParams("query1", "queryVal1")
+                .putHeaderParams("header1", "headerVal1")
+                .putPathParams("path1", "pathVal1")
+                .build();
+
+        Request request2 = Request.builder()
+                .from(request1)
+                .putQueryParams("query2", "queryVal2")
+                .putHeaderParams("header2", "headerVal2")
+                .putPathParams("path2", "pathVal2")
+                .build();
+
+        // make sure new query/header/path parameters were added in addition to whatever was in `request1`
+        assertThat(request2)
+                .extracting(Request::queryParams)
+                .extracting(Multimap::entries, collection(Map.Entry.class))
+                .containsExactlyInAnyOrder(
+                        MapEntry.entry("query1", "queryVal1"), MapEntry.entry("query2", "queryVal2"));
+
+        assertThat(request2)
+                .extracting(Request::headerParams)
+                .extracting(Multimap::entries, collection(Map.Entry.class))
+                .containsExactlyInAnyOrder(
+                        MapEntry.entry("header1", "headerVal1"), MapEntry.entry("header2", "headerVal2"));
+
+        assertThat(request2)
+                .extracting(Request::pathParameters)
+                .extracting(Multimap::entries, collection(Map.Entry.class))
+                .containsExactlyInAnyOrder(MapEntry.entry("path1", "pathVal1"), MapEntry.entry("path2", "pathVal2"));
     }
 }


### PR DESCRIPTION
## Before this PR
Request objects do not copy over query parameters when the builder is created from an existing object

## After this PR
==COMMIT_MSG==
When request objects are created using a builder on an existing object, query parameters will be copied over from the previous object to match the headers and path params implementation 
==COMMIT_MSG==