### PR TITLE
Workaround allowing '=' in query param values.

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -169,7 +169,7 @@ public final class BaseUrl {
         @Override
         public DefaultUrlBuilder queryParam(String name, String value) {
             this.queryNamesAndValues.put(
-                    BaseUrl.UrlEncoder.encodeQueryNameOrValue(name), BaseUrl.UrlEncoder.encodeQueryNameOrValue(value));
+                    BaseUrl.UrlEncoder.encodeQueryName(name), BaseUrl.UrlEncoder.encodeQueryValue(value));
             return this;
         }
 
@@ -272,6 +272,10 @@ public final class BaseUrl {
         // query = *( pchar / "/" / "?" )
         private static final CharMatcher IS_QUERY_CHAR = IS_P_CHAR.or(CharMatcher.anyOf("/?"));
 
+        // Allow '=' in query param value characters because of Gitlab CDN signed query HTTP spec break.
+        private static final CharMatcher IS_QUERY_VAL_CHAR =
+                IS_P_CHAR.or(CharMatcher.is('=')).or(CharMatcher.anyOf("/?"));
+
         static boolean isHost(String maybeHost) {
             return IS_HOST.matchesAllOf(maybeHost) || isIpv6Host(maybeHost);
         }
@@ -296,8 +300,12 @@ public final class BaseUrl {
             return encode(pathComponent, IS_P_CHAR);
         }
 
-        static String encodeQueryNameOrValue(String nameOrValue) {
-            return encode(nameOrValue, IS_QUERY_CHAR);
+        static String encodeQueryName(String name) {
+            return encode(name, IS_QUERY_CHAR);
+        }
+
+        static String encodeQueryValue(String value) {
+            return encode(value, IS_QUERY_VAL_CHAR);
         }
 
         // percent-encodes every byte in the source string with it's percent-encoded representation, except for

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -183,15 +183,22 @@ public final class UrlBuilderTest {
     @Test
     public void urlEncoder_encodeQuery_onlyEncodesNonReservedChars() {
         String nonReserved = "aAzZ09/?";
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue(nonReserved)).isEqualTo(nonReserved);
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("@[]{}ßçö"))
-                .isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("=&+")).isEqualTo("%3D%26%2B");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryName(nonReserved)).isEqualTo(nonReserved);
+        assertThat(BaseUrl.UrlEncoder.encodeQueryName("@[]{}ßçö")).isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryName("=&+")).isEqualTo("%3D%26%2B");
+
+        assertThat(BaseUrl.UrlEncoder.encodeQueryValue(nonReserved)).isEqualTo(nonReserved);
+        assertThat(BaseUrl.UrlEncoder.encodeQueryValue("@[]{}ßçö")).isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
+        // '=' is reserved for query param values.
+        assertThat(BaseUrl.UrlEncoder.encodeQueryValue("&+")).isEqualTo("%26%2B");
     }
 
     @Test
     public void urlEncoder_encodeQuery_encodesPlusSign() {
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("+"))
+        assertThat(BaseUrl.UrlEncoder.encodeQueryName("+"))
+                .as("'+' must be encoded, otherwise many servers will interpret it as a url encoded space")
+                .isEqualTo("%2B");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryValue("+"))
                 .as("'+' must be encoded, otherwise many servers will interpret it as a url encoded space")
                 .isEqualTo("%2B");
     }
@@ -209,6 +216,13 @@ public final class UrlBuilderTest {
         assertThat(BaseUrl.UrlEncoder.encodePathSegment(":"))
                 .as("Several GCP APIs use ':' within paths, and do not handle encoded colons")
                 .isEqualTo(":");
+    }
+
+    @Test
+    public void urlEncoder_encodePath_allowsEqualsValue() {
+        assertThat(BaseUrl.UrlEncoder.encodeQueryValue("="))
+                .as("Gitlab CDN APIs use '=' within query param values, and do not handle encoded equals")
+                .isEqualTo("=");
     }
 
     @Test

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -214,16 +214,17 @@ public abstract class AbstractChannelTest {
 
     @Test
     public void encodesQueryParameters() throws Exception {
-        String mustEncode = "%^&/?a=A3&a=A4";
+        String mustEncodeExceptForEquals = "%^&/?a=A3&a=A4";
         request = Request.builder()
                 .from(request)
-                .putQueryParams(mustEncode, mustEncode)
+                .putQueryParams(mustEncodeExceptForEquals, mustEncodeExceptForEquals)
                 .build();
         channel.execute(endpoint, request);
 
         HttpUrl url = server.takeRequest().getRequestUrl();
-        assertThat(url.queryParameterValues(mustEncode)).containsExactlyInAnyOrder(mustEncode);
-        assertThat(url.url().getQuery()).isEqualTo("%25%5E%26/?a%3DA3%26a%3DA4=%25%5E%26/?a%3DA3%26a%3DA4");
+        assertThat(url.queryParameterValues(mustEncodeExceptForEquals))
+                .containsExactlyInAnyOrder(mustEncodeExceptForEquals);
+        assertThat(url.url().getQuery()).isEqualTo("%25%5E%26/?a%3DA3%26a%3DA4=%25%5E%26/?a=A3%26a=A4");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Gitlab CDN redirect URLs break HTTP spec and require an un-encoded '=' character in URL parameter values.

## After this PR
Dialogue avoids encoding '=' in URL param values.

==COMMIT_MSG==
Workaround allowing '=' in query param values.
==COMMIT_MSG==

