### PR TITLE
Clarify client response metric includes retries and queued time

### DIFF
--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -81,7 +81,9 @@ Dialogue URI parsing metrics.
 
 ### client
 General client metrics produced by dialogue. These metrics are meant to be applicable to all conjure clients without being implementation-specific.
-- `client.response` tagged `channel-name`, `service-name`, `endpoint`, `status` (timer): Request time split by status and endpoint. Possible status values are:
+- `client.response` tagged `channel-name`, `service-name`, `endpoint`, `status` (timer): Request time split by status and endpoint (measured as the time taken by the dialogue client method call,
+including retries, as well as queued time).
+Possible status values are:
 * success: 2xx requests, always excludes time spent reading the response body.
 * failure:
   - QoS failures (429, 308, 503)

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -10,7 +10,9 @@ namespaces:
         type: timer
         tags: [channel-name, service-name, endpoint, status]
         docs: |
-          Request time split by status and endpoint. Possible status values are:
+          Request time split by status and endpoint (measured as the time taken by the dialogue client method call,
+          including retries, as well as queued time).
+          Possible status values are:
           * success: 2xx requests, always excludes time spent reading the response body.
           * failure:
             - QoS failures (429, 308, 503)

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
@@ -48,6 +49,7 @@ import com.palantir.dialogue.TestEndpoint;
 import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.refreshable.Refreshable;
@@ -66,9 +68,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -355,6 +359,125 @@ public final class DialogueChannelTest {
         ListenableFuture<Response> future = channel.execute(endpoint, request);
         assertThatThrownBy(future::get).hasRootCauseInstanceOf(SafeUnknownHostException.class);
         assertThat(retries.getCount()).isEqualTo(maxRetries);
+    }
+
+    @Test
+    void client_response_timer_includes_retries() throws ExecutionException, InterruptedException {
+        String channelName = "my-channel";
+        int maxRetries = 2;
+        int sleepPerAttemptMillis = 300;
+
+        TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
+        DialogueClientMetrics dialogueClientMetrics = DialogueClientMetrics.of(metrics);
+        Meter retries = dialogueClientMetrics
+                .requestRetry()
+                .channelName(channelName)
+                .reason("SafeIoException")
+                .build();
+
+        ClientMetrics clientMetrics = ClientMetrics.of(metrics);
+        Timer responseTimer = clientMetrics
+                .response()
+                .channelName(channelName)
+                .serviceName(endpoint.serviceName())
+                .endpoint(endpoint.endpointName())
+                .status("success")
+                .build();
+
+        AtomicInteger channelInteractions = new AtomicInteger();
+        channel = DialogueChannel.builder()
+                .channelName(channelName)
+                .clientConfiguration(ClientConfiguration.builder()
+                        .from(stubConfig)
+                        .taggedMetricRegistry(metrics)
+                        .maxNumRetries(maxRetries)
+                        .backoffSlotSize(Duration.ZERO)
+                        .build())
+                .factory(_args -> (_endpoint, _currentRequest) -> {
+                    int interactions = channelInteractions.incrementAndGet();
+                    if (interactions > maxRetries) {
+                        return Futures.immediateFuture(new TestResponse()
+                                .code(204)
+                                .withHeader("Interactions", Integer.toString(interactions)));
+                    }
+                    return Futures.submit(
+                            () -> {
+                                Thread.sleep(sleepPerAttemptMillis);
+                                throw new SafeIoException("FAILED");
+                            },
+                            Executors.newSingleThreadExecutor());
+                })
+                .build();
+
+        ListenableFuture<Response> future =
+                channel.execute(endpoint, Request.builder().build());
+        assertThat(future.get()).isInstanceOf(TestResponse.class);
+        assertThat(future.get().getFirstHeader("Interactions")).hasValue(String.valueOf(maxRetries + 1));
+
+        assertThat(retries.getCount()).isEqualTo(maxRetries);
+        assertThat(responseTimer.getCount()).isEqualTo(1);
+        assertThat(responseTimer.getSnapshot().get95thPercentile())
+                .isCloseTo(((double) sleepPerAttemptMillis) * maxRetries * 1_000_000, Percentage.withPercentage(20.0));
+    }
+
+    @Test
+    void client_response_timer_includes_queued_time() throws ExecutionException, InterruptedException {
+        String channelName = "my-channel";
+        int sleepPerAttemptMillis = 1000;
+
+        TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
+        DialogueClientMetrics dialogueClientMetrics = DialogueClientMetrics.of(metrics);
+        Timer queuedTime = dialogueClientMetrics.requestQueuedTime(channelName);
+
+        ClientMetrics clientMetrics = ClientMetrics.of(metrics);
+        Timer responseTimer = clientMetrics
+                .response()
+                .channelName(channelName)
+                .serviceName(endpoint.serviceName())
+                .endpoint(endpoint.endpointName())
+                .status("success")
+                .build();
+        AtomicInteger channelInteractions = new AtomicInteger();
+        channel = DialogueChannel.builder()
+                .channelName(channelName)
+                .clientConfiguration(ClientConfiguration.builder()
+                        .from(stubConfig)
+                        .taggedMetricRegistry(metrics)
+                        .build())
+                .factory(_args -> (_endpoint, _currentRequest) -> {
+                    int interactions = channelInteractions.incrementAndGet();
+                    return Futures.submit(
+                            () -> {
+                                Thread.sleep(sleepPerAttemptMillis);
+                                return new TestResponse()
+                                        .code(204)
+                                        .withHeader("Interactions", Integer.toString(interactions));
+                            },
+                            Executors.newSingleThreadExecutor());
+                })
+                .build();
+
+        // Fill the concurrency limiter
+        int initialConcurrencyLimit = 20;
+        for (int i = 0; i < initialConcurrencyLimit; i++) {
+            ListenableFuture<Response> running = channel.execute(endpoint, request);
+            assertThat(running).isNotDone();
+        }
+
+        ListenableFuture<Response> futureQueued = channel.execute(endpoint, request);
+
+        assertThat(futureQueued.get()).isInstanceOf(TestResponse.class);
+        assertThat(futureQueued.get().getFirstHeader("Interactions")).hasValue("21");
+
+        // One request will have been queued, for roughly the time it takes to respond
+        assertThat(queuedTime.getCount()).isEqualTo(1);
+        assertThat(queuedTime.getSnapshot().get95thPercentile())
+                .isCloseTo((double) sleepPerAttemptMillis * 1_000_000, Percentage.withPercentage(20.0));
+
+        // We'll however see the response timer include the queued time, and account for twice the response time
+        assertThat(responseTimer.getCount()).isEqualTo(21);
+        assertThat(responseTimer.getSnapshot().get99thPercentile())
+                .isCloseTo(((double) sleepPerAttemptMillis) * 2 * 1_000_000, Percentage.withPercentage(20.0));
     }
 
     @Test

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/DialogueChannelTest.java
@@ -414,6 +414,7 @@ public final class DialogueChannelTest {
         assertThat(future.get()).isInstanceOf(TestResponse.class);
         assertThat(future.get().getFirstHeader("Interactions")).hasValue(String.valueOf(maxRetries + 1));
 
+        // The request is retried twice, and thus the timer should include the time taken for all attempts.
         assertThat(retries.getCount()).isEqualTo(maxRetries);
         assertThat(responseTimer.getCount()).isEqualTo(1);
         assertThat(responseTimer.getSnapshot().get95thPercentile())
@@ -423,7 +424,7 @@ public final class DialogueChannelTest {
     @Test
     void client_response_timer_includes_queued_time() throws ExecutionException, InterruptedException {
         String channelName = "my-channel";
-        int sleepPerAttemptMillis = 1000;
+        int sleepPerAttemptMillis = 300;
 
         TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
         DialogueClientMetrics dialogueClientMetrics = DialogueClientMetrics.of(metrics);


### PR DESCRIPTION
## Before this PR
It is not clear, and possibly surprising, that the client.response timer metric also includes the retries as well as the queued time (i.e. it measures the time from the method call, not the individual time each network request took).

## After this PR
==COMMIT_MSG==
Clarify client response metric includes retries and queued time
==COMMIT_MSG==

This also adds tests to clearly verify this behavior

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

