### PR TITLE
BaseUrl$UrlEncoder uses precomputed CharMatchers

### DIFF
--- a/changelog/@unreleased/pr-2572.v2.yml
+++ b/changelog/@unreleased/pr-2572.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Precompute optimized CharMatchers for BaseUrl$UrlEncoder
+  links:
+  - https://github.com/palantir/dialogue/pull/2572

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -238,13 +238,15 @@ public final class BaseUrl {
     @VisibleForTesting
     static class UrlEncoder {
         private static final CharMatcher DIGIT = CharMatcher.inRange('0', '9').precomputed();
-        private static final CharMatcher ALPHA = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('A', 'Z')).precomputed();
+        private static final CharMatcher ALPHA =
+                CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('A', 'Z')).precomputed();
 
         // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
         private static final CharMatcher UNRESERVED = DIGIT.or(ALPHA).or(CharMatcher.anyOf("-._~")).precomputed();
 
         // sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
-        private static final CharMatcher SUB_DELIMS = CharMatcher.anyOf("!$&'()*+,;=").precomputed();
+        private static final CharMatcher SUB_DELIMS =
+                CharMatcher.anyOf("!$&'()*+,;=").precomputed();
         private static final CharMatcher IS_HOST = UNRESERVED.or(SUB_DELIMS).precomputed();
 
         // The RFC permits percent-encoding any character. We also percent encode sub-delimiters to avoid
@@ -260,17 +262,20 @@ public final class BaseUrl {
         // A strict implementation of the rfc allow 'UNRESERVED.or(CharMatcher.anyOf(":@"))',
         // however we have updated it from 'UNRESERVED' to allow colons, and would like to
         // make changes as slowly as possible.
-        private static final CharMatcher IS_P_CHAR = UNRESERVED.or(CharMatcher.is(':')).precomputed();
+        private static final CharMatcher IS_P_CHAR =
+                UNRESERVED.or(CharMatcher.is(':')).precomputed();
 
         // For historical reasons, we allow sub-delims in the base uri if provided directly,
         // but escape them in paths we create/encode. Base-uri paths tend to be simple, so I wouldn't
         // expect the sub-delims to be relevant here in the vast majority of cases. With sufficient
         // research and testing, we should incorporate relevant sub-delims into IS_P_CHAR and update this
         // to: 'IS_P_CHAR.or(CharMatcher.is('/'))'.
-        private static final CharMatcher IS_PATH = IS_P_CHAR.or(SUB_DELIMS).or(CharMatcher.is('/')).precomputed();
+        private static final CharMatcher IS_PATH =
+                IS_P_CHAR.or(SUB_DELIMS).or(CharMatcher.is('/')).precomputed();
 
         // query = *( pchar / "/" / "?" )
-        private static final CharMatcher IS_QUERY_CHAR = IS_P_CHAR.or(CharMatcher.anyOf("/?")).precomputed();
+        private static final CharMatcher IS_QUERY_CHAR =
+                IS_P_CHAR.or(CharMatcher.anyOf("/?")).precomputed();
 
         static boolean isHost(String maybeHost) {
             return IS_HOST.matchesAllOf(maybeHost) || isIpv6Host(maybeHost);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -242,7 +242,8 @@ public final class BaseUrl {
                 CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('A', 'Z')).precomputed();
 
         // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
-        private static final CharMatcher UNRESERVED = DIGIT.or(ALPHA).or(CharMatcher.anyOf("-._~")).precomputed();
+        private static final CharMatcher UNRESERVED =
+                DIGIT.or(ALPHA).or(CharMatcher.anyOf("-._~")).precomputed();
 
         // sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
         private static final CharMatcher SUB_DELIMS =

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -237,15 +237,15 @@ public final class BaseUrl {
     /** Encodes URL components per https://tools.ietf.org/html/rfc3986 . */
     @VisibleForTesting
     static class UrlEncoder {
-        private static final CharMatcher DIGIT = CharMatcher.inRange('0', '9');
-        private static final CharMatcher ALPHA = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('A', 'Z'));
+        private static final CharMatcher DIGIT = CharMatcher.inRange('0', '9').precomputed();
+        private static final CharMatcher ALPHA = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('A', 'Z')).precomputed();
 
         // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
-        private static final CharMatcher UNRESERVED = DIGIT.or(ALPHA).or(CharMatcher.anyOf("-._~"));
+        private static final CharMatcher UNRESERVED = DIGIT.or(ALPHA).or(CharMatcher.anyOf("-._~")).precomputed();
 
         // sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
-        private static final CharMatcher SUB_DELIMS = CharMatcher.anyOf("!$&'()*+,;=");
-        private static final CharMatcher IS_HOST = UNRESERVED.or(SUB_DELIMS);
+        private static final CharMatcher SUB_DELIMS = CharMatcher.anyOf("!$&'()*+,;=").precomputed();
+        private static final CharMatcher IS_HOST = UNRESERVED.or(SUB_DELIMS).precomputed();
 
         // The RFC permits percent-encoding any character. We also percent encode sub-delimiters to avoid
         // incompatibilities with http specification beyond the general URI definition per
@@ -260,17 +260,17 @@ public final class BaseUrl {
         // A strict implementation of the rfc allow 'UNRESERVED.or(CharMatcher.anyOf(":@"))',
         // however we have updated it from 'UNRESERVED' to allow colons, and would like to
         // make changes as slowly as possible.
-        private static final CharMatcher IS_P_CHAR = UNRESERVED.or(CharMatcher.is(':'));
+        private static final CharMatcher IS_P_CHAR = UNRESERVED.or(CharMatcher.is(':')).precomputed();
 
         // For historical reasons, we allow sub-delims in the base uri if provided directly,
         // but escape them in paths we create/encode. Base-uri paths tend to be simple, so I wouldn't
         // expect the sub-delims to be relevant here in the vast majority of cases. With sufficient
         // research and testing, we should incorporate relevant sub-delims into IS_P_CHAR and update this
         // to: 'IS_P_CHAR.or(CharMatcher.is('/'))'.
-        private static final CharMatcher IS_PATH = IS_P_CHAR.or(SUB_DELIMS).or(CharMatcher.is('/'));
+        private static final CharMatcher IS_PATH = IS_P_CHAR.or(SUB_DELIMS).or(CharMatcher.is('/')).precomputed();
 
         // query = *( pchar / "/" / "?" )
-        private static final CharMatcher IS_QUERY_CHAR = IS_P_CHAR.or(CharMatcher.anyOf("/?"));
+        private static final CharMatcher IS_QUERY_CHAR = IS_P_CHAR.or(CharMatcher.anyOf("/?")).precomputed();
 
         static boolean isHost(String maybeHost) {
             return IS_HOST.matchesAllOf(maybeHost) || isIpv6Host(maybeHost);


### PR DESCRIPTION
## Before this PR

In some profiles, noticed that `BaseUrl$UrlEncoder.encodeQueryNameOrValue` was using `CharMatcher$Or.matches(char)` and not an optimized precomputed bit set `CharMatcher`

https://github.com/palantir/dialogue/blob/f93d327dc9dad09d0457a404e2bf3a857ffc72e2/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java#L239-L273

https://github.com/palantir/dialogue/blob/f93d327dc9dad09d0457a404e2bf3a857ffc72e2/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java#L299-L300

## After this PR
==COMMIT_MSG==
Precompute optimized CharMatchers for BaseUrl$UrlEncoder
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
