### PR TITLE
Add spans to various connection methods to help investigate latency

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -40,6 +40,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tracing.Tracer;
 import com.palantir.tracing.api.TraceHttpHeaders;
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
@@ -383,28 +384,53 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             client = null;
             // Avoid attempting to close a response that has already been closed.
             if (clientSnapshot != null) {
-                try {
-                    // Check if the response has been fully drained. If not, we close the connection rather than
-                    // potentially reading massive data unnecessarily.
-                    if (hasSubstantialRemainingData(response)) {
-                        ExecRuntime runtime = HttpClientExecRuntimeAttributeInterceptor.get(context);
-                        if (runtime != null) {
-                            runtime.discardEndpoint();
-                            // Constructing the new metrics component in the unexpected case is more efficient than
-                            // creating the meter for hundreds of services which never hit this case.
-                            DialogueClientMetrics.of(
-                                            clientSnapshot.clientConfiguration().taggedMetricRegistry())
-                                    .connectionClosedPartiallyConsumedResponse(clientSnapshot.name())
-                                    .mark();
-                            // Do not call response.close which internally attempts to drain the response
-                            // because the underlying resources have already been closed.
-                            return;
-                        }
+                if (log.isDebugEnabled()) {
+                    Tracer.fastStartSpan("Dialogue Response.close");
+                    try {
+                        doClose(clientSnapshot);
+                    } finally {
+                        Tracer.fastCompleteSpan();
                     }
-                    response.close();
-                } catch (IOException | RuntimeException e) {
-                    log.warn("Failed to close response", e);
+                } else {
+                    doClose(clientSnapshot);
                 }
+            }
+        }
+
+        private void doClose(ApacheHttpClientChannels.CloseableClient clientSnapshot) {
+            try {
+                // Check if the response has been fully drained. If not, we close the connection rather than
+                // potentially reading massive data unnecessarily.
+                boolean hasRemainingData;
+                if (log.isDebugEnabled()) {
+                    Tracer.fastStartSpan("Dialogue Response.checkRemaining");
+                    try {
+                        hasRemainingData = hasSubstantialRemainingData(response);
+                    } finally {
+                        Tracer.fastCompleteSpan();
+                    }
+                } else {
+                    hasRemainingData = hasSubstantialRemainingData(response);
+                }
+
+                if (hasRemainingData) {
+                    ExecRuntime runtime = HttpClientExecRuntimeAttributeInterceptor.get(context);
+                    if (runtime != null) {
+                        runtime.discardEndpoint();
+                        // Constructing the new metrics component in the unexpected case is more efficient than
+                        // creating the meter for hundreds of services which never hit this case.
+                        DialogueClientMetrics.of(
+                                        clientSnapshot.clientConfiguration().taggedMetricRegistry())
+                                .connectionClosedPartiallyConsumedResponse(clientSnapshot.name())
+                                .mark();
+                        // Do not call response.close which internally attempts to drain the response
+                        // because the underlying resources have already been closed.
+                        return;
+                    }
+                }
+                response.close();
+            } catch (IOException | RuntimeException e) {
+                log.warn("Failed to close response", e);
             }
         }
 

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -384,53 +384,40 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             client = null;
             // Avoid attempting to close a response that has already been closed.
             if (clientSnapshot != null) {
-                if (log.isDebugEnabled()) {
-                    Tracer.fastStartSpan("Dialogue Response.close");
-                    try {
-                        doClose(clientSnapshot);
-                    } finally {
-                        Tracer.fastCompleteSpan();
-                    }
-                } else {
-                    doClose(clientSnapshot);
-                }
-            }
-        }
-
-        private void doClose(ApacheHttpClientChannels.CloseableClient clientSnapshot) {
-            try {
-                // Check if the response has been fully drained. If not, we close the connection rather than
-                // potentially reading massive data unnecessarily.
-                boolean hasRemainingData;
-                if (log.isDebugEnabled()) {
-                    Tracer.fastStartSpan("Dialogue Response.checkRemaining");
-                    try {
+                try {
+                    // Check if the response has been fully drained. If not, we close the connection rather than
+                    // potentially reading massive data unnecessarily.
+                    boolean hasRemainingData;
+                    if (log.isDebugEnabled()) {
+                        Tracer.fastStartSpan("Dialogue Response.checkRemaining");
+                        try {
+                            hasRemainingData = hasSubstantialRemainingData(response);
+                        } finally {
+                            Tracer.fastCompleteSpan();
+                        }
+                    } else {
                         hasRemainingData = hasSubstantialRemainingData(response);
-                    } finally {
-                        Tracer.fastCompleteSpan();
                     }
-                } else {
-                    hasRemainingData = hasSubstantialRemainingData(response);
-                }
 
-                if (hasRemainingData) {
-                    ExecRuntime runtime = HttpClientExecRuntimeAttributeInterceptor.get(context);
-                    if (runtime != null) {
-                        runtime.discardEndpoint();
-                        // Constructing the new metrics component in the unexpected case is more efficient than
-                        // creating the meter for hundreds of services which never hit this case.
-                        DialogueClientMetrics.of(
-                                        clientSnapshot.clientConfiguration().taggedMetricRegistry())
-                                .connectionClosedPartiallyConsumedResponse(clientSnapshot.name())
-                                .mark();
-                        // Do not call response.close which internally attempts to drain the response
-                        // because the underlying resources have already been closed.
-                        return;
+                    if (hasRemainingData) {
+                        ExecRuntime runtime = HttpClientExecRuntimeAttributeInterceptor.get(context);
+                        if (runtime != null) {
+                            runtime.discardEndpoint();
+                            // Constructing the new metrics component in the unexpected case is more efficient than
+                            // creating the meter for hundreds of services which never hit this case.
+                            DialogueClientMetrics.of(
+                                            clientSnapshot.clientConfiguration().taggedMetricRegistry())
+                                    .connectionClosedPartiallyConsumedResponse(clientSnapshot.name())
+                                    .mark();
+                            // Do not call response.close which internally attempts to drain the response
+                            // because the underlying resources have already been closed.
+                            return;
+                        }
                     }
+                    response.close();
+                } catch (IOException | RuntimeException e) {
+                    log.warn("Failed to close response", e);
                 }
-                response.close();
-            } catch (IOException | RuntimeException e) {
-                log.warn("Failed to close response", e);
             }
         }
 

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
@@ -18,6 +18,9 @@ package com.palantir.dialogue.hc5;
 
 import com.codahale.metrics.Timer;
 import com.google.common.net.HttpHeaders;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tracing.Tracer;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketAddress;
@@ -35,6 +38,8 @@ import org.apache.hc.core5.util.Timeout;
 
 /** A simple wrapper around a {@link ManagedHttpClientConnection} which provides instrumentation. */
 final class InstrumentedManagedHttpClientConnection implements ManagedHttpClientConnection {
+
+    private static final SafeLogger log = SafeLoggerFactory.get(InstrumentedManagedHttpClientConnection.class);
 
     private final ManagedHttpClientConnection delegate;
     private final Timer serverTimingOverhead;
@@ -61,17 +66,44 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
 
     @Override
     public void passivate() {
-        delegate.passivate();
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue Connection.passivate");
+            try {
+                delegate.passivate();
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            delegate.passivate();
+        }
     }
 
     @Override
     public void activate() {
-        delegate.activate();
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue Connection.activate");
+            try {
+                delegate.activate();
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            delegate.activate();
+        }
     }
 
     @Override
     public boolean isConsistent() {
-        return delegate.isConsistent();
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue Connection.isConsistent");
+            try {
+                return delegate.isConsistent();
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            return delegate.isConsistent();
+        }
     }
 
     @Override
@@ -124,12 +156,33 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
 
     @Override
     public boolean isDataAvailable(Timeout timeout) throws IOException {
-        return delegate.isDataAvailable(timeout);
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue Connection.isDataAvailable");
+            try {
+                return delegate.isDataAvailable(timeout);
+            } finally {
+                Tracer.fastCompleteSpan(ImmutableMap.of("timeout", String.valueOf(timeout)));
+            }
+        } else {
+            return delegate.isDataAvailable(timeout);
+        }
     }
 
     @Override
     public boolean isStale() throws IOException {
-        return delegate.isStale();
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue ConnectionValidation.isStale");
+            long startNanos = System.nanoTime();
+            try {
+                boolean stale = delegate.isStale();
+                long durationNanos = System.nanoTime() - startNanos;
+                return stale;
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            return delegate.isStale();
+        }
     }
 
     @Override

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
@@ -108,7 +108,16 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
 
     @Override
     public void sendRequestHeader(ClassicHttpRequest request) throws HttpException, IOException {
-        delegate.sendRequestHeader(request);
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue Connection.sendRequestHeader");
+            try {
+                delegate.sendRequestHeader(request);
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            delegate.sendRequestHeader(request);
+        }
     }
 
     @Override
@@ -118,7 +127,16 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
 
     @Override
     public void sendRequestEntity(ClassicHttpRequest request) throws HttpException, IOException {
-        delegate.sendRequestEntity(request);
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue Connection.sendRequestEntity");
+            try {
+                delegate.sendRequestEntity(request);
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            delegate.sendRequestEntity(request);
+        }
     }
 
     @Override
@@ -151,7 +169,16 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
 
     @Override
     public void receiveResponseEntity(ClassicHttpResponse response) throws HttpException, IOException {
-        delegate.receiveResponseEntity(response);
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue Connection.receiveResponseEntity");
+            try {
+                delegate.receiveResponseEntity(response);
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            delegate.receiveResponseEntity(response);
+        }
     }
 
     @Override

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
@@ -172,11 +172,8 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
     public boolean isStale() throws IOException {
         if (log.isDebugEnabled()) {
             Tracer.fastStartSpan("Dialogue ConnectionValidation.isStale");
-            long startNanos = System.nanoTime();
             try {
-                boolean stale = delegate.isStale();
-                long durationNanos = System.nanoTime() - startNanos;
-                return stale;
+                return delegate.isStale();
             } finally {
                 Tracer.fastCompleteSpan();
             }

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
@@ -161,7 +161,7 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
             try {
                 return delegate.isDataAvailable(timeout);
             } finally {
-                Tracer.fastCompleteSpan(ImmutableMap.of("timeout", String.valueOf(timeout)));
+                Tracer.fastCompleteSpan();
             }
         } else {
             return delegate.isDataAvailable(timeout);

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
@@ -27,7 +27,9 @@ import com.palantir.tracing.Tracer;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.ConnectionEndpoint;
@@ -127,11 +129,12 @@ final class InstrumentedPoolingHttpClientConnectionManager
         if (log.isDebugEnabled()) {
             Tracer.fastStartSpan("Dialogue ConnectionPool.lease");
             try {
-                return manager.lease(id, route, requestTimeout, state);
+                return new InstrumentedLeaseRequest(manager.lease(id, route, requestTimeout, state));
             } finally {
                 Tracer.fastCompleteSpan();
             }
         } else {
+            // do not bother with the overhead of creating a new InstrumentedLeaseRequest in the common case.
             return manager.lease(id, route, requestTimeout, state);
         }
     }
@@ -247,5 +250,28 @@ final class InstrumentedPoolingHttpClientConnectionManager
     @Override
     public String toString() {
         return "InstrumentedPoolingHttpClientConnectionManager{" + manager + '}';
+    }
+
+    record InstrumentedLeaseRequest(LeaseRequest delegate) implements LeaseRequest {
+
+        @Override
+        public ConnectionEndpoint get(Timeout timeout)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            if (log.isDebugEnabled()) {
+                Tracer.fastStartSpan("Dialogue LeaseRequest.get");
+                try {
+                    return delegate.get(timeout);
+                } finally {
+                    Tracer.fastCompleteSpan();
+                }
+            } else {
+                return delegate.get(timeout);
+            }
+        }
+
+        @Override
+        public boolean cancel() {
+            return delegate.cancel();
+        }
     }
 }

--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedPoolingHttpClientConnectionManager.java
@@ -23,6 +23,7 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tracing.CloseableTracer;
+import com.palantir.tracing.Tracer;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.IOException;
 import java.util.Set;
@@ -123,12 +124,30 @@ final class InstrumentedPoolingHttpClientConnectionManager
 
     @Override
     public LeaseRequest lease(String id, HttpRoute route, Timeout requestTimeout, Object state) {
-        return manager.lease(id, route, requestTimeout, state);
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue ConnectionPool.lease");
+            try {
+                return manager.lease(id, route, requestTimeout, state);
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            return manager.lease(id, route, requestTimeout, state);
+        }
     }
 
     @Override
     public void release(ConnectionEndpoint endpoint, Object state, TimeValue keepAlive) {
-        manager.release(endpoint, state, keepAlive);
+        if (log.isDebugEnabled()) {
+            Tracer.fastStartSpan("Dialogue ConnectionPool.release");
+            try {
+                manager.release(endpoint, state, keepAlive);
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        } else {
+            manager.release(endpoint, state, keepAlive);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
While debugging slower client perceived latency, it's hard to root cause overhead time without more spans. 
Its helpful to be able to know when our connection configuration is affecting our latencies. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add spans to various connection methods to help investigate latency
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

