### PR TITLE
More descriptive channel names for enabled/disabled params

### DIFF
--- a/changelog/@unreleased/pr-2629.v2.yml
+++ b/changelog/@unreleased/pr-2629.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: More descriptive channel names for enabled/disabled params
+  links:
+  - https://github.com/palantir/dialogue/pull/2629

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelNames.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelNames.java
@@ -16,6 +16,8 @@
 
 package com.palantir.dialogue.clients;
 
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+
 final class ChannelNames {
 
     static String reloading(String serviceName) {
@@ -37,11 +39,16 @@ final class ChannelNames {
     private static String summarizeOptions(AugmentClientConfig augment) {
         StringBuilder builder = new StringBuilder();
         augment.nodeSelectionStrategy().ifPresent(value -> builder.append("-").append(value));
+        // For settings with generic names ENABLED/DISABLED, prepend the field name so it's understandable.
         augment.maxNumRetries()
                 .ifPresent(value -> builder.append("-MAX_RETRIES_").append(value));
-        augment.clientQoS().ifPresent(value -> builder.append("-").append(value));
+        augment.clientQoS().ifPresent(value -> builder.append(
+                        value == ClientConfiguration.ClientQoS.ENABLED ? "-CLIENT_QOS_" : "-")
+                .append(value));
         augment.serverQoS().ifPresent(value -> builder.append("-").append(value));
-        augment.retryOnTimeout().ifPresent(value -> builder.append("-").append(value));
+        augment.retryOnTimeout().ifPresent(value -> builder.append(
+                        value == ClientConfiguration.RetryOnTimeout.DISABLED ? "-RETRY_ON_TIMEOUT_" : "-")
+                .append(value));
         return builder.toString();
     }
 

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ChannelNamesTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ChannelNamesTest.java
@@ -34,6 +34,32 @@ class ChannelNamesTest {
     }
 
     @Test
+    void prepends_enabled_disabled_with_field_name() {
+        String channelName = ChannelNames.reloading(
+                "multipass",
+                ImmutableReloadingParams.builder()
+                        .scb(Refreshable.only(null))
+                        .clientQoS(ClientConfiguration.ClientQoS.ENABLED)
+                        .retryOnTimeout(ClientConfiguration.RetryOnTimeout.DISABLED)
+                        .build());
+        assertThat(channelName).isEqualTo("dialogue-multipass-CLIENT_QOS_ENABLED-RETRY_ON_TIMEOUT_DISABLED");
+    }
+
+    @Test
+    void does_not_prepend_field_name_to_values_not_named_enabled_disabled() {
+        String channelName = ChannelNames.reloading(
+                "multipass",
+                ImmutableReloadingParams.builder()
+                        .scb(Refreshable.only(null))
+                        .clientQoS(ClientConfiguration.ClientQoS.DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS)
+                        .retryOnTimeout(ClientConfiguration.RetryOnTimeout.DANGEROUS_ENABLE_AT_RISK_OF_RETRY_STORMS)
+                        .build());
+        assertThat(channelName)
+                .isEqualTo("dialogue-multipass-DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS-"
+                        + "DANGEROUS_ENABLE_AT_RISK_OF_RETRY_STORMS");
+    }
+
+    @Test
     void verbose_if_necessary() {
         String channelName = ChannelNames.reloading(
                 "multipass",


### PR DESCRIPTION
## Before this PR
Users were seeing dialogue channels with names like `dialogue-actions-enabled` and were unsure what the `-enabled` meant. [Internal slack](https://palantir.slack.com/archives/C5MKHTMD4/p1753800307213799).

## After this PR
==COMMIT_MSG==
More descriptive channel names for enabled/disabled params
==COMMIT_MSG==

With this change, configuration options with generic names enabled/disabled have the name of the field prepended.

So now instead of `dialogue-actions-enabled`, they would see `dialogue-actions-client_qos_enabled`

## Possible downsides?
Any code parsing the format of these channel names may not be able to handle the new format. However, I don't believe the channel names are considered part of the stable public API of dialogue.