### PR TITLE
Reduce Optional allocations from limiter permit acquire()

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
@@ -25,7 +25,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.DoubleBinaryOperator;
 import org.jspecify.annotations.Nullable;
@@ -71,7 +70,8 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
      * {@link Permit#onFailure} which delegate to
      * ignore/dropped/success depending on the success or failure state of the response.
      * */
-    Optional<Permit> acquire(LimitEnforcement limitEnforcement) {
+    @Nullable // avoiding java.util.Optional because this method is on the hot path
+    Permit acquire(LimitEnforcement limitEnforcement) {
 
         // Capture the limit field reference once to avoid work in a tight loop. The JIT cannot
         // reliably optimize out references to final fields due to the potential for reflective
@@ -86,12 +86,12 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
         while (true) {
             int currentInFlight = localInFlight.get();
             if (limitEnforcement.enforceLimits() && currentInFlight >= currentLimit) {
-                return Optional.empty();
+                return null;
             }
 
             int newInFlight = currentInFlight + 1;
             if (inFlight.compareAndSet(currentInFlight, newInFlight)) {
-                return Optional.of(new Permit(newInFlight));
+                return new Permit(newInFlight);
             }
         }
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -23,6 +23,7 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.core.CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Behavior;
+import com.palantir.dialogue.core.CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
@@ -31,6 +32,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Optional;
 import java.util.stream.LongStream;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A channel that monitors the successes and failures of requests in order to determine the number of concurrent
@@ -89,10 +91,9 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
             Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> maybePermit =
-                limiter.acquire(limitEnforcement);
-        if (maybePermit.isPresent()) {
-            CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit permit = maybePermit.get();
+        @Nullable Permit maybePermit = limiter.acquire(limitEnforcement);
+        if (maybePermit != null) {
+            CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit permit = maybePermit;
             logPermitAcquired();
             ListenableFuture<Response> result = delegate.execute(endpoint, request);
             DialogueFutures.addDirectCallback(result, permit);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannel.java
@@ -22,11 +22,13 @@ import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.core.CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Behavior;
+import com.palantir.dialogue.core.CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 final class StickyConcurrencyLimitedChannel implements LimitedChannel {
 
@@ -49,10 +51,9 @@ final class StickyConcurrencyLimitedChannel implements LimitedChannel {
     @Override
     public Optional<ListenableFuture<Response>> maybeExecute(
             Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> maybePermit =
-                limiter.acquire(limitEnforcement);
-        if (maybePermit.isPresent()) {
-            CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit permit = maybePermit.get();
+        @Nullable Permit maybePermit = limiter.acquire(limitEnforcement);
+        if (maybePermit != null) {
+            CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit permit = maybePermit;
             logPermitAcquired();
 
             // This is a trade-off to solve an edge case where the first request on this channel could get
@@ -68,7 +69,7 @@ final class StickyConcurrencyLimitedChannel implements LimitedChannel {
                 DialogueFutures.addDirectCallback(result.get(), permit);
                 return result;
             } else {
-                maybePermit.get().dropped();
+                permit.dropped();
                 return Optional.empty();
             }
         } else {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannel.java
@@ -53,7 +53,6 @@ final class StickyConcurrencyLimitedChannel implements LimitedChannel {
             Endpoint endpoint, Request request, LimitEnforcement limitEnforcement) {
         @Nullable Permit maybePermit = limiter.acquire(limitEnforcement);
         if (maybePermit != null) {
-            CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit permit = maybePermit;
             logPermitAcquired();
 
             // This is a trade-off to solve an edge case where the first request on this channel could get
@@ -64,12 +63,12 @@ final class StickyConcurrencyLimitedChannel implements LimitedChannel {
             Optional<ListenableFuture<Response>> result = delegate.maybeExecute(
                     endpoint,
                     request,
-                    permit.isOnlyInFlight() ? LimitEnforcement.DANGEROUS_BYPASS_LIMITS : limitEnforcement);
+                    maybePermit.isOnlyInFlight() ? LimitEnforcement.DANGEROUS_BYPASS_LIMITS : limitEnforcement);
             if (result.isPresent()) {
-                DialogueFutures.addDirectCallback(result.get(), permit);
+                DialogueFutures.addDirectCallback(result.get(), maybePermit);
                 return result;
             } else {
-                permit.dropped();
+                maybePermit.dropped();
                 return Optional.empty();
             }
         } else {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -58,19 +57,19 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     void acquire_returnsPermitsWhileInflightPermitLimitNotReached(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         double max = limiter.getLimit();
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> latestPermit = null;
+        Permit latestPermit = null;
         for (int i = 0; i < max; ++i) {
             latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
-            assertThat(latestPermit).isPresent();
+            assertThat(latestPermit).isNotNull();
         }
 
         // Limit reached, cannot acquire permit
         assertThat(limiter.getInflight()).isEqualTo((int) max);
-        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNull();
 
         // Release one permit, can acquire new permit.
-        latestPermit.get().ignore();
-        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
+        latestPermit.ignore();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNotNull();
     }
 
     @ParameterizedTest
@@ -79,18 +78,18 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
 
         double max = limiter.getLimit();
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> latestPermit = null;
+        Permit latestPermit = null;
         for (int i = 0; i < max; ++i) {
             latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
-            assertThat(latestPermit).isPresent();
+            assertThat(latestPermit).isNotNull();
         }
 
-        latestPermit.get().success();
+        latestPermit.success();
         assertThat(limiter.getLimit()).isEqualTo(20.05);
 
         // Now we can only acquire one extra permit, not 2
-        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
-        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNotNull();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNull();
     }
 
     @ParameterizedTest
@@ -100,11 +99,11 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
 
         double max = limiter.getLimit();
         for (int i = 0; i < max; ++i) {
-            assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
+            assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNotNull();
         }
 
-        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
-        assertThat(limiter.acquire(LimitEnforcement.DANGEROUS_BYPASS_LIMITS)).isPresent();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNull();
+        assertThat(limiter.acquire(LimitEnforcement.DANGEROUS_BYPASS_LIMITS)).isNotNull();
         assertThat(limiter.getInflight()).isEqualTo((int) (max + 1));
     }
 
@@ -113,10 +112,9 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void ignore_releasesPermit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         assertThat(limiter.getInflight()).isEqualTo(0);
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit =
-                limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
+        Permit permit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
         assertThat(limiter.getInflight()).isEqualTo(1);
-        permit.get().ignore();
+        permit.ignore();
         assertThat(limiter.getInflight()).isEqualTo(0);
     }
 
@@ -125,7 +123,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void ignore_doesNotChangeLimits(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().ignore();
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).ignore();
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -134,10 +132,9 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void dropped_releasesPermit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         assertThat(limiter.getInflight()).isEqualTo(0);
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit =
-                limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
+        Permit permit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
         assertThat(limiter.getInflight()).isEqualTo(1);
-        permit.get().dropped();
+        permit.dropped();
         assertThat(limiter.getInflight()).isEqualTo(0);
     }
 
@@ -146,7 +143,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void dropped_reducesLimit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().dropped();
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).dropped();
         assertThat(limiter.getLimit()).isEqualTo((int) (max * 0.9));
     }
 
@@ -155,10 +152,9 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
     public void success_releasesPermit(Behavior behavior) {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         assertThat(limiter.getInflight()).isEqualTo(0);
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> permit =
-                limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
+        Permit permit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
         assertThat(limiter.getInflight()).isEqualTo(1);
-        permit.get().success();
+        permit.success();
         assertThat(limiter.getInflight()).isEqualTo(0);
     }
 
@@ -168,11 +164,11 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(behavior);
         double max = limiter.getLimit();
         for (int i = 0; i < max * .9; ++i) {
-            assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isPresent();
+            assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNotNull();
             assertThat(limiter.getLimit()).isEqualTo(max);
         }
 
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().success();
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).success();
         assertThat(limiter.getLimit()).isGreaterThan(max).isLessThanOrEqualTo(max + 1);
     }
 
@@ -183,7 +179,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(200);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -193,7 +189,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(308).withHeader("Location", "https://localhost");
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).as("For status %d", 308).isCloseTo(max * 0.9, Percentage.withPercentage(5));
     }
 
@@ -205,7 +201,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(308);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -215,7 +211,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(503);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).as("For status %d", 503).isCloseTo(max * 0.9, Percentage.withPercentage(5));
     }
 
@@ -228,7 +224,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         QosReasons.encodeToResponse(reason, response, TestResponseQosEncoder.INSTANCE);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).as("For DueTo.CUSTOM status %d", 503).isEqualTo(max);
     }
 
@@ -243,7 +239,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         QosReasons.encodeToResponse(reason, response, TestResponseQosEncoder.INSTANCE);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit())
                 .as("For status %d not impacted by RetryHint.DO_NOT_RETRY", 503)
                 .isCloseTo(max * 0.9, Percentage.withPercentage(5));
@@ -256,7 +252,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).as("For status %d", code).isCloseTo(max * 0.9, Percentage.withPercentage(5));
     }
 
@@ -269,7 +265,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         QosReasons.encodeToResponse(reason, response, TestResponseQosEncoder.INSTANCE);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).as("For DueTo.CUSTOM status %d", 429).isEqualTo(max);
     }
 
@@ -284,7 +280,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         QosReasons.encodeToResponse(reason, response, TestResponseQosEncoder.INSTANCE);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit())
                 .as("For status %d not impacted by RetryHint.DO_NOT_RETRY", 429)
                 .isCloseTo(max * 0.9, Percentage.withPercentage(5));
@@ -297,7 +293,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -308,7 +304,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -319,7 +315,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -330,7 +326,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         Response response = new TestResponse().code(code);
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onSuccess(response);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onSuccess(response);
         assertThat(limiter.getLimit()).as("For status %d", code).isCloseTo(max * 0.9, Percentage.withPercentage(5));
     }
 
@@ -340,7 +336,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         IOException exception = new IOException();
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onFailure(exception);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onFailure(exception);
         assertThat(limiter.getLimit()).isEqualTo((int) (max * 0.9));
     }
 
@@ -350,7 +346,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         IOException exception = new IOException();
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onFailure(exception);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onFailure(exception);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -360,7 +356,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         IOException exception = new IOException();
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onFailure(exception);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onFailure(exception);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -371,7 +367,7 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         RuntimeException exception = new RuntimeException();
 
         double max = limiter.getLimit();
-        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).get().onFailure(exception);
+        limiter.acquire(LimitEnforcement.DEFAULT_ENABLED).onFailure(exception);
         assertThat(limiter.getLimit()).isEqualTo(max);
     }
 
@@ -380,16 +376,16 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
         CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter = limiter(Behavior.HOST_LEVEL);
 
         int max = (int) limiter.getLimit();
-        Optional<CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit> latestPermit;
+        Permit latestPermit;
         for (int i = 0; i < max - 1; ++i) {
             latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
-            assertThat(latestPermit).isPresent();
+            assertThat(latestPermit).isNotNull();
         }
 
         latestPermit = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
-        assertThat(latestPermit).isPresent();
-        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isEmpty();
-        latestPermit.get().ignore();
+        assertThat(latestPermit).isNotNull();
+        assertThat(limiter.acquire(LimitEnforcement.DEFAULT_ENABLED)).isNull();
+        latestPermit.ignore();
 
         // Now let's have some threads fight for that last remaining permit.
         int numTasks = 8;
@@ -404,10 +400,10 @@ public class CautiousIncreaseAggressiveDecreaseConcurrencyLimiterTest {
                     Uninterruptibles.awaitUninterruptibly(latch);
 
                     for (int i = 0; i < numIterations; i++) {
-                        Optional<Permit> acquire = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
-                        if (acquire.isPresent()) {
-                            assertThat(acquire.get().inFlightSnapshot()).isLessThanOrEqualTo(max);
-                            acquire.get().ignore();
+                        Permit acquire = limiter.acquire(LimitEnforcement.DEFAULT_ENABLED);
+                        if (acquire != null) {
+                            assertThat(acquire.inFlightSnapshot()).isLessThanOrEqualTo(max);
+                            acquire.ignore();
                         }
                     }
                 }));

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/ConcurrencyLimitedChannelTest.java
@@ -38,7 +38,6 @@ import com.palantir.dialogue.core.LimitedChannel.LimitEnforcement;
 import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,14 +63,12 @@ public class ConcurrencyLimitedChannelTest {
     @Spy
     private CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit hostPermit =
             new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.HOST_LEVEL)
-                    .acquire(LimitEnforcement.DEFAULT_ENABLED)
-                    .get();
+                    .acquire(LimitEnforcement.DEFAULT_ENABLED);
 
     @Spy
     private CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.Permit endpointPermit =
             new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.ENDPOINT_LEVEL)
-                    .acquire(LimitEnforcement.DEFAULT_ENABLED)
-                    .get();
+                    .acquire(LimitEnforcement.DEFAULT_ENABLED);
 
     @Mock
     private Response response;
@@ -264,19 +261,19 @@ public class ConcurrencyLimitedChannelTest {
     }
 
     private void mockHostLimitAvailable() {
-        when(mockLimiter.acquire(any())).thenReturn(Optional.of(hostPermit));
+        when(mockLimiter.acquire(any())).thenReturn(hostPermit);
     }
 
     private void mockHostLimitUnavailable() {
-        when(mockLimiter.acquire(any())).thenReturn(Optional.empty());
+        when(mockLimiter.acquire(any())).thenReturn(null);
     }
 
     private void mockEndpointLimitAvailable() {
-        when(mockLimiter.acquire(any())).thenReturn(Optional.of(endpointPermit));
+        when(mockLimiter.acquire(any())).thenReturn(endpointPermit);
     }
 
     private void mockEndpointLimitUnavailable() {
-        when(mockLimiter.acquire(any())).thenReturn(Optional.empty());
+        when(mockLimiter.acquire(any())).thenReturn(null);
     }
 
     @SuppressWarnings("unchecked")

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannelTest.java
@@ -131,14 +131,14 @@ public final class StickyConcurrencyLimitedChannelTest {
 
     @Test
     public void acquire_fails() {
-        when(mockLimiter.acquire(any())).thenReturn(Optional.empty());
+        when(mockLimiter.acquire(any())).thenReturn(null);
         assertThat(channel.maybeExecute(endpoint, request, LimitEnforcement.DANGEROUS_BYPASS_LIMITS))
                 .isEmpty();
         verifyNoInteractions(permit, delegate);
     }
 
     private void whenAcquireSuccessful() {
-        when(mockLimiter.acquire(any())).thenReturn(Optional.of(permit));
+        when(mockLimiter.acquire(any())).thenReturn(permit);
     }
 
     private void whenOnlyInFlight(boolean onlyInFlight) {


### PR DESCRIPTION
## Before this PR
We are allocating enough instances of Optional in this method that it's showing up in JFRs on prod stacks (barely):

<img width="3104" height="2758" alt="CleanShot 2025-08-25 at 23 26 12" src="https://github.com/user-attachments/assets/7721b075-66b4-4a06-a3cf-d951503f0497" />

## After this PR
==COMMIT_MSG==
Reduce Optional allocations from limiter permit acquire()
==COMMIT_MSG==

Switch from `Optional<Permit>` to `@Nullable Permit` in `CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.acquire(LimitEnforcement)`

## Possible downsides?
- reduces code legibility and increases the risk of NullPointerExceptions if calling code doesn't have NullAway style protections running.  I'm not sure if these allocations are frequent enough that we should try to make improvements, or if we should just leave the code alone.
- risk of API break from changing the method signature, but I think this being package-private and internal API to dialogue means it won't break any consumers
