### PR TITLE
alternative implementation of deadline enforcement

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientChannels.java
@@ -124,6 +124,8 @@ public final class ApacheHttpClientChannels {
         return DialogueChannel.builder()
                 .channelName(channelName)
                 .clientConfiguration(conf)
+                // this is a legacy codepath; creating clients with optional deadline enforcement
+                // is only supported via dialogue-clients' ReloadingClientFactory
                 .factory(args -> createSingleUri(args, client))
                 .build();
     }

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelCache.java
@@ -21,7 +21,9 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.dialogue.core.DeadlineEnforcement;
 import com.palantir.dialogue.core.DialogueChannel;
+import com.palantir.dialogue.core.DialogueChannelFactory;
 import com.palantir.dialogue.core.DialogueDnsResolver;
 import com.palantir.dialogue.core.TargetUri;
 import com.palantir.dialogue.hc5.ApacheHttpClientChannels;
@@ -137,6 +139,7 @@ final class ChannelCache {
                 .dnsResolver(reloadingParams.dnsResolver())
                 .dnsRefreshInterval(reloadingParams.dnsRefreshInterval())
                 .dnsNodeDiscovery(overrideHostIndex.isEmpty() && reloadingParams.dnsNodeDiscovery())
+                .enforceDeadlines(reloadingParams.enforceDeadlines())
                 .build());
     }
 
@@ -172,6 +175,7 @@ final class ChannelCache {
                             dnsResolutionResults.resolvedHosts(),
                             channelCacheRequest.taggedMetrics()));
         }
+        DialogueChannelFactory factory = args -> ApacheHttpClientChannels.createSingleUri(args, apacheClient.client());
         return DialogueChannel.builder()
                 .channelName(channelCacheRequest.channelName())
                 .clientConfiguration(ClientConfiguration.builder()
@@ -179,7 +183,8 @@ final class ChannelCache {
                         .uris(channelCacheRequest.serviceConf().uris()) // restore uris
                         .build())
                 .uris(targets)
-                .factory(args -> ApacheHttpClientChannels.createSingleUri(args, apacheClient.client()))
+                .factory(DeadlineEnforcement.createDialogueChannelFactoryWithDeadlineEnforcement(
+                        channelCacheRequest.enforceDeadlines(), factory))
                 .overrideHostIndex(channelCacheRequest.overrideHostIndex().stream()
                         .mapToInt(OverrideHostIndex::index)
                         .findAny())
@@ -274,6 +279,8 @@ final class ChannelCache {
         Duration dnsRefreshInterval();
 
         boolean dnsNodeDiscovery();
+
+        Optional<Boolean> enforceDeadlines();
     }
 
     @Unsafe

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -208,6 +208,8 @@ public final class DialogueClients {
         StickyChannelFactory2 getStickyChannels2(String serviceName);
 
         PerHostClientFactory perHost(String serviceName);
+
+        ReloadingFactory withDeadlineEnforcement(boolean enforced);
     }
 
     private DialogueClients() {}

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -45,7 +45,9 @@ import com.palantir.dialogue.clients.DialogueClients.ReloadingFactory;
 import com.palantir.dialogue.clients.DialogueClients.StickyChannelFactory;
 import com.palantir.dialogue.clients.DialogueClients.StickyChannelFactory2;
 import com.palantir.dialogue.clients.DialogueClients.StickyChannelSession;
+import com.palantir.dialogue.core.DeadlineEnforcement;
 import com.palantir.dialogue.core.DialogueChannel;
+import com.palantir.dialogue.core.DialogueChannelFactory;
 import com.palantir.dialogue.core.DialogueDnsResolver;
 import com.palantir.dialogue.core.StickyEndpointChannels;
 import com.palantir.dialogue.core.TargetUri;
@@ -88,6 +90,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
                 .dnsResolver(params.dnsResolver());
         params.blockingExecutor().ifPresent(clientBuilder::executor);
         ApacheHttpClientChannels.CloseableClient apacheClient = clientBuilder.build();
+        DialogueChannelFactory factory = args -> ApacheHttpClientChannels.createSingleUri(args, apacheClient);
         return DialogueChannel.builder()
                 .channelName(channelName)
                 .clientConfiguration(clientConf)
@@ -104,7 +107,8 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
                                 dnsResult.config().proxy(),
                                 dnsResult.resolvedHosts(),
                                 params.taggedMetrics())))
-                .factory(args -> ApacheHttpClientChannels.createSingleUri(args, apacheClient))
+                .factory(DeadlineEnforcement.createDialogueChannelFactoryWithDeadlineEnforcement(
+                        params.enforceDeadlines(), factory))
                 .build();
     }
 
@@ -136,6 +140,8 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         }
 
         Optional<ExecutorService> blockingExecutor();
+
+        Optional<Boolean> enforceDeadlines();
     }
 
     @Override
@@ -397,6 +403,11 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
     @Override
     public ReloadingFactory withDnsNodeDiscovery(boolean dnsNodeDiscovery) {
         return new ReloadingClientFactory(params.withDnsNodeDiscovery(dnsNodeDiscovery), cache);
+    }
+
+    @Override
+    public ReloadingFactory withDeadlineEnforcement(boolean enforced) {
+        return new ReloadingClientFactory(params.withEnforceDeadlines(enforced), cache);
     }
 
     @Override

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineAdvertisementChannel.java
@@ -43,10 +43,12 @@ final class DeadlineAdvertisementChannel implements Channel {
 
     @Override
     public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+        Deadlines.Enforcement enforcement = DeadlineEnforcement.getDeadlineEnforcement(request)
+                .map(value -> value ? Deadlines.Enforcement.ENFORCE : Deadlines.Enforcement.DISABLE)
+                .orElse(Deadlines.Enforcement.DEFER);
         Request.Builder requestBuilder = Request.builder().from(request);
         try {
-            Deadlines.encodeToRequest(
-                    readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE, Deadlines.Enforcement.DEFER);
+            Deadlines.encodeToRequest(readTimeout, requestBuilder, RequestBuilderEncodingAdapter.INSTANCE, enforcement);
         } catch (DeadlineExpiredException e) {
             return Futures.immediateFailedFuture(e);
         }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineEnforcement.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DeadlineEnforcement.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.RequestAttachmentKey;
+import com.palantir.dialogue.Response;
+import java.util.Optional;
+
+/**
+ * A utility class for constructing a {@link DialogueChannelFactory} which optionally sets a deadline enforcement strategy.
+ * <p>
+ * This class is intended to be internal API, but is public so that classes within dialogue-clients can create a factory
+ * that sets an enforcement strategy when constructing clients.
+ */
+public final class DeadlineEnforcement {
+
+    private DeadlineEnforcement() {}
+
+    /**
+     * Create a {@link DialogueChannelFactory} wrapping an existing factory and optionally controls deadline enforcement.
+     * @param enforcement an {@link Optional} boolean indicating the deadline enforcement strategy. If absent, the
+     * default strategy is used. If false, deadline enforcement will be disabled; if true, enforcement will be
+     * enabled
+     * @param delegate a {@link DialogueChannelFactory} to wrap, such that channels created by this factory will be
+     * wrapped in a channel which sets the deadline enforcement strategy first
+     * @return a {@link DialogueChannelFactory} conforming to the above rules
+     */
+    // public so that this factory method can be called from dialogue-clients
+    public static DialogueChannelFactory createDialogueChannelFactoryWithDeadlineEnforcement(
+            Optional<Boolean> enforcement, DialogueChannelFactory delegate) {
+        if (enforcement.isEmpty()) {
+            return delegate;
+        }
+        return args -> {
+            Channel delegateChannel = delegate.create(args);
+            return new DeadlineEnforcementChannel(delegateChannel, enforcement.get());
+        };
+    }
+
+    private static final RequestAttachmentKey<Boolean> ATTACHMENT_KEY = RequestAttachmentKey.create(Boolean.class);
+
+    // this method is called by DeadlineAdvertisementChannel to read the enforcement strategy for the request
+    static Optional<Boolean> getDeadlineEnforcement(Request request) {
+        return Optional.ofNullable(request.attachments().getOrDefault(ATTACHMENT_KEY, null));
+    }
+
+    private static final class DeadlineEnforcementChannel implements Channel {
+        private final Channel delegate;
+        private final boolean enforcement;
+
+        private DeadlineEnforcementChannel(Channel delegate, boolean enforcement) {
+            this.delegate = delegate;
+            this.enforcement = enforcement;
+        }
+
+        @Override
+        public ListenableFuture<Response> execute(Endpoint endpoint, Request request) {
+            request.attachments().put(ATTACHMENT_KEY, enforcement);
+            return delegate.execute(endpoint, request);
+        }
+    }
+}


### PR DESCRIPTION
ReloadingClientFactory.ReloadingParams is modified to support an Optional<Boolean> indicating deadline enforcement. When a value is present, this dictates how we construct a DialogueChannelFactory which is passed to DialogueChannel's builder and used to construct channels.

This change adds a utility class DeadlineEnforcement which has a method for constructing a DialogueChannelFactory that wraps an existing factory and, dependeing on the value of the Optional<Boolean> from the reloading params, creates a channel which sets a request attachment indicating the enforcement strategy; this then wraps the channel created by the delegate factory.

DeadlineAdvertisementChannel looks for the request attachment to ultimately decide the deadline enforcement strategy to use.

Ideally the DeadlineEnforcement class could be made package-private, but dialogue-clients needs visibility to create the delegating DialogueChannelFactory, and DeadlineAdvertisementChannel also needs visibility in order to read the request attachment.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

