### PR TITLE
Fix deadlines deprecation

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
@@ -45,8 +45,7 @@ final class DeadlineAdvertisementChannel implements Channel {
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
         Request.Builder requestBuilder = Request.builder().from(request);
         try {
-            Deadlines.encodeToRequest(
-                    readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE, Deadlines.Enforcement.DEFER);
+            Deadlines.encodeToRequest(readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE, Deadlines.Enforcement.DEFER);
         } catch (DeadlineExpiredException e) {
             return Futures.immediateFailedFuture(e);
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
@@ -45,7 +45,8 @@ final class DeadlineAdvertisementChannel implements Channel {
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
         Request.Builder requestBuilder = Request.builder().from(request);
         try {
-            Deadlines.encodeToRequest(readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE, Deadlines.Enforcement.DEFER);
+            Deadlines.encodeToRequest(
+                    readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE, Deadlines.Enforcement.DEFER);
         } catch (DeadlineExpiredException e) {
             return Futures.immediateFailedFuture(e);
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
@@ -41,12 +41,11 @@ final class DeadlineAdvertisementChannel implements Channel {
         this.readTimeout = readTimeout.isNegative() || readTimeout.isZero() ? Duration.ofDays(1) : readTimeout;
     }
 
-    @SuppressWarnings({"for-rollout:InlineMeInliner", "for-rollout:deprecation"})
     @Override
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
         Request.Builder requestBuilder = Request.builder().from(request);
         try {
-            Deadlines.encodeToRequest(readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE);
+            Deadlines.encodeToRequest(readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE, Deadlines.Enforcement.DEFER);
         } catch (DeadlineExpiredException e) {
             return Futures.immediateFailedFuture(e);
         }


### PR DESCRIPTION
## Before this PR
InlineMeInliner does not get auto-applied yet. Instead, it gets suppressed, as in https://github.com/palantir/dialogue/pull/2704, which means that the annotation added in https://github.com/palantir/deadlines-java/pull/188/files#diff-f8f90c9951b97fc3abe992cb927e3601222e7e3ce25efb471821039feab57432R179-R181 doesn't get auto-fixed

## After this PR
==COMMIT_MSG==
Fix deadlines deprecation
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

