### PR TITLE
Improve ExceptionDeserializingErrorDecoder logs and remove unused constructors

### DIFF
--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -107,7 +107,9 @@ final class ConjureBodySerDe implements BodySerDe {
                         key.type(),
                         emptyContainerDeserializer,
                         key.args().returnType(),
-                        new ExceptionDeserializingErrorDecoder(key.args().errorNameToExceptionTypeMarkers())));
+                        new ExceptionDeserializingErrorDecoder(
+                                key.args().errorNameToExceptionTypeMarkers(),
+                                errorParameterFormat().isPresent())));
     }
 
     @SuppressWarnings("unchecked")

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -23,6 +23,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.net.HttpHeaders;
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.Deserializer;
@@ -108,8 +109,7 @@ final class ConjureBodySerDe implements BodySerDe {
                         emptyContainerDeserializer,
                         key.args().returnType(),
                         new ExceptionDeserializingErrorDecoder(
-                                key.args().errorNameToExceptionTypeMarkers(),
-                                errorParameterFormat().isPresent())));
+                                key.args().errorNameToExceptionTypeMarkers(), expectJsonErrors())));
     }
 
     @SuppressWarnings("unchecked")
@@ -234,6 +234,11 @@ final class ConjureBodySerDe implements BodySerDe {
                 }
             }
         };
+    }
+
+    private boolean expectJsonErrors() {
+        return errorParameterFormat().isPresent()
+                && errorParameterFormat().get().equals(ConjureErrorParameterFormat.JSON_FORMAT);
     }
 
     private static final class EncodingSerializerRegistry<T> implements Serializer<T> {

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ErrorDecoder.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.java.dialogue.serde;
 
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.dialogue.Response;
-import java.util.Collections;
 
 /**
  * Extracts and returns a {@link RemoteException} from an {@link Response}.
@@ -30,7 +29,7 @@ public enum ErrorDecoder {
     INSTANCE;
 
     private static final ExceptionDeserializingErrorDecoder EXCEPTION_DESERIALIZING_ERROR_DECODER =
-            new ExceptionDeserializingErrorDecoder(Collections.emptyMap());
+            ExceptionDeserializingErrorDecoder.withoutExceptions();
 
     public boolean isError(Response response) {
         return EXCEPTION_DESERIALIZING_ERROR_DECODER.isError(response);

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
@@ -172,7 +172,7 @@ final class ExceptionDeserializingErrorDecoder {
         }
     }
 
-    private RuntimeException jsonExceptionFromBody(byte[] body, int code) throws IOException {
+    private RemoteException jsonExceptionFromBody(byte[] body, int code) throws IOException {
         String errorName = extractErrorName(body);
         if (errorName == null) {
             // Per the Conjure spec, errorName is required. We fall back to creating a RemoteException to handle

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
@@ -143,7 +143,7 @@ final class ExceptionDeserializingErrorDecoder {
         try (InputStream bodyStream = response.body()) {
             body = bodyStream.readAllBytes();
         } catch (NullPointerException | IOException e) {
-            UnknownRemoteException exception = new UnknownRemoteException(code, "<unreadable>");
+            UnknownRemoteException exception = new UnknownRemoteException(code, "<unparseable>");
             exception.initCause(e);
             return exception;
         }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
@@ -74,22 +74,20 @@ final class ExceptionDeserializingErrorDecoder {
             JSON_ENCODING.deserializer(new TypeMarker<>() {});
     private static final Deserializer<SerializableError> SERIALIZABLE_ERROR_DESERIALIZER =
             JSON_ENCODING.deserializer(new TypeMarker<>() {});
+
     private final Map<String, DeserializerExceptionPair<?, ?>> errorNameToExceptionDeserializerMap;
+    private final boolean expectRichErrors;
 
     static ExceptionDeserializingErrorDecoder withoutExceptions() {
-        return new ExceptionDeserializingErrorDecoder(Collections.emptyMap());
-    }
-
-    ExceptionDeserializingErrorDecoder(Map<String, ErrorExceptionPair<?, ?>> errorNameToExceptionTypeMap) {
-        this(errorNameToExceptionTypeMap, Optional.empty());
+        return new ExceptionDeserializingErrorDecoder(Collections.emptyMap(), false);
     }
 
     ExceptionDeserializingErrorDecoder(
-            Map<String, ErrorExceptionPair<?, ?>> errorNameToExceptionTypeMap, Optional<Encoding> maybeJsonEncoding) {
+            Map<String, ErrorExceptionPair<?, ?>> errorNameToExceptionTypeMap, boolean expectRichErrors) {
         this.errorNameToExceptionDeserializerMap = ImmutableMap.copyOf(Maps.transformValues(
                 errorNameToExceptionTypeMap,
-                errorExceptionPair ->
-                        createDeserializerForException(maybeJsonEncoding.orElse(JSON_ENCODING), errorExceptionPair)));
+                errorExceptionPair -> createDeserializerForException(JSON_ENCODING, errorExceptionPair)));
+        this.expectRichErrors = expectRichErrors;
     }
 
     boolean isError(Response response) {
@@ -145,46 +143,72 @@ final class ExceptionDeserializingErrorDecoder {
         try (InputStream bodyStream = response.body()) {
             body = bodyStream.readAllBytes();
         } catch (NullPointerException | IOException e) {
-            UnknownRemoteException exception = new UnknownRemoteException(code, "<unparseable>");
+            UnknownRemoteException exception = new UnknownRemoteException(code, "<unreadable>");
             exception.initCause(e);
             return exception;
         }
 
+        if (log.isDebugEnabled()) {
+            log.debug("Read error response body", UnsafeArg.of("body", new String(body, StandardCharsets.UTF_8)));
+        }
+
         Optional<String> contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);
         if (contentType.isEmpty() || !Encodings.matchesContentType(JSON_ENCODING.getContentType(), contentType.get())) {
-            return new UnknownRemoteException(code, new String(body, StandardCharsets.UTF_8));
+            String stringBody = new String(body, StandardCharsets.UTF_8);
+            log.debug(
+                    "Error response body had missing or non-JSON content-type, cannot deserialize error",
+                    UnsafeArg.of("contentType", contentType.orElse("<missing>")),
+                    UnsafeArg.of("body", stringBody));
+            return new UnknownRemoteException(code, stringBody);
         }
 
         try {
-            String errorName = extractErrorName(body);
-            if (errorName == null) {
-                // Per the Conjure spec, errorName is required. We fall back to creating a RemoteException to handle
-                // legacy errors that used a "message" field instead of "errorName".
-                return createRemoteException(body, code);
-            }
-            DeserializerExceptionPair<?, ?> deserializerExceptionPair =
-                    errorNameToExceptionDeserializerMap.get(errorName);
-            if (deserializerExceptionPair == null) {
-                return createRemoteException(body, code);
-            }
-            // Attempt to deserialize the error using the deserializer for the specific exception type.
-            try {
-                // The concrete error type is a subtype of AbstractSerializableError<?> at runtime.
-                // AbstractSerializableError is an abstract class.
-                AbstractSerializableError<?> error =
-                        deserializerExceptionPair.deserializer().deserialize(new ByteArrayInputStream(body));
-                return ErrorExceptionPair.getExceptionFromSerializableError(
-                        error, deserializerExceptionPair.exceptionType(), code);
-            } catch (Exception e) {
-                // If we're unable to deserialize the error as JSON, throw a RemoteException.
-                log.error("Failed to deserialize error response as exception", SafeArg.of("errorName", errorName), e);
-                return createRemoteException(body, code);
-            }
+            return jsonExceptionFromBody(body, code);
         } catch (Exception e) {
             UnknownRemoteException unknownRemoteException =
                     new UnknownRemoteException(code, new String(body, StandardCharsets.UTF_8));
             unknownRemoteException.initCause(e);
             return unknownRemoteException;
+        }
+    }
+
+    private RuntimeException jsonExceptionFromBody(byte[] body, int code) throws IOException {
+        String errorName = extractErrorName(body);
+        if (errorName == null) {
+            // Per the Conjure spec, errorName is required. We fall back to creating a RemoteException to handle
+            // legacy errors that used a "message" field instead of "errorName".
+            log.debug("Could not find errorName field in error response body - falling back to RemoteException");
+            return createRemoteException(body, code);
+        }
+        DeserializerExceptionPair<?, ?> deserializerExceptionPair = errorNameToExceptionDeserializerMap.get(errorName);
+        if (deserializerExceptionPair == null) {
+            log.debug(
+                    "No deserializer found for error name - falling back to RemoteException",
+                    SafeArg.of("errorName", errorName));
+            return createRemoteException(body, code);
+        }
+        // Attempt to deserialize the error using the deserializer for the specific exception type.
+        try {
+            // The concrete error type is a subtype of AbstractSerializableError<?> at runtime.
+            // AbstractSerializableError is an abstract class.
+            AbstractSerializableError<?> error =
+                    deserializerExceptionPair.deserializer().deserialize(new ByteArrayInputStream(body));
+            return ErrorExceptionPair.getExceptionFromSerializableError(
+                    error, deserializerExceptionPair.exceptionType(), code);
+        } catch (Exception e) {
+            // If we're unable to deserialize the error as JSON, throw a RemoteException.
+            if (expectRichErrors) {
+                log.error(
+                        "Failed to deserialize error response as exception - falling back to RemoteException",
+                        SafeArg.of("errorName", errorName),
+                        e);
+            } else if (log.isDebugEnabled()) {
+                log.debug(
+                        "Failed to deserialize error response as exception - falling back to RemoteException",
+                        SafeArg.of("errorName", errorName),
+                        e);
+            }
+            return createRemoteException(body, code);
         }
     }
 

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
@@ -155,10 +155,12 @@ final class ExceptionDeserializingErrorDecoder {
         Optional<String> contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);
         if (contentType.isEmpty() || !Encodings.matchesContentType(JSON_ENCODING.getContentType(), contentType.get())) {
             String stringBody = new String(body, StandardCharsets.UTF_8);
-            log.debug(
-                    "Error response body had missing or non-JSON content-type, cannot deserialize error",
-                    UnsafeArg.of("contentType", contentType.orElse("<missing>")),
-                    UnsafeArg.of("body", stringBody));
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Error response body had missing or non-JSON content-type, cannot deserialize error",
+                        UnsafeArg.of("contentType", contentType.orElse("<missing>")),
+                        UnsafeArg.of("body", stringBody));
+            }
             return new UnknownRemoteException(code, stringBody);
         }
 
@@ -182,9 +184,11 @@ final class ExceptionDeserializingErrorDecoder {
         }
         DeserializerExceptionPair<?, ?> deserializerExceptionPair = errorNameToExceptionDeserializerMap.get(errorName);
         if (deserializerExceptionPair == null) {
-            log.debug(
-                    "No deserializer found for error name - falling back to RemoteException",
-                    SafeArg.of("errorName", errorName));
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "No deserializer found for error name - falling back to RemoteException",
+                        SafeArg.of("errorName", errorName));
+            }
             return createRemoteException(body, code);
         }
         // Attempt to deserialize the error using the deserializer for the specific exception type.

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
@@ -148,13 +148,18 @@ final class ExceptionDeserializingErrorDecoder {
             return exception;
         }
 
+        String stringBody = null;
         if (log.isDebugEnabled()) {
-            log.debug("Read error response body", UnsafeArg.of("body", new String(body, StandardCharsets.UTF_8)));
+            stringBody = new String(body, StandardCharsets.UTF_8);
+            log.debug("Read error response body", UnsafeArg.of("body", stringBody));
         }
 
         Optional<String> contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);
         if (contentType.isEmpty() || !Encodings.matchesContentType(JSON_ENCODING.getContentType(), contentType.get())) {
-            String stringBody = new String(body, StandardCharsets.UTF_8);
+            if (stringBody == null) {
+                // Only convert to string if we haven't already done so
+                stringBody = new String(body, StandardCharsets.UTF_8);
+            }
             if (log.isDebugEnabled()) {
                 log.debug(
                         "Error response body had missing or non-JSON content-type, cannot deserialize error",
@@ -167,8 +172,11 @@ final class ExceptionDeserializingErrorDecoder {
         try {
             return jsonExceptionFromBody(body, code);
         } catch (Exception e) {
-            UnknownRemoteException unknownRemoteException =
-                    new UnknownRemoteException(code, new String(body, StandardCharsets.UTF_8));
+            if (stringBody == null) {
+                // Only convert to string if we haven't already done so
+                stringBody = new String(body, StandardCharsets.UTF_8);
+            }
+            UnknownRemoteException unknownRemoteException = new UnknownRemoteException(code, stringBody);
             unknownRemoteException.initCause(e);
             return unknownRemoteException;
         }

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
@@ -76,18 +76,18 @@ final class ExceptionDeserializingErrorDecoder {
             JSON_ENCODING.deserializer(new TypeMarker<>() {});
 
     private final Map<String, DeserializerExceptionPair<?, ?>> errorNameToExceptionDeserializerMap;
-    private final boolean expectRichErrors;
+    private final boolean expectJsonErrors;
 
     static ExceptionDeserializingErrorDecoder withoutExceptions() {
         return new ExceptionDeserializingErrorDecoder(Collections.emptyMap(), false);
     }
 
     ExceptionDeserializingErrorDecoder(
-            Map<String, ErrorExceptionPair<?, ?>> errorNameToExceptionTypeMap, boolean expectRichErrors) {
+            Map<String, ErrorExceptionPair<?, ?>> errorNameToExceptionTypeMap, boolean expectJsonErrors) {
         this.errorNameToExceptionDeserializerMap = ImmutableMap.copyOf(Maps.transformValues(
                 errorNameToExceptionTypeMap,
                 errorExceptionPair -> createDeserializerForException(JSON_ENCODING, errorExceptionPair)));
-        this.expectRichErrors = expectRichErrors;
+        this.expectJsonErrors = expectJsonErrors;
     }
 
     boolean isError(Response response) {
@@ -197,7 +197,7 @@ final class ExceptionDeserializingErrorDecoder {
                     error, deserializerExceptionPair.exceptionType(), code);
         } catch (Exception e) {
             // If we're unable to deserialize the error as JSON, throw a RemoteException.
-            if (expectRichErrors) {
+            if (expectJsonErrors) {
                 log.error(
                         "Failed to deserialize error response as exception - falling back to RemoteException",
                         SafeArg.of("errorName", errorName),


### PR DESCRIPTION
## Before this PR
The `ExceptionDeserializingErrorDecoder` decode logic logs an error when using a the client has registered rich exception types, but didn't receive json errors from the server.

This is desirable _only_ if the client actually _requested_ the server to send json errors, rather than just being able to deserialize them, which isn't always the case, and can lead to confusion.

## After this PR
==COMMIT_MSG==
Improve ExceptionDeserializingErrorDecoder logs and remove unused constructors
==COMMIT_MSG==

This
- Adds a boolean to `ExceptionDeserializingErrorDecoder` to indicate whether we should expect to receive back json errors for rich exceptions we know about (i.e. if we have sent the json error format header)
  - Updates the error log to log as debug if we didn't send that header
- Adds some additional debug logs to facilitate debugging this workflow in the future if needed
- Refactors out by splitting into two methods to reduce cyclomatic complexity

Another approach _could_ be to directly deserialize as a `RemoteException` if we didn't send the header, but this is better since it lets us support the server sending json errors regardless of the request headers.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

