### PR TITLE
Wire up `DeadlineExpiredException` parsing

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
@@ -19,14 +19,17 @@ package com.palantir.dialogue.core;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.deadlines.DeadlineExpiredException;
+import com.palantir.deadlines.DeadlineExpiredReasons;
 import com.palantir.deadlines.Deadlines;
 import com.palantir.deadlines.Deadlines.Enforcement;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.futures.DialogueFutures;
 import java.time.Duration;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 final class DeadlineAdvertisementChannel implements Channel {
 
@@ -65,7 +68,15 @@ final class DeadlineAdvertisementChannel implements Channel {
         } catch (DeadlineExpiredException e) {
             return Futures.immediateFailedFuture(e);
         }
-        return delegate.execute(endpoint, requestBuilder.build());
+
+        return DialogueFutures.transformAsync(delegate.execute(endpoint, requestBuilder.build()), response -> {
+            DeadlineExpiredException deadlineException =
+                    DeadlineExpiredReasons.maybeParseFromResponse(response, ResponseDecodingAdapter.INSTANCE);
+            if (deadlineException != null) {
+                return Futures.immediateFailedFuture(deadlineException);
+            }
+            return Futures.immediateFuture(response);
+        });
     }
 
     private enum RequestBuilderEncodingAdapter implements Deadlines.RequestEncodingAdapter<Request.Builder> {
@@ -74,6 +85,20 @@ final class DeadlineAdvertisementChannel implements Channel {
         @Override
         public void setHeader(Request.Builder builder, String headerName, String headerValue) {
             builder.putHeaderParams(headerName, headerValue);
+        }
+    }
+
+    private enum ResponseDecodingAdapter implements DeadlineExpiredReasons.ResponseDecodingAdapter<Response> {
+        INSTANCE;
+
+        @Override
+        public @Nullable String maybeFirstHeader(Response response, String headerName) {
+            return response.getFirstHeader(headerName).orElse(null);
+        }
+
+        @Override
+        public int getStatus(Response response) {
+            return response.code();
         }
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DeadlineAdvertisementChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DeadlineAdvertisementChannelTest.java
@@ -237,7 +237,7 @@ class DeadlineAdvertisementChannelTest {
                 new TestResponse().code(400).withHeader(DeadlinesHttpHeaders.DEADLINE_EXPIRED_REASON, "external");
 
         Channel delegate = (_endpoint, _request) -> Futures.immediateFuture(deadlineResponse);
-        Channel channel = new DeadlineAdvertisementChannel(delegate, readTimeout);
+        Channel channel = DeadlineAdvertisementChannel.create(delegate, readTimeout);
 
         ListenableFuture<Response> response =
                 channel.execute(TestEndpoint.GET, Request.builder().build());
@@ -254,7 +254,7 @@ class DeadlineAdvertisementChannelTest {
                 new TestResponse().code(500).withHeader(DeadlinesHttpHeaders.DEADLINE_EXPIRED_REASON, "internal");
 
         Channel delegate = (_endpoint, _request) -> Futures.immediateFuture(deadlineResponse);
-        Channel channel = new DeadlineAdvertisementChannel(delegate, readTimeout);
+        Channel channel = DeadlineAdvertisementChannel.create(delegate, readTimeout);
 
         ListenableFuture<Response> response =
                 channel.execute(TestEndpoint.GET, Request.builder().build());
@@ -270,7 +270,7 @@ class DeadlineAdvertisementChannelTest {
         TestResponse normalResponse = new TestResponse().code(200);
 
         Channel delegate = (_endpoint, _request) -> Futures.immediateFuture(normalResponse);
-        Channel channel = new DeadlineAdvertisementChannel(delegate, readTimeout);
+        Channel channel = DeadlineAdvertisementChannel.create(delegate, readTimeout);
 
         ListenableFuture<Response> response =
                 channel.execute(TestEndpoint.GET, Request.builder().build());

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DeadlineAdvertisementChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DeadlineAdvertisementChannelTest.java
@@ -30,6 +30,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestEndpoint;
+import com.palantir.dialogue.TestResponse;
 import com.palantir.tracing.CloseableTracer;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -227,6 +228,53 @@ class DeadlineAdvertisementChannelTest {
             assertThat(request.headerParams().get("Expect-Within")).containsExactly("60.000");
             assertThat(request.headerParams().get("Expect-Within-Enforced")).containsExactly("false");
         });
+    }
+
+    @Test
+    void parses_external_deadline_expired_from_response() {
+        Duration readTimeout = Duration.ofSeconds(1);
+        TestResponse deadlineResponse =
+                new TestResponse().code(400).withHeader(DeadlinesHttpHeaders.DEADLINE_EXPIRED_REASON, "external");
+
+        Channel delegate = (_endpoint, _request) -> Futures.immediateFuture(deadlineResponse);
+        Channel channel = new DeadlineAdvertisementChannel(delegate, readTimeout);
+
+        ListenableFuture<Response> response =
+                channel.execute(TestEndpoint.GET, Request.builder().build());
+        assertThat(response).isDone();
+        assertThatExceptionOfType(ExecutionException.class)
+                .isThrownBy(response::get)
+                .withCauseInstanceOf(DeadlineExpiredException.External.class);
+    }
+
+    @Test
+    void parses_internal_deadline_expired_from_response() {
+        Duration readTimeout = Duration.ofSeconds(1);
+        TestResponse deadlineResponse =
+                new TestResponse().code(500).withHeader(DeadlinesHttpHeaders.DEADLINE_EXPIRED_REASON, "internal");
+
+        Channel delegate = (_endpoint, _request) -> Futures.immediateFuture(deadlineResponse);
+        Channel channel = new DeadlineAdvertisementChannel(delegate, readTimeout);
+
+        ListenableFuture<Response> response =
+                channel.execute(TestEndpoint.GET, Request.builder().build());
+        assertThat(response).isDone();
+        assertThatExceptionOfType(ExecutionException.class)
+                .isThrownBy(response::get)
+                .withCauseInstanceOf(DeadlineExpiredException.Internal.class);
+    }
+
+    @Test
+    void ignores_response_without_deadline_header() {
+        Duration readTimeout = Duration.ofSeconds(1);
+        TestResponse normalResponse = new TestResponse().code(200);
+
+        Channel delegate = (_endpoint, _request) -> Futures.immediateFuture(normalResponse);
+        Channel channel = new DeadlineAdvertisementChannel(delegate, readTimeout);
+
+        ListenableFuture<Response> response =
+                channel.execute(TestEndpoint.GET, Request.builder().build());
+        assertThat(response).succeedsWithin(Duration.ofSeconds(1)).isSameAs(normalResponse);
     }
 
     private enum Decoder implements RequestDecodingAdapter<Request> {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When DeadlineExpiredExceptions are thrown downstream, they are encoded in the response's headers, and this wasn't parsed correctly in Dialogue.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Dialogue properly parses DeadlineExpiredExceptions thrown downstream.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

