### PR TITLE
Preserve stacktrace for thrown QosExceptions, same as RemoteExceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ __init__.pyc
 
 # Gradle JDKs setup
 !gradle/*
+
+.claude/settings.local.json

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.api.errors.AbstractSerializableError;
+import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
 import com.palantir.conjure.java.api.errors.UnknownRemoteException;
@@ -139,6 +140,10 @@ enum DefaultClients implements Clients {
                 throw newUnknownRemoteException(unknownRemoteException);
             }
 
+            if (cause instanceof QosException qosException) {
+                throw newQosException(qosException);
+            }
+
             // In this case we provide a suppressed exception to mark the site where the failure was rethrown
             // to avoid losing data while retaining the original failure information.
             if (cause instanceof RuntimeException runtimeException) {
@@ -213,6 +218,30 @@ enum DefaultClients implements Clients {
     private static UnknownRemoteException newUnknownRemoteException(UnknownRemoteException cause) {
         UnknownRemoteException newException = new UnknownRemoteException(cause.getStatus(), cause.getBody());
         newException.initCause(cause);
+        return newException;
+    }
+
+    // Re-create QosException so our current stacktrace is included, similar to RemoteException handling
+    private static QosException newQosException(QosException qosException) {
+        QosException newException = qosException.accept(new QosException.Visitor<>() {
+            @Override
+            public QosException visit(QosException.Throttle exception) {
+                return exception.getRetryAfter().isPresent()
+                        ? QosException.throttle(
+                                exception.getReason(), exception.getRetryAfter().get(), qosException)
+                        : QosException.throttle(exception.getReason(), qosException);
+            }
+
+            @Override
+            public QosException visit(QosException.RetryOther exception) {
+                return QosException.retryOther(exception.getReason(), exception.getRedirectTo(), qosException);
+            }
+
+            @Override
+            public QosException visit(QosException.Unavailable exception) {
+                return QosException.unavailable(exception.getReason(), qosException);
+            }
+        });
         return newException;
     }
 

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
@@ -26,6 +26,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.conjure.java.api.errors.AbstractSerializableError;
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.QosException;
+import com.palantir.conjure.java.api.errors.QosReason;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
@@ -35,6 +37,7 @@ import com.palantir.dialogue.DialogueException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -70,6 +73,62 @@ public class DefaultClientsBlockingTest {
                 .satisfies(exception -> {
                     assertThat(((UnknownRemoteException) exception).getBody()).isEqualTo("Nginx broke");
                 });
+    }
+
+    @Test
+    public void testQosExceptionThrottle() {
+        QosException qosException = QosException.throttle(QosReason.of("test-reason"));
+        ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(qosException);
+
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
+                .isInstanceOf(QosException.Throttle.class)
+                .isNotSameAs(qosException)
+                .hasCause(qosException)
+                .satisfies(exception ->
+                        assertThat(((QosException) exception).getReason()).isEqualTo(QosReason.of("test-reason")));
+    }
+
+    @Test
+    public void testQosExceptionThrottleWithRetryAfter() {
+        QosException qosException = QosException.throttle(QosReason.of("test-reason"), Duration.ofSeconds(30));
+        ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(qosException);
+
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
+                .isInstanceOf(QosException.Throttle.class)
+                .isNotSameAs(qosException)
+                .hasCause(qosException)
+                .satisfies(exception -> {
+                    QosException.Throttle throttle = (QosException.Throttle) exception;
+                    assertThat(throttle.getReason()).isEqualTo(QosReason.of("test-reason"));
+                    assertThat(throttle.getRetryAfter()).hasValue(Duration.ofSeconds(30));
+                });
+    }
+
+    @Test
+    public void testQosExceptionUnavailable() {
+        QosException qosException = QosException.unavailable(QosReason.of("test-unavailable"));
+        ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(qosException);
+
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
+                .isInstanceOf(QosException.Unavailable.class)
+                .isNotSameAs(qosException)
+                .hasCause(qosException)
+                .satisfies(exception ->
+                        assertThat(((QosException) exception).getReason()).isEqualTo(QosReason.of("test-unavailable")));
+    }
+
+    @Test
+    public void testQosExceptionStackTraceIncludesBlockCallSite() {
+        QosException qosException = QosException.throttle(QosReason.of("test-reason"));
+        // Clear the stack trace to simulate an exception created on a remote/async thread
+        qosException.setStackTrace(new StackTraceElement[0]);
+        ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(qosException);
+
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
+                .isInstanceOf(QosException.Throttle.class)
+                .satisfies(exception -> assertThat(exception.getStackTrace())
+                        .extracting(StackTraceElement::getMethodName)
+                        .contains("testQosExceptionStackTraceIncludesBlockCallSite"));
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
When QosExceptions are thrown from dialogue blocking clients, they have little useful stacktrace because they're run on a separate executor service from the calling thread.

Example:
```
com.palantir.conjure.java.api.errors.QosException$Throttle: Suggested request throttling
	at com.palantir.conjure.java.api.errors.QosException.throttle(QosException.java:77)
	at com.palantir.conjure.java.dialogue.serde.ExceptionDeserializingErrorDecoder.lambda$decodeInternal$1(ExceptionDeserializingErrorDecoder.java:135)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at com.palantir.conjure.java.dialogue.serde.ExceptionDeserializingErrorDecoder.decodeInternal(ExceptionDeserializingErrorDecoder.java:135)
	at com.palantir.conjure.java.dialogue.serde.ExceptionDeserializingErrorDecoder.decode(ExceptionDeserializingErrorDecoder.java:101)
	at com.palantir.conjure.java.dialogue.serde.ConjureBodySerDe$EncodingDeserializerRegistry.deserialize(ConjureBodySerDe.java:322)
	at com.palantir.dialogue.futures.DialogueDirectTransformationFuture.onSuccess(DialogueDirectTransformationFuture.java:109)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:48)
	at com.palantir.dialogue.futures.DialogueDirectTransformationFuture.onSuccess(DialogueDirectTransformationFuture.java:110)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.AbstractCatchingFuture.run(AbstractCatchingFuture.java:122)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$0(MoreExecutors.java:1063)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.AbstractCatchingFuture.run(AbstractCatchingFuture.java:122)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$0(MoreExecutors.java:1063)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.AbstractCatchingFuture.run(AbstractCatchingFuture.java:122)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$0(MoreExecutors.java:1063)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.AbstractCatchingFuture.run(AbstractCatchingFuture.java:122)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$0(MoreExecutors.java:1063)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.AbstractCatchingFuture.run(AbstractCatchingFuture.java:122)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$0(MoreExecutors.java:1063)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.setFuture(AbstractFuture.java:560)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.setResult(AbstractTransformFuture.java:237)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.setResult(AbstractTransformFuture.java:213)
	at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:172)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$0(MoreExecutors.java:1063)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:48)
	at com.palantir.dialogue.core.RetryingChannel$RetryingCallback$1.onSuccess(RetryingChannel.java:350)
	at com.palantir.dialogue.core.RetryingChannel$RetryingCallback$1.onSuccess(RetryingChannel.java:347)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.setFuture(AbstractFuture.java:560)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.setResult(AbstractTransformFuture.java:237)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.setResult(AbstractTransformFuture.java:213)
	at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:172)
	at com.palantir.dialogue.futures.SafeDirectExecutor.execute(SafeDirectExecutor.java:32)
	at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$0(MoreExecutors.java:1063)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
	at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
	at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:48)
	at com.palantir.dialogue.blocking.BlockingChannelAdapter$BlockingChannelAdapterChannel$BlockingChannelAdapterTask.run(BlockingChannelAdapter.java:141)
	at com.palantir.tracing.Tracers$TracingAwareRunnable.run(Tracers.java:617)
	at com.palantir.tritium.metrics.TaggedMetricsExecutorService$TaggedMetricsRunnable.run(TaggedMetricsExecutorService.java:134)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at com.palantir.nylon.threads.RenamingExecutorService$RenamingRunnable.run(RenamingExecutorService.java:92)
	at org.jboss.threads.EnhancedViewExecutor$EnhancedViewExecutorRunnable.run(EnhancedViewExecutor.java:496)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1622)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
	at com.palantir.tritium.metrics.TaggedMetricsThreadFactory$InstrumentedTask.run(TaggedMetricsThreadFactory.java:94)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	Suppressed: com.palantir.conjure.java.dialogue.serde.ExceptionDeserializingErrorDecoder$ResponseDiagnostic: Response Diagnostic Information
```

## After this PR
==COMMIT_MSG==
Preserve stacktrace for thrown QosExceptions, same as RemoteExceptions
==COMMIT_MSG==

With this change, we apply the same technique that `RemoteExceptions` and `UnknownRemoteExceptions` get in the two clauses above.  Those blocks re-create the exception, but now with the current thread's stacktrace. This will now include the service's callsite, making it easier to determine what codepath is triggering the QosExceptions. It also includes the service + method in the stacktrace (e.g. `DeletionOrchestrationServiceBlocking$1.initializeAndGetActiveServiceDeletionContexts`) making it easier to determine which endpoint is responding with QosExceptions.

## Possible downsides?
- this is now more code to execute during QosExceptions, which happen when the service is already under load.  Ideally we wouldn't put more work on the "service is overloaded" codepath, but I think the improvement in debuggability is worth it to me as a service owner.