### PR TITLE
Client should not await the readTimeout twice when server is unresponsive

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/InstrumentedManagedHttpClientConnection.java
@@ -179,6 +179,19 @@ final class InstrumentedManagedHttpClientConnection implements ManagedHttpClient
 
     @Override
     public void close(CloseMode closeMode) {
+        if (closeMode == CloseMode.IMMEDIATE) {
+            // When the connection is being closed in IMMEDIATE mode, we want to avoid any blocking read calls.
+            // In particular, SSLSocketImpl's close method tries to read any remaining data from the input stream
+            //   to complete the SSL/TLS closure handshake. By setting a very short socket timeout,
+            //   we ensure that any read operations will time out almost immediately, allowing for a prompt closure
+            //   of the connection without unnecessary delays.
+            // See also https://github.com/apache/httpcomponents-core/pull/573 which proposes to do the same
+            //   in the downstream BHttpConnectionBase.close method.
+            // We use ONE_MILLISECOND here instead of ZERO because 0 is interpreted as an infinite timeout.
+            // Note that this should not be a problem once we upgrade http-client to 5.4+, but is still a good default
+            //   to have.
+            setSocketTimeout(Timeout.ONE_MILLISECOND);
+        }
         delegate.close(closeMode);
     }
 

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsIntegrationTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/otherpackage/DialogueClientsIntegrationTest.java
@@ -21,11 +21,13 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.conjure.java.api.config.service.HumanReadableDuration;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
@@ -34,6 +36,7 @@ import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.client.config.ClientConfigurations;
 import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.dialogue.DialogueException;
 import com.palantir.dialogue.TestConfigurations;
 import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.dialogue.clients.DialogueClients.ReloadingFactory;
@@ -49,6 +52,7 @@ import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.BlockingHandler;
 import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,6 +62,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -65,6 +71,7 @@ import java.util.stream.IntStream;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
+import org.assertj.core.data.Percentage;
 import org.immutables.value.Value;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -126,6 +133,40 @@ public class DialogueClientsIntegrationTest {
         assertThatThrownBy(() -> DialogueClients.create(Refreshable.only(null))
                         .getNonReloading(SampleServiceAsync.class, serviceConfig))
                 .hasMessageContaining("userAgent must be specified");
+    }
+
+    @Test
+    void timeout_is_respected() {
+        Duration readTimeout = Duration.ofSeconds(1);
+
+        CountDownLatch requestDone = new CountDownLatch(1);
+        undertowHandler = exchange -> {
+            // Block the response until the test is complete
+            // If we haven't finished within 3x the read timeout, something is wrong, so we give up waiting.
+            requestDone.await(readTimeout.toMillis() * 3, TimeUnit.MILLISECONDS);
+            exchange.setStatusCode(200);
+        };
+        ServicesConfigBlock badScb = ServicesConfigBlock.builder()
+                .from(scb)
+                .defaultReadTimeout(HumanReadableDuration.seconds(readTimeout.toSeconds()))
+                .build();
+        SettableRefreshable<ServicesConfigBlock> refreshable = Refreshable.create(badScb);
+
+        DialogueClients.ReloadingFactory factory =
+                DialogueClients.create(refreshable).withUserAgent(TestConfigurations.AGENT);
+
+        SampleServiceBlocking client = factory.get(SampleServiceBlocking.class, "foo");
+
+        Ticker ticker = Ticker.systemTicker();
+        long startNanos = ticker.read();
+        assertThatThrownBy(client::voidToVoid)
+                .isInstanceOf(DialogueException.class)
+                .hasCauseInstanceOf(SocketTimeoutException.class);
+        Duration elapsed = Duration.ofNanos(ticker.read() - startNanos);
+        assertThat(elapsed.toMillis()).isCloseTo(readTimeout.toMillis(), Percentage.withPercentage(20));
+
+        // Now that we're done, allow the server to respond and shutdown cleanly.
+        requestDone.countDown();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Dialogue uses the configured `readTimeout` as the underlying Apache HTTP client's socket timeout.

Getting a `SocketTimeoutException` upon reading from the socket will end up going through [`HttpRequestExecutor`'s cleanup, which attempts to close the connection by calling `close(CloseMode.IMMEDIATE)`](https://github.com/apache/httpcomponents-core/blob/1ee9e0875fca9f5cb369a54f23ae8aa41b1f2327/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java#L221) (since https://github.com/apache/httpcomponents-core/pull/508).

However, when used with an SSL connection, especially when using http-client 5.3 (which might get fixed once https://github.com/palantir/dialogue/pull/2348 is picked back up and merged), because the [baseSocket here](https://github.com/apache/httpcomponents-core/blob/1ee9e0875fca9f5cb369a54f23ae8aa41b1f2327/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/BHttpConnectionBase.java#L235-L236) is [actually an `SSLSocket`](https://github.com/apache/httpcomponents-client/blob/rel/v5.3.1/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java#L189-L190), this causes [the `Closer.closeQuietly(baseSocket);` call](https://github.com/apache/httpcomponents-core/blob/1ee9e0875fca9f5cb369a54f23ae8aa41b1f2327/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/BHttpConnectionBase.java#L243) to try to clean up the SSL state, which will potentially hang up to the configured `socketTimeout`.

## After this PR
==COMMIT_MSG==
Client should not await the readTimeout twice when server is unresponsive
==COMMIT_MSG==

## Possible downsides?
We should probably not put this in `InstrumentedManagedHttpClientConnection` and should instead put it in another intermediary layer, but this is simpler and hopefully becomes unnecessary once either https://github.com/apache/httpcomponents-core/pull/573 gets merged, or we bump the http-client dependency through something akin to https://github.com/palantir/dialogue/pull/2348 (at which point we can probably get rid of this)

