### PR TITLE
Add metrics to track exhausted retries and retry counts

### DIFF
--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -100,9 +100,12 @@ Instrumentation for BalancedChannel internals.
 Dialogue-specific metrics that are not necessarily applicable to other client implementations.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
-- `dialogue.client.request.retry.count` tagged `channel-name` (histogram): Distribution of retry counts per request. Only recorded for requests that required at least one retry
-and eventually received a response (not recorded for requests that fail with an exception).
+- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for requests that required at least one retry. The result tag of 
+"success" indicates that the request eventually received a response, while "failure" indicates that there was 
+no response received from the server (e.g. the connection timed out).
 
+  - `channel-name`
+  - `result` values (`success`,`failure`)
 - `dialogue.client.request.retry.exhausted` tagged `channel-name`, `reason` (counter): Count of requests that exhaust all retry attempts without receiving a successful response. The reason is 
 populated with the reason for which the last retry has failed.
 

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -100,7 +100,9 @@ Instrumentation for BalancedChannel internals.
 Dialogue-specific metrics that are not necessarily applicable to other client implementations.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
-- `dialogue.client.request.retry.count` tagged `channel-name` (histogram): Distribution of retry counts per request. Only recorded for requests that required at least one retry.
+- `dialogue.client.request.retry.count` tagged `channel-name` (histogram): Distribution of retry counts per request. Only recorded for requests that required at least one retry
+and eventually received a response (not recorded for requests that fail with an exception).
+
 - `dialogue.client.request.retry.exhausted` tagged `channel-name`, `reason` (counter): Count of requests that exhaust all retry attempts without receiving a successful response. The reason is 
 populated with the reason for which the last retry has failed.
 

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -100,14 +100,15 @@ Instrumentation for BalancedChannel internals.
 Dialogue-specific metrics that are not necessarily applicable to other client implementations.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
-- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for retryable requests. The result tag indicates the terminal
-state: "success" means the request eventually received a successful (2xx) response, "non-retryable" means
-the request received a non-retryable response (e.g. 4xx) before exhausting retries, and "failure" means
-retries were exhausted due to retryable errors (e.g. 429, 503, socket read timeout).
+- `dialogue.client.request.retry.count` (histogram): Distribution of failed attempt counts per request. The value recorded is the number of failed attempts
+before the terminal result. For "success", this equals the number of retries before a 2xx response.
+For "failure" (retries exhausted), this equals maxRetries + 1 since the final attempt also failed.
+For "non-retryable", this is the number of retryable failures before receiving a non-retryable response
+(e.g. 4xx), or 0 if the request itself was not retryable (e.g. non-repeatable body).
 
   - `channel-name`
   - `result` values (`success`,`failure`,`non-retryable`)
-- `dialogue.client.request.retry.exhausted` tagged `channel-name`, `reason` (counter): Count of requests that exhaust all retry attempts without receiving a successful response. The reason is 
+- `dialogue.client.request.retry.exhausted` tagged `channel-name`, `reason` (counter): Count of requests that exhaust all retry attempts without receiving a successful response. The reason is
 populated with the reason for which the last retry has failed.
 
 - `dialogue.client.requests.queued` tagged `channel-name` (counter): Number of queued requests waiting to execute.

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -100,13 +100,13 @@ Instrumentation for BalancedChannel internals.
 Dialogue-specific metrics that are not necessarily applicable to other client implementations.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
-- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that
-the request eventually received a successful (2xx) response, while "failure" indicates that the request
-ultimately completed with a non-successful response (e.g. 429, 503) or no response at all (e.g. socket
-read timeout).
+- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for retryable requests. The result tag indicates the terminal
+state: "success" means the request eventually received a successful (2xx) response, "non-retryable" means
+the request received a non-retryable response (e.g. 4xx) before exhausting retries, and "failure" means
+retries were exhausted due to retryable errors (e.g. 429, 503, socket read timeout).
 
   - `channel-name`
-  - `result` values (`success`,`failure`)
+  - `result` values (`success`,`failure`,`non-retryable`)
 - `dialogue.client.request.retry.exhausted` tagged `channel-name`, `reason` (counter): Count of requests that exhaust all retry attempts without receiving a successful response. The reason is 
 populated with the reason for which the last retry has failed.
 

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -102,7 +102,7 @@ Dialogue-specific metrics that are not necessarily applicable to other client im
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
 - `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for requests that required at least one retry. The result tag of 
 "success" indicates that the request eventually received a response, while "failure" indicates that there was 
-no response received from the server (e.g. the connection timed out).
+no response received from the server (e.g. socket read timeout).
 
   - `channel-name`
   - `result` values (`success`,`failure`)

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -100,9 +100,9 @@ Instrumentation for BalancedChannel internals.
 Dialogue-specific metrics that are not necessarily applicable to other client implementations.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
-- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for requests that required at least one retry. The result tag of 
-"success" indicates that the request eventually received a response, while "failure" indicates that there was 
-no response received from the server (e.g. socket read timeout).
+- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that 
+the request eventually received a response, while "failure" indicates that there was no response received 
+from the server (e.g. socket read timeout).
 
   - `channel-name`
   - `result` values (`success`,`failure`)

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -100,6 +100,10 @@ Instrumentation for BalancedChannel internals.
 Dialogue-specific metrics that are not necessarily applicable to other client implementations.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
+- `dialogue.client.request.retry.count` tagged `channel-name` (histogram): Distribution of retry counts per request. Only recorded for requests that required at least one retry.
+- `dialogue.client.request.retry.exhausted` tagged `channel-name`, `reason` (counter): Count of requests that exhaust all retry attempts without receiving a successful response. The reason is 
+populated with the reason for which the last retry has failed.
+
 - `dialogue.client.requests.queued` tagged `channel-name` (counter): Number of queued requests waiting to execute.
 - `dialogue.client.requests.endpoint.queued` tagged `channel-name`, `service-name`, `endpoint` (counter): Number of queued requests waiting to execute for a specific endpoint due to server QoS.
 - `dialogue.client.requests.sticky.queued` tagged `channel-name` (counter): Number of sticky queued requests waiting to try to be executed.

--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -100,9 +100,10 @@ Instrumentation for BalancedChannel internals.
 Dialogue-specific metrics that are not necessarily applicable to other client implementations.
 - `dialogue.client.response.leak` tagged `client-name`, `service-name`, `endpoint` (meter): Rate that responses are garbage collected without being closed. This should only occur in the case of a programming error.
 - `dialogue.client.request.retry` tagged `channel-name`, `reason` (meter): Rate at which the RetryingChannel retries requests (across all endpoints).
-- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that 
-the request eventually received a response, while "failure" indicates that there was no response received 
-from the server (e.g. socket read timeout).
+- `dialogue.client.request.retry.count` (histogram): Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that
+the request eventually received a successful (2xx) response, while "failure" indicates that the request
+ultimately completed with a non-successful response (e.g. 429, 503) or no response at all (e.g. socket
+read timeout).
 
   - `channel-name`
   - `result` values (`success`,`failure`)

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -287,13 +287,16 @@ final class RetryingChannel implements EndpointChannel {
             DialogueFutures.addDirectCallback(result, new FutureCallback<>() {
                 @Override
                 public void onSuccess(@Nullable Response response) {
-                    if (Responses.isSuccess(response)) {
-                        retryCountSuccessHistogram.get().update(failures);
-                    } else {
-                        retryCountFailureHistogram.get().update(failures);
-                    }
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
+                        if (Responses.isSuccess(response)) {
+                            retryCountSuccessHistogram.get().update(failures);
+                        } else {
+                            retryCountFailureHistogram.get().update(failures);
+                        }
+                    } else if (requestCanBeRetried()) {
+                        // Only update the success metric if the request was retry-able.
+                        retryCountSuccessHistogram.get().update(failures);
                     }
                 }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -157,6 +157,29 @@ final class RetryingChannel implements EndpointChannel {
                 () -> ThreadLocalRandom.current().nextDouble());
     }
 
+    @VisibleForTesting
+    RetryingChannel(
+            EndpointChannel delegate,
+            Endpoint endpoint,
+            String channelName,
+            TaggedMetricRegistry taggedMetricRegistry,
+            int maxRetries,
+            Duration backoffSlotSize,
+            ClientConfiguration.ServerQoS serverQoS,
+            ClientConfiguration.RetryOnTimeout retryOnTimeout) {
+        this(
+                delegate,
+                endpoint,
+                channelName,
+                taggedMetricRegistry,
+                maxRetries,
+                backoffSlotSize,
+                serverQoS,
+                retryOnTimeout,
+                sharedScheduler.get(),
+                () -> ThreadLocalRandom.current().nextDouble());
+    }
+
     private RetryingChannel(
             EndpointChannel delegate,
             Endpoint endpoint,
@@ -263,10 +286,14 @@ final class RetryingChannel implements EndpointChannel {
             ListenableFuture<Response> result = wrap(delegate.execute(request));
             DialogueFutures.addDirectCallback(result, new FutureCallback<>() {
                 @Override
-                public void onSuccess(@Nullable Response _response) {
+                public void onSuccess(@Nullable Response response) {
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
-                        retryCountSuccessHistogram.get().update(failures);
+                        if (Responses.isSuccess(response)) {
+                            retryCountSuccessHistogram.get().update(failures);
+                        } else {
+                            retryCountFailureHistogram.get().update(failures);
+                        }
                     }
                 }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -287,21 +287,21 @@ final class RetryingChannel implements EndpointChannel {
             DialogueFutures.addDirectCallback(result, new FutureCallback<>() {
                 @Override
                 public void onSuccess(@Nullable Response response) {
+                    if (Responses.isSuccess(response)) {
+                        retryCountSuccessHistogram.get().update(failures);
+                    } else {
+                        retryCountFailureHistogram.get().update(failures);
+                    }
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
-                        if (Responses.isSuccess(response)) {
-                            retryCountSuccessHistogram.get().update(failures);
-                        } else {
-                            retryCountFailureHistogram.get().update(failures);
-                        }
                     }
                 }
 
                 @Override
                 public void onFailure(Throwable _throwable) {
+                    retryCountFailureHistogram.get().update(failures);
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
-                        retryCountFailureHistogram.get().update(failures);
                     }
                 }
             });

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -250,14 +250,22 @@ final class RetryingChannel implements EndpointChannel {
 
         ListenableFuture<Response> execute() {
             ListenableFuture<Response> result = wrap(delegate.execute(request));
-            result.addListener(
-                    () -> {
-                        if (failures > 0) {
-                            span.complete(RetryingCallbackTranslator.INSTANCE, this);
-                            retryCountHistogram.get().update(failures);
-                        }
-                    },
-                    DialogueFutures.safeDirectExecutor());
+            DialogueFutures.addDirectCallback(result, new FutureCallback<>() {
+                @Override
+                public void onSuccess(@Nullable Response _response) {
+                    if (failures > 0) {
+                        span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
+                        retryCountHistogram.get().update(failures);
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable _throwable) {
+                    if (failures > 0) {
+                        span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
+                    }
+                }
+            });
             return result;
         }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -297,7 +297,7 @@ final class RetryingChannel implements EndpointChannel {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
                     }
 
-                    if (Responses.isSuccess(response)) {
+                    if (requestCanBeRetried() && Responses.isSuccess(response)) {
                         retryCountSuccessHistogram.get().update(failures);
                     } else if (failures > maxRetries) {
                         // Means we got a retryable failure response, but retries were exhausted

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -158,29 +158,6 @@ final class RetryingChannel implements EndpointChannel {
                 () -> ThreadLocalRandom.current().nextDouble());
     }
 
-    @VisibleForTesting
-    RetryingChannel(
-            EndpointChannel delegate,
-            Endpoint endpoint,
-            String channelName,
-            TaggedMetricRegistry taggedMetricRegistry,
-            int maxRetries,
-            Duration backoffSlotSize,
-            ClientConfiguration.ServerQoS serverQoS,
-            ClientConfiguration.RetryOnTimeout retryOnTimeout) {
-        this(
-                delegate,
-                endpoint,
-                channelName,
-                taggedMetricRegistry,
-                maxRetries,
-                backoffSlotSize,
-                serverQoS,
-                retryOnTimeout,
-                sharedScheduler.get(),
-                () -> ThreadLocalRandom.current().nextDouble());
-    }
-
     private RetryingChannel(
             EndpointChannel delegate,
             Endpoint endpoint,

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -35,6 +35,7 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
+import com.palantir.dialogue.core.DialogueClientMetrics.RequestRetryCount_Result;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -108,7 +109,8 @@ final class RetryingChannel implements EndpointChannel {
     private final Supplier<Meter> retryDueToServerError;
     private final Supplier<Meter> retryDueToQosResponse;
     private final Function<Throwable, Meter> retryDueToThrowable;
-    private final Supplier<Histogram> retryCountHistogram;
+    private final Supplier<Histogram> retryCountSuccessHistogram;
+    private final Supplier<Histogram> retryCountFailureHistogram;
     private final Supplier<Counter> exhaustedDueToServerError;
     private final Supplier<Counter> exhaustedDueToQosResponse;
     private final Function<Throwable, Counter> exhaustedDueToThrowable;
@@ -191,7 +193,16 @@ final class RetryingChannel implements EndpointChannel {
                 .channelName(channelName)
                 .reason(throwable.getClass().getSimpleName())
                 .build();
-        this.retryCountHistogram = Suppliers.memoize(() -> dialogueClientMetrics.requestRetryCount(channelName));
+        this.retryCountSuccessHistogram = Suppliers.memoize(() -> dialogueClientMetrics
+                .requestRetryCount()
+                .channelName(channelName)
+                .result(RequestRetryCount_Result.SUCCESS)
+                .build());
+        this.retryCountFailureHistogram = Suppliers.memoize(() -> dialogueClientMetrics
+                .requestRetryCount()
+                .channelName(channelName)
+                .result(RequestRetryCount_Result.FAILURE)
+                .build());
         this.exhaustedDueToServerError = Suppliers.memoize(() -> dialogueClientMetrics
                 .requestRetryExhausted()
                 .channelName(channelName)
@@ -255,7 +266,7 @@ final class RetryingChannel implements EndpointChannel {
                 public void onSuccess(@Nullable Response _response) {
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
-                        retryCountHistogram.get().update(failures);
+                        retryCountSuccessHistogram.get().update(failures);
                     }
                 }
 
@@ -263,6 +274,7 @@ final class RetryingChannel implements EndpointChannel {
                 public void onFailure(Throwable _throwable) {
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
+                        retryCountFailureHistogram.get().update(failures);
                     }
                 }
             });

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -111,6 +111,7 @@ final class RetryingChannel implements EndpointChannel {
     private final Function<Throwable, Meter> retryDueToThrowable;
     private final Supplier<Histogram> retryCountSuccessHistogram;
     private final Supplier<Histogram> retryCountFailureHistogram;
+    private final Supplier<Histogram> retryCountNonRetryableHistogram;
     private final Supplier<Counter> exhaustedDueToServerError;
     private final Supplier<Counter> exhaustedDueToQosResponse;
     private final Function<Throwable, Counter> exhaustedDueToThrowable;
@@ -226,6 +227,11 @@ final class RetryingChannel implements EndpointChannel {
                 .channelName(channelName)
                 .result(RequestRetryCount_Result.FAILURE)
                 .build());
+        this.retryCountNonRetryableHistogram = Suppliers.memoize(() -> dialogueClientMetrics
+                .requestRetryCount()
+                .channelName(channelName)
+                .result(RequestRetryCount_Result.NON_RETRYABLE)
+                .build());
         this.exhaustedDueToServerError = Suppliers.memoize(() -> dialogueClientMetrics
                 .requestRetryExhausted()
                 .channelName(channelName)
@@ -291,18 +297,22 @@ final class RetryingChannel implements EndpointChannel {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
                         if (Responses.isSuccess(response)) {
                             retryCountSuccessHistogram.get().update(failures);
-                        } else {
+                        } else if (failures > maxRetries) {
                             retryCountFailureHistogram.get().update(failures);
+                        } else {
+                            retryCountNonRetryableHistogram.get().update(failures);
                         }
-                    } else if (requestCanBeRetried()) {
-                        // Only update the success metric if the request was retry-able.
+                    } else if (requestCanBeRetried() && Responses.isSuccess(response)) {
+                        // Only update the success metric if the request was retry-able and succeeded.
                         retryCountSuccessHistogram.get().update(failures);
                     }
                 }
 
                 @Override
                 public void onFailure(Throwable _throwable) {
-                    retryCountFailureHistogram.get().update(failures);
+                    if (requestCanBeRetried()) {
+                        retryCountFailureHistogram.get().update(failures);
+                    }
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
                     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -295,16 +295,15 @@ final class RetryingChannel implements EndpointChannel {
                 public void onSuccess(@Nullable Response response) {
                     if (failures > 0) {
                         span.complete(RetryingCallbackTranslator.INSTANCE, RetryingCallback.this);
-                        if (Responses.isSuccess(response)) {
-                            retryCountSuccessHistogram.get().update(failures);
-                        } else if (failures > maxRetries) {
-                            retryCountFailureHistogram.get().update(failures);
-                        } else {
-                            retryCountNonRetryableHistogram.get().update(failures);
-                        }
-                    } else if (requestCanBeRetried() && Responses.isSuccess(response)) {
-                        // Only update the success metric if the request was retry-able and succeeded.
+                    }
+
+                    if (Responses.isSuccess(response)) {
                         retryCountSuccessHistogram.get().update(failures);
+                    } else if (failures > maxRetries) {
+                        // Means we got a retryable failure response, but retries were exhausted
+                        retryCountFailureHistogram.get().update(failures);
+                    } else {
+                        retryCountNonRetryableHistogram.get().update(failures);
                     }
                 }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/RetryingChannel.java
@@ -16,6 +16,8 @@
 
 package com.palantir.dialogue.core;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
@@ -106,6 +108,10 @@ final class RetryingChannel implements EndpointChannel {
     private final Supplier<Meter> retryDueToServerError;
     private final Supplier<Meter> retryDueToQosResponse;
     private final Function<Throwable, Meter> retryDueToThrowable;
+    private final Supplier<Histogram> retryCountHistogram;
+    private final Supplier<Counter> exhaustedDueToServerError;
+    private final Supplier<Counter> exhaustedDueToQosResponse;
+    private final Function<Throwable, Counter> exhaustedDueToThrowable;
 
     static EndpointChannel create(Config cf, EndpointChannel channel, Endpoint endpoint) {
         ClientConfiguration clientConf = cf.clientConf();
@@ -185,6 +191,22 @@ final class RetryingChannel implements EndpointChannel {
                 .channelName(channelName)
                 .reason(throwable.getClass().getSimpleName())
                 .build();
+        this.retryCountHistogram = Suppliers.memoize(() -> dialogueClientMetrics.requestRetryCount(channelName));
+        this.exhaustedDueToServerError = Suppliers.memoize(() -> dialogueClientMetrics
+                .requestRetryExhausted()
+                .channelName(channelName)
+                .reason("serverError")
+                .build());
+        this.exhaustedDueToQosResponse = Suppliers.memoize(() -> dialogueClientMetrics
+                .requestRetryExhausted()
+                .channelName(channelName)
+                .reason("qosResponse")
+                .build());
+        this.exhaustedDueToThrowable = throwable -> dialogueClientMetrics
+                .requestRetryExhausted()
+                .channelName(channelName)
+                .reason(throwable.getClass().getSimpleName())
+                .build();
     }
 
     @Override
@@ -232,6 +254,7 @@ final class RetryingChannel implements EndpointChannel {
                     () -> {
                         if (failures > 0) {
                             span.complete(RetryingCallbackTranslator.INSTANCE, this);
+                            retryCountHistogram.get().update(failures);
                         }
                     },
                     DialogueFutures.safeDirectExecutor());
@@ -261,11 +284,13 @@ final class RetryingChannel implements EndpointChannel {
         private ListenableFuture<Response> handleHttpResponse(Response response) {
             boolean canRetryRequest = requestCanBeRetried();
             if (canRetryRequest && isRetryableQosStatus(response)) {
-                return incrementFailuresAndMaybeRetry(response, qosThrowable, retryDueToQosResponse.get());
+                return incrementFailuresAndMaybeRetry(
+                        response, qosThrowable, retryDueToQosResponse.get(), exhaustedDueToQosResponse.get());
             }
 
             if (canRetryRequest && Responses.isInternalServerError(response) && safeToRetry(endpoint.httpMethod())) {
-                return incrementFailuresAndMaybeRetry(response, serverErrorThrowable, retryDueToServerError.get());
+                return incrementFailuresAndMaybeRetry(
+                        response, serverErrorThrowable, retryDueToServerError.get(), exhaustedDueToServerError.get());
             }
 
             return Futures.immediateFuture(response);
@@ -290,12 +315,18 @@ final class RetryingChannel implements EndpointChannel {
                                 clientSideThrowable);
                     }
                 }
+            } else {
+                // Retries exhausted due to throwable
+                exhaustedDueToThrowable.apply(clientSideThrowable).inc();
             }
             return Futures.immediateFailedFuture(clientSideThrowable);
         }
 
         private ListenableFuture<Response> incrementFailuresAndMaybeRetry(
-                Response response, BiFunction<Endpoint, Response, Throwable> failureSupplier, Meter meter) {
+                Response response,
+                BiFunction<Endpoint, Response, Throwable> failureSupplier,
+                Meter retryMeter,
+                Counter exhaustedCounter) {
             // We've made a request which has failed, so we apply a floor of a single failure if there are no
             // proxy upstream request attempts. Otherwise, if the proxy has reported upstream request attempts,
             // those are considered as well. When the proxy makes a single request, that is considered part of
@@ -314,8 +345,9 @@ final class RetryingChannel implements EndpointChannel {
                 Throwable throwableToLog = log.isTraceEnabled() ? failureSupplier.apply(endpoint, response) : null;
                 long backoffNanos = Responses.isRetryOther(response) ? 0 : getBackoffNanoseconds();
                 infoLogRetry(backoffNanos, OptionalInt.of(response.code()), throwableToLog);
-                return scheduleRetry(meter, backoffNanos);
+                return scheduleRetry(retryMeter, backoffNanos);
             }
+            exhaustedCounter.inc();
             infoLogRetriesExhausted(response);
             // not closing response because ConjureBodySerde will need to deserialize it
             return Futures.immediateFuture(response);

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -37,7 +37,9 @@ namespaces:
       request.retry.count:
         type: histogram
         tags: [channel-name]
-        docs: Distribution of retry counts per request. Only recorded for requests that required at least one retry.
+        docs: |
+          Distribution of retry counts per request. Only recorded for requests that required at least one retry
+          and eventually received a response (not recorded for requests that fail with an exception).
       request.retry.exhausted:
         type: counter
         tags: [channel-name, reason]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -41,12 +41,12 @@ namespaces:
         tags:
           - name: channel-name
           - name: result
-            values: [ success, failure ]
+            values: [ success, failure, non-retryable ]
         docs: |
-          Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that
-          the request eventually received a successful (2xx) response, while "failure" indicates that the request
-          ultimately completed with a non-successful response (e.g. 429, 503) or no response at all (e.g. socket
-          read timeout).
+          Distribution of retry counts per request for retryable requests. The result tag indicates the terminal
+          state: "success" means the request eventually received a successful (2xx) response, "non-retryable" means
+          the request received a non-retryable response (e.g. 4xx) before exhausting retries, and "failure" means
+          retries were exhausted due to retryable errors (e.g. 429, 503, socket read timeout).
       request.retry.exhausted:
         type: counter
         tags: [channel-name, reason]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -43,15 +43,16 @@ namespaces:
           - name: result
             values: [ success, failure, non-retryable ]
         docs: |
-          Distribution of retry counts per request for retryable requests. The result tag indicates the terminal
-          state: "success" means the request eventually received a successful (2xx) response, "non-retryable" means
-          the request received a non-retryable response (e.g. 4xx) before exhausting retries, and "failure" means
-          retries were exhausted due to retryable errors (e.g. 429, 503, socket read timeout).
+          Distribution of failed attempt counts per request. The value recorded is the number of failed attempts
+          before the terminal result. For "success", this equals the number of retries before a 2xx response.
+          For "failure" (retries exhausted), this equals maxRetries + 1 since the final attempt also failed.
+          For "non-retryable", this is the number of retryable failures before receiving a non-retryable response
+          (e.g. 4xx), or 0 if the request itself was not retryable (e.g. non-repeatable body).
       request.retry.exhausted:
         type: counter
         tags: [channel-name, reason]
         docs: |
-          Count of requests that exhaust all retry attempts without receiving a successful response. The reason is 
+          Count of requests that exhaust all retry attempts without receiving a successful response. The reason is
           populated with the reason for which the last retry has failed.
       requests.queued:
         type: counter

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -34,12 +34,18 @@ namespaces:
         type: meter
         tags: [channel-name, reason]
         docs: Rate at which the RetryingChannel retries requests (across all endpoints).
+      # Note: endpoint is not added as a tag to the retry metrics below because we do not want to greatly increase
+      # the cardinality of tags: doing so adds load to the observability pipeline.
       request.retry.count:
         type: histogram
-        tags: [channel-name]
+        tags:
+          - name: channel-name
+          - name: result
+            values: [ success, failure ]
         docs: |
-          Distribution of retry counts per request. Only recorded for requests that required at least one retry
-          and eventually received a response (not recorded for requests that fail with an exception).
+          Distribution of retry counts per request for requests that required at least one retry. The result tag of 
+          "success" indicates that the request eventually received a response, while "failure" indicates that there was 
+          no response received from the server (e.g. the connection timed out).
       request.retry.exhausted:
         type: counter
         tags: [channel-name, reason]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -45,7 +45,7 @@ namespaces:
         docs: |
           Distribution of retry counts per request for requests that required at least one retry. The result tag of 
           "success" indicates that the request eventually received a response, while "failure" indicates that there was 
-          no response received from the server (e.g. the connection timed out).
+          no response received from the server (e.g. socket read timeout).
       request.retry.exhausted:
         type: counter
         tags: [channel-name, reason]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -43,9 +43,9 @@ namespaces:
           - name: result
             values: [ success, failure ]
         docs: |
-          Distribution of retry counts per request for requests that required at least one retry. The result tag of 
-          "success" indicates that the request eventually received a response, while "failure" indicates that there was 
-          no response received from the server (e.g. socket read timeout).
+          Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that 
+          the request eventually received a response, while "failure" indicates that there was no response received 
+          from the server (e.g. socket read timeout).
       request.retry.exhausted:
         type: counter
         tags: [channel-name, reason]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -34,6 +34,16 @@ namespaces:
         type: meter
         tags: [channel-name, reason]
         docs: Rate at which the RetryingChannel retries requests (across all endpoints).
+      request.retry.count:
+        type: histogram
+        tags: [channel-name]
+        docs: Distribution of retry counts per request. Only recorded for requests that required at least one retry.
+      request.retry.exhausted:
+        type: counter
+        tags: [channel-name, reason]
+        docs: |
+          Count of requests that exhaust all retry attempts without receiving a successful response. The reason is 
+          populated with the reason for which the last retry has failed.
       requests.queued:
         type: counter
         tags: [channel-name]

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -43,9 +43,10 @@ namespaces:
           - name: result
             values: [ success, failure ]
         docs: |
-          Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that 
-          the request eventually received a response, while "failure" indicates that there was no response received 
-          from the server (e.g. socket read timeout).
+          Distribution of retry counts per request for retryable requests. The result tag of "success" indicates that
+          the request eventually received a successful (2xx) response, while "failure" indicates that the request
+          ultimately completed with a non-successful response (e.g. 429, 503) or no response at all (e.g. socket
+          read timeout).
       request.retry.exhausted:
         type: counter
         tags: [channel-name, reason]

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -1050,10 +1050,10 @@ public class RetryingChannelTest {
 
     private EndpointChannel channel(int maxRetries) {
         return new RetryingChannel(
+                registry,
                 channel,
                 TestEndpoint.POST,
                 "my-channel",
-                registry,
                 maxRetries,
                 Duration.ZERO,
                 ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -44,20 +44,24 @@ import com.palantir.dialogue.core.DialogueClientMetrics.RequestRetryCount_Result
 import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.OngoingStubbing;
 
 @ExtendWith(MockitoExtension.class)
 public class RetryingChannelTest {
@@ -69,6 +73,13 @@ public class RetryingChannelTest {
 
     @Mock
     private EndpointChannel channel;
+
+    private TaggedMetricRegistry registry;
+
+    @BeforeEach
+    public void before() {
+        registry = new DefaultTaggedMetricRegistry();
+    }
 
     @Test
     public void testNoFailures() throws ExecutionException, InterruptedException {
@@ -892,164 +903,53 @@ public class RetryingChannelTest {
 
     @Test
     public void retryCountSuccessHistogramUpdatedAfter429ThenSuccess() throws Exception {
-        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        // 2 retries that return 429 before a successful response
+        setupResponses(429, 429, 200);
 
-        when(channel.execute(any()))
-                .thenAnswer((Answer<ListenableFuture<Response>>)
-                        _invocation -> Futures.immediateFuture(new TestResponse().code(429)))
-                .thenAnswer((Answer<ListenableFuture<Response>>)
-                        _invocation -> Futures.immediateFuture(new TestResponse().code(429)))
-                .thenAnswer((Answer<ListenableFuture<Response>>)
-                        _invocation -> Futures.immediateFuture(new TestResponse().code(200)));
-
-        EndpointChannel retryer = new RetryingChannel(
-                channel,
-                TestEndpoint.POST,
-                "my-channel",
-                registry,
-                4,
-                Duration.ZERO,
-                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
-                ClientConfiguration.RetryOnTimeout.DISABLED);
+        EndpointChannel retryer = channel(4);
 
         ListenableFuture<Response> response = retryer.execute(REQUEST);
         assertThat(response.get().code()).isEqualTo(200);
+        verify(channel, times(3)).execute(REQUEST);
 
-        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getCount())
-                .as("Success histogram should be updated when request succeeds after 429 retry")
-                .isEqualTo(1);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getSnapshot()
-                        .getValues())
-                .as("Success histogram should record 2 failures (the 429s) before success")
-                .containsExactly(2L);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getCount())
-                .as("Failure histogram should not be updated when request eventually succeeds")
-                .isEqualTo(0);
+        verifyMetrics(
+                new ExpectedMetrics(RequestRetryCount_Result.SUCCESS, 2),
+                "2 retries with request eventually succeeding after 429s");
     }
 
     @Test
     public void retryCountFailureHistogramUpdatedWhenRetriesExhaustedDueToException() {
-        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
-
         when(channel.execute(any())).thenReturn(FAILED);
 
-        EndpointChannel retryer = new RetryingChannel(
-                channel,
-                TestEndpoint.POST,
-                "my-channel",
-                registry,
-                4,
-                Duration.ZERO,
-                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
-                ClientConfiguration.RetryOnTimeout.DISABLED);
+        EndpointChannel retryer = channel(4);
 
         ListenableFuture<Response> response = retryer.execute(REQUEST);
         assertThatThrownBy(response::get).hasCauseInstanceOf(SafeIoException.class);
         verify(channel, times(5)).execute(REQUEST);
 
-        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getCount())
-                .as("Failure histogram should be updated when retries exhausted due to exception")
-                .isEqualTo(1);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getSnapshot()
-                        .getValues())
-                .as("Failure histogram should record 5 failures (initial + 4 retries)")
-                .containsExactly(5L);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getCount())
-                .as("Success histogram should not be updated when request fails")
-                .isEqualTo(0);
-        assertThat(metrics.requestRetryExhausted()
-                        .channelName("my-channel")
-                        .reason("SafeIoException")
-                        .build()
-                        .getCount())
-                .as("Exhausted counter should be incremented when retries exhausted due to exception")
-                .isEqualTo(1);
+        verifyMetrics(
+                new ExpectedMetrics(RequestRetryCount_Result.FAILURE, 5, "SafeIoException"),
+                "retries exhausted due to exception");
     }
 
     @Test
     public void retryCountFailureHistogramUpdatedWhenRetriesExhaustedDueTo429() throws Exception {
-        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        setupResponses(429);
 
-        when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>)
-                _invocation -> Futures.immediateFuture(new TestResponse().code(429)));
-
-        EndpointChannel retryer = new RetryingChannel(
-                channel,
-                TestEndpoint.POST,
-                "my-channel",
-                registry,
-                4,
-                Duration.ZERO,
-                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
-                ClientConfiguration.RetryOnTimeout.DISABLED);
+        EndpointChannel retryer = channel(4);
 
         ListenableFuture<Response> response = retryer.execute(REQUEST);
         assertThat(response.get().code()).isEqualTo(429);
         verify(channel, times(5)).execute(REQUEST);
 
         // Exhausted 429s are not successful responses, so they update the FAILURE histogram
-        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getCount())
-                .as("Failure histogram should be updated when retries exhausted due to 429")
-                .isEqualTo(1);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getSnapshot()
-                        .getValues())
-                .as("Failure histogram should record 5 failures (initial + 4 retries)")
-                .containsExactly(5L);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getCount())
-                .as("Success histogram should not be updated when response is not successful")
-                .isEqualTo(0);
-        assertThat(metrics.requestRetryExhausted()
-                        .channelName("my-channel")
-                        .reason("qosResponse")
-                        .build()
-                        .getCount())
-                .as("Exhausted counter should be incremented when retries exhausted due to 429")
-                .isEqualTo(1);
+        verifyMetrics(
+                new ExpectedMetrics(RequestRetryCount_Result.FAILURE, 5, "qosResponse"),
+                "retries exhausted due to 429 response");
     }
 
     @Test
     public void testIoExceptionFailuresThenQosResponseThenSuccess() throws Exception {
-        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
-
         when(channel.execute(any()))
                 .thenReturn(Futures.immediateFailedFuture(new SocketTimeoutException("connect timed out")))
                 .thenReturn(FAILED)
@@ -1058,15 +958,8 @@ public class RetryingChannelTest {
                 .thenAnswer((Answer<ListenableFuture<Response>>)
                         _invocation -> Futures.immediateFuture(new TestResponse().code(200)));
 
-        EndpointChannel retryer = new RetryingChannel(
-                channel,
-                TestEndpoint.POST,
-                "my-channel",
-                registry,
-                4,
-                Duration.ZERO,
-                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
-                ClientConfiguration.RetryOnTimeout.DISABLED);
+        EndpointChannel retryer = channel(4);
+
         ListenableFuture<Response> response = retryer.execute(REQUEST);
         assertThat(response).isDone();
         assertThat(response.get().code())
@@ -1074,175 +967,151 @@ public class RetryingChannelTest {
                 .isEqualTo(200);
         verify(channel, times(4)).execute(REQUEST);
 
-        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getCount())
-                .as("Success histogram should be updated when request eventually succeeds")
-                .isEqualTo(1);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getSnapshot()
-                        .getValues())
-                .as("Success histogram should record 3 failures (2 IOExceptions + 1 429) before success")
-                .containsExactly(3L);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getCount())
-                .as("Failure histogram should not be updated when request eventually succeeds")
-                .isEqualTo(0);
+        verifyMetrics(
+                new ExpectedMetrics(RequestRetryCount_Result.SUCCESS, 3),
+                "2 IOExceptions and 1 retryable 429 before success");
     }
 
     @Test
     public void retryCountNonRetryableHistogramUpdatedWhenNonRetryableResponseAfterRetries() throws Exception {
-        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        setupResponses(429, 400);
 
-        when(channel.execute(any()))
-                .thenAnswer((Answer<ListenableFuture<Response>>)
-                        _invocation -> Futures.immediateFuture(new TestResponse().code(429)))
-                .thenAnswer((Answer<ListenableFuture<Response>>)
-                        _invocation -> Futures.immediateFuture(new TestResponse().code(400)));
-
-        EndpointChannel retryer = new RetryingChannel(
-                channel,
-                TestEndpoint.POST,
-                "my-channel",
-                registry,
-                4,
-                Duration.ZERO,
-                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
-                ClientConfiguration.RetryOnTimeout.DISABLED);
+        EndpointChannel retryer = channel(4);
 
         ListenableFuture<Response> response = retryer.execute(REQUEST);
         assertThat(response.get().code()).isEqualTo(400);
         verify(channel, times(2)).execute(REQUEST);
 
-        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.NON_RETRYABLE)
-                        .build()
-                        .getCount())
-                .as("Non-retryable histogram should be updated when request ends with a non-retryable response")
-                .isEqualTo(1);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.NON_RETRYABLE)
-                        .build()
-                        .getSnapshot()
-                        .getValues())
-                .as("Non-retryable histogram should record 1 failure (the 429) before the non-retryable 400")
-                .containsExactly(1L);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getCount())
-                .as("Success histogram should not be updated for non-retryable responses")
-                .isEqualTo(0);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getCount())
-                .as("Failure histogram should not be updated when retries were not exhausted")
-                .isEqualTo(0);
+        verifyMetrics(
+                new ExpectedMetrics(RequestRetryCount_Result.NON_RETRYABLE, 1),
+                "non-retryable response after retryable 429");
+    }
+
+    @Test
+    public void retryCountNonRetryableHistogramUpdatedWhenNonRetryableResponseAfterAlmostMaxRetries() throws Exception {
+        setupResponses(429, 429, 429, 429, 400);
+
+        EndpointChannel retryer = channel(4);
+
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response.get().code()).isEqualTo(400);
+        verify(channel, times(5)).execute(REQUEST);
+
+        verifyMetrics(
+                // We should update the non-retryable metric if we get a non-retryable response at the last retry
+                new ExpectedMetrics(RequestRetryCount_Result.NON_RETRYABLE, 4),
+                "non-retryable response after retryable 429");
     }
 
     @Test
     public void retryCountSuccessHistogramUpdatedForFirstTrySuccess() throws Exception {
-        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        setupResponses(200);
 
-        when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>)
-                _invocation -> Futures.immediateFuture(new TestResponse().code(200)));
-
-        EndpointChannel retryer = new RetryingChannel(
-                channel,
-                TestEndpoint.POST,
-                "my-channel",
-                registry,
-                4,
-                Duration.ZERO,
-                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
-                ClientConfiguration.RetryOnTimeout.DISABLED);
+        EndpointChannel retryer = channel(4);
 
         ListenableFuture<Response> response = retryer.execute(REQUEST);
         assertThat(response.get().code()).isEqualTo(200);
 
-        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getCount())
-                .as("Success histogram should be updated for first-try success on retryable request")
-                .isEqualTo(1);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
-                        .build()
-                        .getSnapshot()
-                        .getValues())
-                .as("Success histogram should record 0 failures for first-try success")
-                .containsExactly(0L);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getCount())
-                .as("Failure histogram should not be updated for first-try success")
-                .isEqualTo(0);
+        verifyMetrics(new ExpectedMetrics(RequestRetryCount_Result.SUCCESS, 0), "first-try success without retries");
     }
 
     @Test
-    public void retryCountNotUpdatedForNon2xxFirstTryResponse() throws Exception {
-        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+    public void retryCountUpdatedForNon2xxFirstTryResponse() throws Exception {
+        setupResponses(400);
 
-        when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>)
-                _invocation -> Futures.immediateFuture(new TestResponse().code(400)));
-
-        EndpointChannel retryer = new RetryingChannel(
-                channel,
-                TestEndpoint.POST,
-                "my-channel",
-                registry,
-                4,
-                Duration.ZERO,
-                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
-                ClientConfiguration.RetryOnTimeout.DISABLED);
+        EndpointChannel retryer = channel(4);
 
         ListenableFuture<Response> response = retryer.execute(REQUEST);
         assertThat(response.get().code()).isEqualTo(400);
         verify(channel, times(1)).execute(REQUEST);
 
+        verifyMetrics(new ExpectedMetrics(RequestRetryCount_Result.NON_RETRYABLE, 0), "non-2xx first-try response");
+    }
+
+    private EndpointChannel channel(int maxRetries) {
+        return new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                maxRetries,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+    }
+
+    private void setupResponses(int... codes) {
+        OngoingStubbing<ListenableFuture<Response>> stubbing = when(channel.execute(any()));
+        for (int code : codes) {
+            stubbing = stubbing.thenAnswer(_invocation -> Futures.immediateFuture(new TestResponse().code(code)));
+        }
+    }
+
+    private record ExpectedMetrics(
+            RequestRetryCount_Result resultState, long retryCount, Optional<String> exhaustedReason) {
+        ExpectedMetrics(RequestRetryCount_Result resultState, long retryCount) {
+            this(resultState, retryCount, Optional.empty());
+        }
+
+        ExpectedMetrics(RequestRetryCount_Result resultState, long retryCount, String exhaustedReason) {
+            this(resultState, retryCount, Optional.of(exhaustedReason));
+        }
+    }
+
+    private void verifyMetrics(ExpectedMetrics expected, String description) {
         DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
         assertThat(metrics.requestRetryCount()
                         .channelName("my-channel")
-                        .result(RequestRetryCount_Result.SUCCESS)
+                        .result(expected.resultState)
                         .build()
                         .getCount())
-                .as("Success histogram should not be updated for non-2xx first-try response")
-                .isEqualTo(0);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.FAILURE)
-                        .build()
-                        .getCount())
-                .as("Failure histogram should not be updated for non-2xx first-try response")
-                .isEqualTo(0);
-        assertThat(metrics.requestRetryCount()
-                        .channelName("my-channel")
-                        .result(RequestRetryCount_Result.NON_RETRYABLE)
-                        .build()
-                        .getCount())
-                .as("Non-retryable histogram should not be updated for non-2xx first-try response")
-                .isEqualTo(0);
+                .as(expected.resultState + " histogram should be updated (" + description + ")")
+                .isEqualTo(1);
+        for (RequestRetryCount_Result result : RequestRetryCount_Result.values()) {
+            if (result != expected.resultState) {
+                assertThat(metrics.requestRetryCount()
+                                .channelName("my-channel")
+                                .result(result)
+                                .build()
+                                .getCount())
+                        .as(result + " histogram should not be updated (" + description + ")")
+                        .isEqualTo(0);
+            } else {
+                assertThat(metrics.requestRetryCount()
+                                .channelName("my-channel")
+                                .result(result)
+                                .build()
+                                .getSnapshot()
+                                .getValues())
+                        .as(expected.resultState + " histogram should record " + expected.retryCount + " retry ("
+                                + description + ")")
+                        .containsExactly(expected.retryCount);
+            }
+        }
+        if (expected.exhaustedReason.isPresent()) {
+            assertThat(metrics.requestRetryExhausted()
+                            .channelName("my-channel")
+                            .reason(expected.exhaustedReason.get())
+                            .build()
+                            .getCount())
+                    .as("Exhausted counter should be incremented with reason " + expected.exhaustedReason.get() + " ("
+                            + description + ")")
+                    .isEqualTo(1);
+        } else {
+            // Ideally we'd check we didn't increment the exhausted counter for any reason, but we don't really
+            //   have a way to query all possible reasons, so just check the predefined one and the exception reason
+            //   that we use in the tests.
+            for (String reason : List.of("qosResponse", "serverError", "SafeIoException")) {
+                assertThat(metrics.requestRetryExhausted()
+                                .channelName("my-channel")
+                                .reason(reason)
+                                .build()
+                                .getCount())
+                        .as("Exhausted counter should not be incremented with reason " + reason + " (" + description
+                                + ")")
+                        .isEqualTo(0);
+            }
+        }
     }
 
     private static Response mockResponse(int status) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -983,6 +983,13 @@ public class RetryingChannelTest {
                         .getCount())
                 .as("Success histogram should not be updated when request fails")
                 .isEqualTo(0);
+        assertThat(metrics.requestRetryExhausted()
+                        .channelName("my-channel")
+                        .reason("SafeIoException")
+                        .build()
+                        .getCount())
+                .as("Exhausted counter should be incremented when retries exhausted due to exception")
+                .isEqualTo(1);
     }
 
     @Test
@@ -1029,6 +1036,212 @@ public class RetryingChannelTest {
                         .build()
                         .getCount())
                 .as("Success histogram should not be updated when response is not successful")
+                .isEqualTo(0);
+        assertThat(metrics.requestRetryExhausted()
+                        .channelName("my-channel")
+                        .reason("qosResponse")
+                        .build()
+                        .getCount())
+                .as("Exhausted counter should be incremented when retries exhausted due to 429")
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void testIoExceptionFailuresThenQosResponseThenSuccess() throws Exception {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+        when(channel.execute(any()))
+                .thenReturn(Futures.immediateFailedFuture(new SocketTimeoutException("connect timed out")))
+                .thenReturn(FAILED)
+                .thenAnswer((Answer<ListenableFuture<Response>>)
+                        _invocation -> Futures.immediateFuture(new TestResponse().code(429)))
+                .thenAnswer((Answer<ListenableFuture<Response>>)
+                        _invocation -> Futures.immediateFuture(new TestResponse().code(200)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                4,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response).isDone();
+        assertThat(response.get().code())
+                .as("Should succeed after IOException failures followed by a retryable 429")
+                .isEqualTo(200);
+        verify(channel, times(4)).execute(REQUEST);
+
+        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getCount())
+                .as("Success histogram should be updated when request eventually succeeds")
+                .isEqualTo(1);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getSnapshot()
+                        .getValues())
+                .as("Success histogram should record 3 failures (2 IOExceptions + 1 429) before success")
+                .containsExactly(3L);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getCount())
+                .as("Failure histogram should not be updated when request eventually succeeds")
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void retryCountNonRetryableHistogramUpdatedWhenNonRetryableResponseAfterRetries() throws Exception {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+        when(channel.execute(any()))
+                .thenAnswer((Answer<ListenableFuture<Response>>)
+                        _invocation -> Futures.immediateFuture(new TestResponse().code(429)))
+                .thenAnswer((Answer<ListenableFuture<Response>>)
+                        _invocation -> Futures.immediateFuture(new TestResponse().code(400)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                4,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response.get().code()).isEqualTo(400);
+        verify(channel, times(2)).execute(REQUEST);
+
+        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.NON_RETRYABLE)
+                        .build()
+                        .getCount())
+                .as("Non-retryable histogram should be updated when request ends with a non-retryable response")
+                .isEqualTo(1);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.NON_RETRYABLE)
+                        .build()
+                        .getSnapshot()
+                        .getValues())
+                .as("Non-retryable histogram should record 1 failure (the 429) before the non-retryable 400")
+                .containsExactly(1L);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getCount())
+                .as("Success histogram should not be updated for non-retryable responses")
+                .isEqualTo(0);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getCount())
+                .as("Failure histogram should not be updated when retries were not exhausted")
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void retryCountSuccessHistogramUpdatedForFirstTrySuccess() throws Exception {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+        when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>)
+                _invocation -> Futures.immediateFuture(new TestResponse().code(200)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                4,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response.get().code()).isEqualTo(200);
+
+        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getCount())
+                .as("Success histogram should be updated for first-try success on retryable request")
+                .isEqualTo(1);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getSnapshot()
+                        .getValues())
+                .as("Success histogram should record 0 failures for first-try success")
+                .containsExactly(0L);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getCount())
+                .as("Failure histogram should not be updated for first-try success")
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void retryCountNotUpdatedForNon2xxFirstTryResponse() throws Exception {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+        when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>)
+                _invocation -> Futures.immediateFuture(new TestResponse().code(400)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                4,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response.get().code()).isEqualTo(400);
+        verify(channel, times(1)).execute(REQUEST);
+
+        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getCount())
+                .as("Success histogram should not be updated for non-2xx first-try response")
+                .isEqualTo(0);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getCount())
+                .as("Failure histogram should not be updated for non-2xx first-try response")
+                .isEqualTo(0);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.NON_RETRYABLE)
+                        .build()
+                        .getCount())
+                .as("Non-retryable histogram should not be updated for non-2xx first-try response")
                 .isEqualTo(0);
     }
 

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -40,6 +40,7 @@ import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestEndpoint;
 import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.TestResponseQosEncoder;
+import com.palantir.dialogue.core.DialogueClientMetrics.RequestRetryCount_Result;
 import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -887,6 +888,148 @@ public class RetryingChannelTest {
                 .hasRootCauseExactlyInstanceOf(SafeIoException.class)
                 .hasRootCauseMessage("FAILED");
         verify(channel, times(1)).execute(any());
+    }
+
+    @Test
+    public void retryCountSuccessHistogramUpdatedAfter429ThenSuccess() throws Exception {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+        when(channel.execute(any()))
+                .thenAnswer((Answer<ListenableFuture<Response>>)
+                        _invocation -> Futures.immediateFuture(new TestResponse().code(429)))
+                .thenAnswer((Answer<ListenableFuture<Response>>)
+                        _invocation -> Futures.immediateFuture(new TestResponse().code(429)))
+                .thenAnswer((Answer<ListenableFuture<Response>>)
+                        _invocation -> Futures.immediateFuture(new TestResponse().code(200)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                4,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response.get().code()).isEqualTo(200);
+
+        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getCount())
+                .as("Success histogram should be updated when request succeeds after 429 retry")
+                .isEqualTo(1);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getSnapshot()
+                        .getValues())
+                .as("Success histogram should record 2 failures (the 429s) before success")
+                .containsExactly(2L);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getCount())
+                .as("Failure histogram should not be updated when request eventually succeeds")
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void retryCountFailureHistogramUpdatedWhenRetriesExhaustedDueToException() {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+        when(channel.execute(any())).thenReturn(FAILED);
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                4,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThatThrownBy(response::get).hasCauseInstanceOf(SafeIoException.class);
+        verify(channel, times(5)).execute(REQUEST);
+
+        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getCount())
+                .as("Failure histogram should be updated when retries exhausted due to exception")
+                .isEqualTo(1);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getSnapshot()
+                        .getValues())
+                .as("Failure histogram should record 5 failures (initial + 4 retries)")
+                .containsExactly(5L);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getCount())
+                .as("Success histogram should not be updated when request fails")
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void retryCountFailureHistogramUpdatedWhenRetriesExhaustedDueTo429() throws Exception {
+        DefaultTaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+        when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>)
+                _invocation -> Futures.immediateFuture(new TestResponse().code(429)));
+
+        EndpointChannel retryer = new RetryingChannel(
+                channel,
+                TestEndpoint.POST,
+                "my-channel",
+                registry,
+                4,
+                Duration.ZERO,
+                ClientConfiguration.ServerQoS.AUTOMATIC_RETRY,
+                ClientConfiguration.RetryOnTimeout.DISABLED);
+
+        ListenableFuture<Response> response = retryer.execute(REQUEST);
+        assertThat(response.get().code()).isEqualTo(429);
+        verify(channel, times(5)).execute(REQUEST);
+
+        // Exhausted 429s are not successful responses, so they update the FAILURE histogram
+        DialogueClientMetrics metrics = DialogueClientMetrics.of(registry);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getCount())
+                .as("Failure histogram should be updated when retries exhausted due to 429")
+                .isEqualTo(1);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.FAILURE)
+                        .build()
+                        .getSnapshot()
+                        .getValues())
+                .as("Failure histogram should record 5 failures (initial + 4 retries)")
+                .containsExactly(5L);
+        assertThat(metrics.requestRetryCount()
+                        .channelName("my-channel")
+                        .result(RequestRetryCount_Result.SUCCESS)
+                        .build()
+                        .getCount())
+                .as("Success histogram should not be updated when response is not successful")
+                .isEqualTo(0);
     }
 
     private static Response mockResponse(int status) {

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/RetryingChannelTest.java
@@ -1016,6 +1016,26 @@ public class RetryingChannelTest {
     }
 
     @Test
+    public void nonRetryableRequestSuccessRecordedAsNonRetryable() throws Exception {
+        // Channel consumes the body and returns 200
+        when(channel.execute(any())).thenAnswer((Answer<ListenableFuture<Response>>) invocation -> {
+            Request request = invocation.getArgument(0);
+            request.body().get().writeTo(new ByteArrayOutputStream());
+            return Futures.immediateFuture(new TestResponse().code(200));
+        });
+
+        EndpointChannel retryer = channel(4);
+
+        ListenableFuture<Response> response = retryer.execute(requestWithNonRepeatableBody());
+        assertThat(response.get().code()).isEqualTo(200);
+        verify(channel, times(1)).execute(any());
+
+        verifyMetrics(
+                new ExpectedMetrics(RequestRetryCount_Result.NON_RETRYABLE, 0),
+                "non-retryable request success should not be counted in success histogram");
+    }
+
+    @Test
     public void retryCountUpdatedForNon2xxFirstTryResponse() throws Exception {
         setupResponses(400);
 
@@ -1112,6 +1132,28 @@ public class RetryingChannelTest {
                         .isEqualTo(0);
             }
         }
+    }
+
+    private static Request requestWithNonRepeatableBody() {
+        return Request.builder()
+                .body(new RequestBody() {
+                    @Override
+                    public void writeTo(OutputStream _output) {}
+
+                    @Override
+                    public String contentType() {
+                        return "application/octet-stream";
+                    }
+
+                    @Override
+                    public boolean repeatable() {
+                        return false;
+                    }
+
+                    @Override
+                    public void close() {}
+                })
+                .build();
     }
 
     private static Response mockResponse(int status) {


### PR DESCRIPTION
## Before this PR
We'd like to gain better visibility into Dialogue's retrying behavior. Initially, we'd like to gather some data on which services consistently exhaust their retries, and the distributions of retries needed for requests to succeed.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add metrics to track exhausted retries and retry counts
==COMMIT_MSG==

## Possible downsides?

