### PR TITLE
Add `errorParamterFormat` to BodySerDe

### DIFF
--- a/dialogue-target/build.gradle
+++ b/dialogue-target/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.code.findbugs:jsr305'
+    implementation 'com.palantir.conjure.java.api:errors'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.assertj:assertj-guava'

--- a/dialogue-target/src/main/java/com/palantir/dialogue/BodySerDe.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/BodySerDe.java
@@ -16,6 +16,7 @@
 
 package com.palantir.dialogue;
 
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
 import java.io.InputStream;
 import java.util.Optional;
 
@@ -61,4 +62,8 @@ public interface BodySerDe {
 
     /** Serializes a {@link BinaryRequestBody} to <pre>application/octet-stream</pre>. */
     RequestBody serialize(BinaryRequestBody value);
+
+    default Optional<ConjureErrorParameterFormat> errorParameterFormat() {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
## Before this PR
This PR splits #2652. #2652 enables clients to set the error parameter format, while this PR just adds the error parameter format to `BodySerDe`.

This split allows us to check in code that generates Dialogue clients that are able to respect the error parameter format, without supporting setting the error parameter format.

## After this PR
==COMMIT_MSG==
Add `errorParamterFormat` to BodySerDe
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
