### PR TITLE
com.palantir.conjure.java.api:errors should be an api dep in dialogue-target

### DIFF
--- a/dialogue-target/build.gradle
+++ b/dialogue-target/build.gradle
@@ -7,12 +7,12 @@ dependencies {
     api 'com.palantir.ri:resource-identifier'
     api 'com.palantir.conjure.java:conjure-lib'
     api 'org.jspecify:jspecify'
+    api 'com.palantir.conjure.java.api:errors'
 
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.code.findbugs:jsr305'
-    implementation 'com.palantir.conjure.java.api:errors'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.assertj:assertj-guava'


### PR DESCRIPTION
## Before this PR
In #2658, we added `com.palantir.conjure.java.api:errors` as an implementation dependency. It should be an API dep because the `ConjureErrorParameterFormat` from the package is exposed in a public API.

## After this PR
==COMMIT_MSG==
com.palantir.conjure.java.api:errors should be an api dep in dialogue-target
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
