### PR TITLE
Downgrade Caffeine and remove gradle hack trying to force down error-prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,12 +69,6 @@ allprojects {
     }
     configurations.all {
         resolutionStrategy.preferProjectModules()
-        resolutionStrategy.eachDependency { details ->
-            if (details.requested.group == 'com.google.errorprone' && details.requested.name == 'error_prone_annotations') {
-                details.useTarget group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.7.1'
-                details.because "The error_prone_annotations dependency must be low to avoid forcing consumers to use newer releases"
-            }
-        }
     }
 }
 

--- a/versions.lock
+++ b/versions.lock
@@ -18,13 +18,13 @@ com.fasterxml.jackson.datatype:jackson-datatype-joda:2.20.0 (1 constraints: 841c
 
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.0 (1 constraints: 841cada4)
 
-com.github.ben-manes.caffeine:caffeine:3.2.3 (3 constraints: 0128d133)
+com.github.ben-manes.caffeine:caffeine:3.2.2 (3 constraints: 00286e33)
 
 com.google.auto:auto-common:1.2.2 (1 constraints: 181210fb)
 
 com.google.code.findbugs:jsr305:3.0.2 (9 constraints: 0e9ceffe)
 
-com.google.errorprone:error_prone_annotations:2.7.1 (19 constraints: f22e1864)
+com.google.errorprone:error_prone_annotations:2.41.0 (19 constraints: ef2e645a)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 

--- a/versions.props
+++ b/versions.props
@@ -26,7 +26,7 @@ org.derive4j:* = 1.1.1
 org.immutables:* = 2.11.6
 org.junit.platform:* = 6.0.0
 org.slf4j:* = 2.0.17
-com.github.ben-manes.caffeine:caffeine = 3.2.3
+com.github.ben-manes.caffeine:caffeine = 3.2.2
 
 # test deps
 org.junit.jupiter:* = 6.0.0


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/dialogue/pull/2769 bumped Caffeine to 3.2.3, which actually bumps error-prone to 2.43.0, which [requires compiling with jdk 21](https://github.com/google/error-prone/releases/tag/v2.43.0).

https://github.com/palantir/dialogue/blob/6c9acee2b665968ed0494db1f9567f8d3d3401ea/build.gradle#L72-L77 forces our version of error-prone-annotations down to a pretty low version, trying to avoid bumping it transitively, but this doesn't actually work, and instead gets bumped transitively anyway in downstream consumers, due to bumping Caffeine.

If we didn't have this, we would instead have been clear that error-prone would have been bumped and probably failed the bump itself, thereby actually protecting downstream consumers.

We don't have a direct versions.props constraint on error-prone, so we just get it transitively from other deps, meaning we're already at the lowest we could get anyway.

## After this PR
==COMMIT_MSG==
Downgrade Caffeine and remove gradle hack trying to force down error-prone
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

