### PR TITLE
Dialogue allows unencoded equals signs (=) in URL query parameter values

### DIFF
--- a/changelog/@unreleased/pr-2574.v2.yml
+++ b/changelog/@unreleased/pr-2574.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Dialogue allows unencoded equals signs (=) in URL query parameter values
+  links:
+  - https://github.com/palantir/dialogue/pull/2574

--- a/changelog/@unreleased/pr-2574.v2.yml
+++ b/changelog/@unreleased/pr-2574.v2.yml
@@ -1,5 +1,5 @@
-type: break
-break:
+type: improvement
+improvement:
   description: Dialogue allows unencoded equals signs (=) in URL query parameter values
   links:
   - https://github.com/palantir/dialogue/pull/2574

--- a/changelog/@unreleased/pr-2574.v2.yml
+++ b/changelog/@unreleased/pr-2574.v2.yml
@@ -1,5 +1,14 @@
 type: improvement
 improvement:
-  description: Dialogue allows unencoded equals signs (=) in URL query parameter values
+  description: |-
+    Dialogue allows unencoded equals signs (`=`) in URL query parameter values
+
+    This is not an API break, however we're using a breaking changelog entry for visibility in case of unknown non-compliant servers.
+
+    Previously the `=` character would be encoded as `%3D`, which is also allowed, but not required, by rfc3986. Some server implementations require equals signs in query parameters not to be encoded.
+
+    This encoding is an implementation detail within dialogue, where either way is valid for servers which are compliant with the rfc.
+
+    It is possible that some servers or proxies do not handle unencoded equals signs correctly. Please reach out to us if you find cases where servers do not behave as expected.
   links:
   - https://github.com/palantir/dialogue/pull/2574

--- a/changelog/@unreleased/pr-2574.v2.yml
+++ b/changelog/@unreleased/pr-2574.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: break
+break:
   description: |-
     Dialogue allows unencoded equals signs (`=`) in URL query parameter values
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/BaseUrl.java
@@ -169,7 +169,7 @@ public final class BaseUrl {
         @Override
         public DefaultUrlBuilder queryParam(String name, String value) {
             this.queryNamesAndValues.put(
-                    BaseUrl.UrlEncoder.encodeQueryNameOrValue(name), BaseUrl.UrlEncoder.encodeQueryNameOrValue(value));
+                    BaseUrl.UrlEncoder.encodeQueryParamName(name), BaseUrl.UrlEncoder.encodeQueryParamValue(value));
             return this;
         }
 
@@ -278,6 +278,13 @@ public final class BaseUrl {
         private static final CharMatcher IS_QUERY_CHAR =
                 IS_P_CHAR.or(CharMatcher.anyOf("/?")).precomputed();
 
+        // According to https://tools.ietf.org/html/rfc3986#section-3.4, the query component can contain sub-delims
+        // including '='. It would be more correct to extend IS_QUERY_CHAR to include sub-delims and use it for both
+        // query parameter names and values. To make minimal changes (as not to break existing clients), we only
+        // extend IS_QUERY_CHAR to include '=' for query parameter values.
+        private static final CharMatcher IS_QUERY_PARAM_VALUE_CHAR =
+                IS_QUERY_CHAR.or(CharMatcher.anyOf("=")).precomputed();
+
         static boolean isHost(String maybeHost) {
             return IS_HOST.matchesAllOf(maybeHost) || isIpv6Host(maybeHost);
         }
@@ -302,8 +309,12 @@ public final class BaseUrl {
             return encode(pathComponent, IS_P_CHAR);
         }
 
-        static String encodeQueryNameOrValue(String nameOrValue) {
+        static String encodeQueryParamName(String nameOrValue) {
             return encode(nameOrValue, IS_QUERY_CHAR);
+        }
+
+        static String encodeQueryParamValue(String value) {
+            return encode(value, IS_QUERY_PARAM_VALUE_CHAR);
         }
 
         // percent-encodes every byte in the source string with it's percent-encoded representation, except for

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/UrlBuilderTest.java
@@ -136,6 +136,12 @@ public final class UrlBuilderTest {
         assertThat(minimalUrl().queryParam("question?&", "answer!&").build().toString())
                 .isEqualTo("http://host:80?question?%26=answer%21%26");
         assertThat(minimalUrl().queryParam("q", ":").build().toString()).isEqualTo("http://host:80?q=:");
+        assertThat(minimalUrl()
+                        .queryParam("question1=", "answer1=")
+                        .queryParam("question2=", "answer2=")
+                        .build()
+                        .toString())
+                .isEqualTo("http://host:80?question1%3D=answer1=&question2%3D=answer2=");
     }
 
     @Test
@@ -183,15 +189,14 @@ public final class UrlBuilderTest {
     @Test
     public void urlEncoder_encodeQuery_onlyEncodesNonReservedChars() {
         String nonReserved = "aAzZ09/?";
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue(nonReserved)).isEqualTo(nonReserved);
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("@[]{}ßçö"))
-                .isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("=&+")).isEqualTo("%3D%26%2B");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryParamName(nonReserved)).isEqualTo(nonReserved);
+        assertThat(BaseUrl.UrlEncoder.encodeQueryParamName("@[]{}ßçö")).isEqualTo("%40%5B%5D%7B%7D%C3%9F%C3%A7%C3%B6");
+        assertThat(BaseUrl.UrlEncoder.encodeQueryParamName("=&+")).isEqualTo("%3D%26%2B");
     }
 
     @Test
     public void urlEncoder_encodeQuery_encodesPlusSign() {
-        assertThat(BaseUrl.UrlEncoder.encodeQueryNameOrValue("+"))
+        assertThat(BaseUrl.UrlEncoder.encodeQueryParamName("+"))
                 .as("'+' must be encoded, otherwise many servers will interpret it as a url encoded space")
                 .isEqualTo("%2B");
     }

--- a/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
+++ b/dialogue-test-common/src/main/java/com/palantir/dialogue/AbstractChannelTest.java
@@ -223,7 +223,7 @@ public abstract class AbstractChannelTest {
 
         HttpUrl url = server.takeRequest().getRequestUrl();
         assertThat(url.queryParameterValues(mustEncode)).containsExactlyInAnyOrder(mustEncode);
-        assertThat(url.url().getQuery()).isEqualTo("%25%5E%26/?a%3DA3%26a%3DA4=%25%5E%26/?a%3DA3%26a%3DA4");
+        assertThat(url.url().getQuery()).isEqualTo("%25%5E%26/?a%3DA3%26a%3DA4=%25%5E%26/?a=A3%26a=A4");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
This is similar to #2360. This is required for some servers (like [Gitlab](https://gitlab.com/gitlab-org/gitlab/-/issues/539302)) which do not support url-encoded equals signs in query parameter values.

[RFC3986 section 3.4](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4) defines the query section of the URL, and allows sub-delims (which include "=") to be present, unencoded.

[Also mentioned in the RFC:
](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2:~:text=However%2C%20as%20query%20components%0A%20%20%20are%20often%20used%20to%20carry%20identifying%20information%20in%20the%20form%20of%0A%20%20%20%22key%3Dvalue%22%20pairs%20and%20one%20frequently%20used%20value%20is%20a%20reference%20to%0A%20%20%20another%20URI%2C%20it%20is%20sometimes%20better%20for%20usability%20to%20avoid%20percent%2D%0A%20%20%20encoding%20those%20characters.)
> However, as query components are often used to carry identifying information in the form of "key=value" pairs and one frequently used value is a reference to another URI, it is sometimes better for usability to avoid percent-encoding those characters.

## After this PR
==COMMIT_MSG==
Dialogue allows unencoded equals signs (=) in URL query parameter values

This is not an API break, however we're using a breaking changelog entry for visibility in case of unknown non-compliant servers.

Previously the `=` character would be encoded as `%3D`, which is also allowed, but not required, by rfc3986. Some server implementations require equals signs in query parameters not to be encoded.

This encoding is an implementation detail within dialogue, where either way is valid for servers which are compliant with the rfc.

It is possible that some servers or proxies do not handle unencoded equals signs correctly. Please reach out to us if you find cases where servers do not behave as expected.
==COMMIT_MSG==

## Possible downsides?
Dialogue does not encode the equals sign ("=") when present in a query parameter value. The main risk is that certain servers which expect percent-encoded values may break. According to the RFC, servers _should_ be able to handle both encoded and uncoded equals signs.

It is RFC compliant to allow equals signs in any part of the query portion of the URL. I've chosen to only allow unencoded equals signs in the query parameter value to make minimal changes to URL encoding behavior minimizing any potential breaks.