### PR TITLE
Refactor `ApacheHttpClientChannelsTest#metrics` test to not rely on flaky website

### DIFF
--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
@@ -99,9 +100,13 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
         assertThatThrownBy(() -> Futures.getUnchecked(again)).hasCauseInstanceOf(UnknownHostException.class);
     }
 
-    @Test
+    @RepeatedTest(value = 1000, failureThreshold = 1)
     public void metrics() throws Exception {
-        ClientConfiguration conf = TestConfigurations.create("http://unused");
+        ClientConfiguration conf = ClientConfiguration.builder()
+                .from(TestConfigurations.create("http://unused"))
+                // Use a longer-than-default connect timeout to avoid flakiness in tests
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
 
         try (ApacheHttpClientChannels.CloseableClient client =
                 ApacheHttpClientChannels.createCloseableHttpClient(conf, "testClient")) {

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
@@ -100,12 +100,12 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
         assertThatThrownBy(() -> Futures.getUnchecked(again)).hasCauseInstanceOf(UnknownHostException.class);
     }
 
-    @RepeatedTest(value = 1000, failureThreshold = 1)
+    @RepeatedTest(value = 100, failureThreshold = 1)
     public void metrics() throws Exception {
         ClientConfiguration conf = ClientConfiguration.builder()
                 .from(TestConfigurations.create("http://unused"))
                 // Use a longer-than-default connect timeout to avoid flakiness in tests
-                .connectTimeout(Duration.ofSeconds(30))
+                .connectTimeout(Duration.ofMinutes(5))
                 .build();
 
         try (ApacheHttpClientChannels.CloseableClient client =

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
@@ -100,40 +99,32 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
         assertThatThrownBy(() -> Futures.getUnchecked(again)).hasCauseInstanceOf(UnknownHostException.class);
     }
 
-    @RepeatedTest(value = 100, failureThreshold = 1)
-    public void metrics() throws Exception {
-        ClientConfiguration conf = ClientConfiguration.builder()
-                .from(TestConfigurations.create("http://unused"))
-                // Use a longer-than-default connect timeout to avoid flakiness in tests
-                .connectTimeout(Duration.ofMinutes(5))
-                .build();
+    @Test
+    public void metrics() {
+        ClientConfiguration conf =
+                TestConfigurations.create(server.url("").url().toString());
 
-        try (ApacheHttpClientChannels.CloseableClient client =
-                ApacheHttpClientChannels.createCloseableHttpClient(conf, "testClient")) {
+        Channel channel = ApacheHttpClientChannels.create(conf, "testClient");
+        ListenableFuture<Response> future = channel.execute(endpoint, request);
 
-            Channel channel = ApacheHttpClientChannels.createSingleUri("http://neverssl.com", client);
-            ListenableFuture<Response> future =
-                    channel.execute(TestEndpoint.GET, Request.builder().build());
-
-            TaggedMetricRegistry metrics = conf.taggedMetricRegistry();
-            try (Response response = Futures.getUnchecked(future)) {
-                assertThat(response.code()).isEqualTo(200);
-
-                assertThat(poolGaugeValue(metrics, "testClient", "idle"))
-                        .describedAs("available")
-                        .isZero();
-                assertThat(poolGaugeValue(metrics, "testClient", "leased"))
-                        .describedAs("leased")
-                        .isEqualTo(1L);
-            }
+        TaggedMetricRegistry metrics = conf.taggedMetricRegistry();
+        try (Response response = Futures.getUnchecked(future)) {
+            assertThat(response.code()).isEqualTo(200);
 
             assertThat(poolGaugeValue(metrics, "testClient", "idle"))
-                    .describedAs("available after response closed")
-                    .isOne();
-            assertThat(poolGaugeValue(metrics, "testClient", "leased"))
-                    .describedAs("leased after response closed")
+                    .describedAs("available")
                     .isZero();
+            assertThat(poolGaugeValue(metrics, "testClient", "leased"))
+                    .describedAs("leased")
+                    .isEqualTo(1L);
         }
+
+        assertThat(poolGaugeValue(metrics, "testClient", "idle"))
+                .describedAs("available after response closed")
+                .isOne();
+        assertThat(poolGaugeValue(metrics, "testClient", "leased"))
+                .describedAs("leased after response closed")
+                .isZero();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
The `ApacheHttpClientChannelsTest#metrics` test connects to `http://neverssl.com`. It seems like this test is flaking _a lot_, at least recently, always when trying to connect, leading to excavator PRs not merging, as well as develop builds being broken.

There are two options I can see to make this test less flaky:
- Increase the connection timeout
  - I tried to do this in this PR (see the first two commits https://github.com/palantir/dialogue/pull/2605/commits/546ad500f4bb23eadb01b4677ab92fb77cee1c72 and https://github.com/palantir/dialogue/pull/2605/commits/005d2b3c607b328b8fa1ed180a508f59ca53f47c), but it kept [failing](https://app.circleci.com/pipelines/github/palantir/dialogue/9248/workflows/37c07270-16bd-4729-a3ec-0edef874eab2/jobs/29854/tests) even with a 5 minutes timeout
- Move away from connecting to a real website
  - This is what this PR is currently doing

## After this PR
==COMMIT_MSG==
Refactor `ApacheHttpClientChannelsTest#metrics` test to not rely on flaky website
==COMMIT_MSG==

## Possible downsides?
I'm not entirely clear as to whether it was important for this test to connect to a real website, but given it's testing metrics and these seem to still be set, this should be fine?
