### PR TITLE
Support nested service interfaces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:6.32.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:3.4.0'
         classpath 'com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.4.0'
-        classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
         classpath 'com.palantir.metricschema:gradle-metric-schema:0.33.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.9.0'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:5.57.0'
@@ -81,7 +80,6 @@ allprojects {
 
 subprojects {
     apply plugin: 'java-library'
-    apply plugin: 'org.inferred.processors'
 
     tasks.withType(JavaCompile) {
         options.compilerArgs += ['-Werror']

--- a/changelog/@unreleased/pr-2591.v2.yml
+++ b/changelog/@unreleased/pr-2591.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: '`dialogue-annotations-processor` now supports service interfaces nested
+    in other classes.'
+  links:
+  - https://github.com/palantir/dialogue/pull/2591

--- a/dialogue-annotations-example/build.gradle
+++ b/dialogue-annotations-example/build.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'org.inferred.processors'
-
 dependencies {
     // IntelliJ does not seem to invoke the processor without this line
     implementation project(':dialogue-annotations-processor')

--- a/dialogue-annotations-processor/build.gradle
+++ b/dialogue-annotations-processor/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'org.inferred.processors'
 
 dependencies {
     // All those must be compile because of some IntelliJ classpath issue

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessor.java
@@ -35,6 +35,7 @@ import com.palantir.goethe.Goethe;
 import com.palantir.goethe.GoetheException;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Preconditions;
@@ -153,9 +154,7 @@ public final class DialogueRequestAnnotationsProcessor extends AbstractProcessor
             return maybeEndpoints.stream().map(Optional::get).collect(Collectors.toList());
         });
 
-        ClassName serviceInterface = ClassName.get(
-                MoreElements.getPackage(annotatedInterface).getQualifiedName().toString(),
-                annotatedInterface.getSimpleName().toString());
+        ClassName serviceInterface = (ClassName) TypeName.get(annotatedInterface.asType());
 
         ServiceDefinition serviceDefinition = ImmutableServiceDefinition.builder()
                 .serviceInterface(serviceInterface)

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ServiceDefinition.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/data/ServiceDefinition.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue.annotations.processor.data;
 
 import com.palantir.javapoet.ClassName;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -28,7 +29,9 @@ public interface ServiceDefinition {
     @Value.Derived
     default ClassName serviceFactory() {
         return ClassName.get(
-                serviceInterface().packageName(), serviceInterface().simpleName() + "DialogueServiceFactory");
+                serviceInterface().packageName(),
+                serviceInterface().simpleNames().stream()
+                        .collect(Collectors.joining("", "", "DialogueServiceFactory")));
     }
 
     @Value.Derived

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/DialogueServiceFactoryGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/DialogueServiceFactoryGenerator.java
@@ -42,7 +42,6 @@ public final class DialogueServiceFactoryGenerator {
     }
 
     public TypeSpec generate() {
-
         TypeSpec.Builder serviceFactoryBuilder = TypeSpec.classBuilder(serviceDefinition.serviceFactory())
                 .addAnnotation(AnnotationSpec.builder(ClassName.get(Generated.class))
                         .addMember("value", "$S", getClass().getCanonicalName())

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -29,6 +29,7 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.myservice.service.MismatchedPathParam;
 import com.palantir.myservice.service.MultipleParamAnnotations;
 import com.palantir.myservice.service.MyService;
+import com.palantir.myservice.service.NestedService;
 import com.palantir.myservice.service.RequestAnnotatedClass;
 import com.palantir.myservice.service.UnmatchedPathParam;
 import com.palantir.myservice.service.UnmatchedPathTemplateParam;
@@ -41,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 import org.junit.jupiter.api.Test;
@@ -54,6 +56,11 @@ public final class DialogueRequestAnnotationsProcessorTest {
     @Test
     public void testExampleFileCompiles() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, MyService.class);
+    }
+
+    @Test
+    public void testNestedExampleFileCompiles() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, NestedService.class, NestedService.MyService.class);
     }
 
     @Test
@@ -105,21 +112,26 @@ public final class DialogueRequestAnnotationsProcessorTest {
                 .hadErrorContaining("Path template parameters do not match method path parameters");
     }
 
-    private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {
-        Compilation compilation = compileTestClass(basePath, clazz);
+    private void assertTestFileCompileAndMatches(Path basePath, Class<?> fileClass, Class<?>... serviceClasses) {
+        Compilation compilation = compileTestClass(basePath, fileClass);
         assertThat(compilation).succeededWithoutWarnings();
-        String generatedClassName = clazz.getSimpleName() + "DialogueServiceFactory";
-        String generatedFqnClassName = clazz.getPackage().getName() + "." + generatedClassName;
-        String generatedClassFileRelativePath = generatedFqnClassName.replaceAll("\\.", "/") + ".java";
-        assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, generatedClassFileRelativePath))
-                .hasValueSatisfying(javaFileObject -> {
-                    assertContentsMatch(javaFileObject, generatedClassFileRelativePath);
 
-                    assertThat(Compiler.javac()
-                                    .withOptions("-source", "11", "-Werror", "-Xlint:deprecation", "-Xlint:unchecked")
-                                    .compile(javaFileObject))
-                            .succeededWithoutWarnings();
-                });
+        List<Class<?>> classes = serviceClasses.length > 0 ? List.of(serviceClasses) : List.of(fileClass);
+
+        classes.forEach(clazz -> {
+            String generatedClassFileRelativePath =
+                    clazz.getName().replace(".", "/").replace("$", "") + "DialogueServiceFactory.java";
+            assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, generatedClassFileRelativePath))
+                    .hasValueSatisfying(javaFileObject -> {
+                        assertContentsMatch(javaFileObject, generatedClassFileRelativePath);
+
+                        assertThat(Compiler.javac()
+                                        .withOptions(
+                                                "-source", "11", "-Werror", "-Xlint:deprecation", "-Xlint:unchecked")
+                                        .compile(javaFileObject))
+                                .succeededWithoutWarnings();
+                    });
+        });
     }
 
     private Compilation compileTestClass(Path basePath, Class<?> clazz) {

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/NestedService.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/NestedService.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.service;
+
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.annotations.Request;
+
+// Annotation processor is not invoked directly here.
+// @DialogueService(NestedServiceMyServiceDialogueServiceFactory.class)
+public class NestedService {
+
+    public interface MyService {
+
+        @Request(method = HttpMethod.GET, path = "/get")
+        String get();
+    }
+}

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/NestedServiceMyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/NestedServiceMyServiceDialogueServiceFactory.java.generated
@@ -1,0 +1,82 @@
+package com.palantir.myservice.service;
+
+import com.google.common.collect.ListMultimap;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.PathTemplate;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.dialogue.UrlBuilder;
+import com.palantir.dialogue.annotations.ConjureErrorDecoder;
+import com.palantir.dialogue.annotations.DefaultParameterSerializer;
+import com.palantir.dialogue.annotations.ErrorHandlingDeserializerFactory;
+import com.palantir.dialogue.annotations.Json;
+import com.palantir.dialogue.annotations.ParameterSerializer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.dialogue.annotations.processor.generate.DialogueServiceFactoryGenerator")
+public final class NestedServiceMyServiceDialogueServiceFactory
+        implements DialogueServiceFactory<NestedService.MyService> {
+    @Override
+    public NestedService.MyService create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+        return new NestedService.MyService() {
+            private final ParameterSerializer _parameterSerializer = DefaultParameterSerializer.INSTANCE;
+
+            private final EndpointChannel getChannel = endpointChannelFactory.endpoint(Endpoints.get);
+
+            private final Deserializer<String> getDeserializer = new ErrorHandlingDeserializerFactory<>(
+                            new Json(), new ConjureErrorDecoder())
+                    .deserializerFor(new TypeMarker<String>() {});
+
+            @Override
+            public String get() {
+                Request.Builder _request = Request.builder();
+                return runtime.clients().callBlocking(getChannel, _request.build(), getDeserializer);
+            }
+        };
+    }
+
+    private enum Endpoints implements Endpoint {
+        get {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("get").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "MyService";
+            }
+
+            @Override
+            public String endpointName() {
+                return "get";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        };
+
+        private static final String VERSION = Optional.ofNullable(
+                        NestedService.MyService.class.getPackage().getImplementationVersion())
+                .orElse("0.0.0");
+    }
+}


### PR DESCRIPTION
Service interfaces can now be generated from nested classes.

```java
@DialogueService(OuterMyServiceDialogueServiceFactory.class)
class Outer {
    public interface MyService {
        @Request(method = HttpMethod.GET, path = "/get")
        String get();
    }
}
```

Currently, if you try to add these annotation to a nested interface, it generates code that fails to compile.

The equivalent PR for `conjure-undertow-annotations` is in https://github.com/palantir/conjure-java/pull/2551.