### PR TITLE
Add cause to UnknownRemoteException upon remote exception deserialization issue

### DIFF
--- a/changelog/@unreleased/pr-2594.v2.yml
+++ b/changelog/@unreleased/pr-2594.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Add cause to UnknownRemoteException upon remote exception deserialization
+    issue
+  links:
+  - https://github.com/palantir/dialogue/pull/2594

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/EndpointErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/EndpointErrorDecoder.java
@@ -179,7 +179,10 @@ final class EndpointErrorDecoder<T> {
                 // rethrow the created remote exception
                 throw remoteException;
             } catch (Exception e) {
-                throw new UnknownRemoteException(code, new String(body, StandardCharsets.UTF_8));
+                UnknownRemoteException unknownRemoteException =
+                        new UnknownRemoteException(code, new String(body, StandardCharsets.UTF_8));
+                unknownRemoteException.initCause(e);
+                throw unknownRemoteException;
             }
         }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
@@ -86,7 +86,9 @@ public enum ErrorDecoder {
                 SerializableError serializableError = MAPPER.readValue(body, SerializableError.class);
                 return new RemoteException(serializableError, code);
             } catch (Exception e) {
-                return new UnknownRemoteException(code, body);
+                UnknownRemoteException unknownRemoteException = new UnknownRemoteException(code, body);
+                unknownRemoteException.initCause(e);
+                return unknownRemoteException;
             }
         }
 


### PR DESCRIPTION
## Before this PR
When we fail to deserialize an error (no matter the reason), we will currently throw an `UnknownRemoteException`. Unfortunately, the underlying error is swallowed, which makes it significantly harder to understand and debug the issue (though in most cases this could be reproduced from the string itself).

Other instances of wrapping `UnknownRemoteException` already add the underlying exception as the cause, e.g. https://github.com/palantir/dialogue/blob/713da0c527a84f6cdf28f6325293e7cf013806bf/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/EndpointErrorDecoder.java#L160-L162 so we can just do the same here

## After this PR
==COMMIT_MSG==
Add cause to UnknownRemoteException upon remote exception deserialization issue
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
