### PR TITLE
Retry immediately on first failure

### DIFF
--- a/changelog/@unreleased/pr-2644.v2.yml
+++ b/changelog/@unreleased/pr-2644.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: On request failures due to a retryable exception, the call is immediately
+    retried on a second host.
+  links:
+  - https://github.com/palantir/dialogue/pull/2644

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -276,7 +276,7 @@ final class RetryingChannel implements EndpointChannel {
                 if (requestCanBeRetried() && shouldAttemptToRetry(clientSideThrowable)) {
                     callsiteStacktrace.ifPresent(clientSideThrowable::addSuppressed);
                     Meter retryReason = retryDueToThrowable.apply(clientSideThrowable);
-                    long backoffNanoseconds = getBackoffNanoseconds();
+                    long backoffNanoseconds = failures <= 1 ? 0 : getBackoffNanoseconds();
                     infoLogRetry(backoffNanoseconds, OptionalInt.empty(), clientSideThrowable);
                     return scheduleRetry(retryReason, backoffNanoseconds);
                 } else if (log.isDebugEnabled()) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -170,6 +170,31 @@ public class RetryingChannelTest {
     }
 
     @Test
+    public void retriesFirstFailureImmediately() throws Exception {
+        when(channel.execute(any())).thenReturn(FAILED).thenReturn(SUCCESS);
+
+        // One retry allows an initial request (not a retry) and a single retry.
+        long startTime = System.nanoTime();
+        Duration backoffSlotSize = Duration.ofSeconds(10);
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                1,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response).isDone();
+        assertThat(response.get()).isEqualTo(EXPECTED_RESPONSE);
+
+        verify(channel, times(2)).execute(REQUEST);
+        assertThat(Duration.ofNanos(System.nanoTime() - startTime))
+                .as("IOException retry immediately on first failure")
+                .isLessThan(backoffSlotSize);
+    }
+
+    @Test
     public void retries_429s() throws Exception {
         when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>)
                 _invocation -> Futures.immediateFuture(new TestResponse().code(429)));

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -190,7 +190,7 @@ public class RetryingChannelTest {
 
         verify(channel, times(2)).execute(REQUEST);
         assertThat(Duration.ofNanos(System.nanoTime() - startTime))
-                .as("IOException retry immediately on first failure")
+                .as("First failure with retryable exceptions should be immediately retried")
                 .isLessThan(backoffSlotSize);
     }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We run services on environments which are quite hostile - servers restarts every X hours, which causes `IOException` errors for clients. Our retry strategy does make these requests eventually succeed, but at the cost of a first retry, which, with default parameters takes from 0 to `250 ms` ([ref](https://github.com/palantir/conjure-java-runtime/blob/db9a10d5942aa79e6d68a204b2a1dd79db9c5ac1/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java#L54)).

This PR attempts to solve this common pattern (retries due to service restarts) by immediately retrying on the 1st failure.

From internal numbers for a service on a test stack:
- 50% of requests succeed on the first retry
- 50% of requests fail after exhausting all four retries
- the vast majority of exceptions are of type `HttpHostConnectException`, with the 2 most common being `NoHttpResponseException`

## After this PR
==COMMIT_MSG==
If a request failed, the call is immediately retried on a second host.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
