### PR TITLE
Don't wrap thrown exceptions in blocking client

### DIFF
--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/DefaultClients.java
@@ -20,10 +20,6 @@ import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.palantir.conjure.java.api.errors.AbstractSerializableError;
-import com.palantir.conjure.java.api.errors.RemoteException;
-import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
-import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Clients;
 import com.palantir.dialogue.Deserializer;
@@ -44,7 +40,6 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.jspecify.annotations.Nullable;
@@ -121,99 +116,21 @@ enum DefaultClients implements Clients {
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
 
-            // TODO(jellis): can consider propagating other relevant exceptions (eg: HttpConnectTimeoutException)
-            // see HttpClientImpl#send(HttpRequest req, BodyHandler<T> responseHandler)
-            if (cause instanceof RemoteException remoteException) {
-                if (cause.getClass() == RemoteException.class) {
-                    throw newRemoteException(remoteException);
-                } else {
-                    // This is a user-defined subclass of RemoteException, so we want to preserve the type. But we also
-                    // want to propagate the current stacktrace. Another (arguably better) option is to add a suppressed
-                    // RuntimeException. In order to preserve backwards compatibility for clients that may inspect the
-                    // cause of a remote exception, we take this approach.
-                    throw newCustomRemoteException(remoteException);
-                }
-            }
-
-            if (cause instanceof UnknownRemoteException unknownRemoteException) {
-                throw newUnknownRemoteException(unknownRemoteException);
-            }
-
             // In this case we provide a suppressed exception to mark the site where the failure was rethrown
             // to avoid losing data while retaining the original failure information.
+
             if (cause instanceof RuntimeException runtimeException) {
                 cause.addSuppressed(new SafeRuntimeException("Rethrown by dialogue"));
                 throw runtimeException;
             }
 
-            // This matches the behavior in Futures.getUnchecked(Future)
             if (cause instanceof Error error) {
                 cause.addSuppressed(new SafeRuntimeException("Rethrown by dialogue"));
                 throw error;
             }
+
             throw new DialogueException(cause);
         }
-    }
-
-    // Need to create a new exception so our current stacktrace is included in the exception
-    private static RemoteException newRemoteException(RemoteException remoteException) {
-        RemoteException newException = new RemoteException(remoteException.getError(), remoteException.getStatus());
-        newException.initCause(remoteException);
-        return newException;
-    }
-
-    private static RemoteException newCustomRemoteException(RemoteException remoteException) {
-        RemoteException newException = createRemoteExceptionWithReflection(remoteException);
-        newException.initCause(remoteException);
-        return newException;
-    }
-
-    private static RemoteException createRemoteExceptionWithReflection(RemoteException remoteException) {
-        try {
-            Class<?> clazz = remoteException.getClass();
-            if (!(remoteException instanceof SerializableErrorProvider)) {
-                log.warn(
-                        "RemoteException subclass does not implement SerializableErrorProvider",
-                        SafeArg.of("remoteExceptionClass", clazz.getSimpleName()));
-                return newRemoteException(remoteException);
-            }
-
-            // Iterate through the constructors and find one that takes (AbstractSerializableError, int)
-            for (Constructor<?> constructor : clazz.getConstructors()) {
-                if (constructor.getParameterCount() != 2) {
-                    continue;
-                }
-                if (!AbstractSerializableError.class.isAssignableFrom(
-                        constructor.getParameterTypes()[0])) {
-                    continue;
-                }
-                if (constructor.getParameterTypes()[1] != int.class) {
-                    continue;
-                }
-                // Found a matching constructor, use it to create a new instance
-                AbstractSerializableError<?> abstractSerializableError =
-                        (AbstractSerializableError<?>) clazz.getMethod("error").invoke(remoteException);
-                return (RemoteException)
-                        constructor.newInstance(abstractSerializableError, remoteException.getStatus());
-            }
-            log.warn(
-                    "Did not find a constructor on "
-                            + "RemoteException subclass with parameters (AbstractSerializableError, int)",
-                    SafeArg.of("remoteExceptionClass", clazz.getSimpleName()));
-        } catch (Exception e) {
-            log.warn(
-                    "Failed to create new RemoteException with reflection, falling back to base type",
-                    SafeArg.of(
-                            "remoteExceptionClass", remoteException.getClass().getSimpleName()),
-                    e);
-        }
-        return newRemoteException(remoteException);
-    }
-
-    private static UnknownRemoteException newUnknownRemoteException(UnknownRemoteException cause) {
-        UnknownRemoteException newException = new UnknownRemoteException(cause.getStatus(), cause.getBody());
-        newException.initCause(cause);
-        return newException;
     }
 
     enum CancelListener implements FutureCallback<Object> {

--- a/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
+++ b/dialogue-serde/src/test/java/com/palantir/conjure/java/dialogue/serde/DefaultClientsBlockingTest.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.conjure.java.api.errors.AbstractSerializableError;
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
@@ -38,6 +39,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 public class DefaultClientsBlockingTest {
@@ -55,8 +57,14 @@ public class DefaultClientsBlockingTest {
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(remoteException);
 
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
-                .isInstanceOf(RemoteException.class)
-                .hasFieldOrPropertyWithValue("status", ErrorType.INVALID_ARGUMENT.httpErrorCode());
+                .isSameAs(remoteException)
+                .satisfies(exception -> {
+                    assertThat(exception.getSuppressed())
+                            .singleElement()
+                            .asInstanceOf(InstanceOfAssertFactories.throwable(SafeRuntimeException.class))
+                            .hasMessage("Rethrown by dialogue")
+                            .hasStackTraceContaining("DefaultClientsBlockingTest");
+                });
     }
 
     @Test
@@ -65,10 +73,29 @@ public class DefaultClientsBlockingTest {
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(remoteException);
 
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
-                .isInstanceOf(UnknownRemoteException.class)
-                .hasMessage("Response status: 502")
+                .isSameAs(remoteException)
                 .satisfies(exception -> {
-                    assertThat(((UnknownRemoteException) exception).getBody()).isEqualTo("Nginx broke");
+                    assertThat(exception.getSuppressed())
+                            .singleElement()
+                            .asInstanceOf(InstanceOfAssertFactories.throwable(SafeRuntimeException.class))
+                            .hasMessage("Rethrown by dialogue")
+                            .hasStackTraceContaining("DefaultClientsBlockingTest");
+                });
+    }
+
+    @Test
+    public void testQosException() {
+        QosException qosException = QosException.unavailable();
+        ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(qosException);
+
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
+                .isSameAs(qosException)
+                .satisfies(exception -> {
+                    assertThat(exception.getSuppressed())
+                            .singleElement()
+                            .asInstanceOf(InstanceOfAssertFactories.throwable(SafeRuntimeException.class))
+                            .hasMessage("Rethrown by dialogue")
+                            .hasStackTraceContaining("DefaultClientsBlockingTest");
                 });
     }
 
@@ -79,10 +106,13 @@ public class DefaultClientsBlockingTest {
 
         assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
                 .isSameAs(runtimeException)
-                .satisfies(exception -> assertThat(exception.getSuppressed()).hasSize(1))
-                .satisfies(exception -> assertThat(exception.getSuppressed()[0])
-                        .isInstanceOf(SafeRuntimeException.class)
-                        .hasMessage("Rethrown by dialogue"));
+                .satisfies(exception -> {
+                    assertThat(exception.getSuppressed())
+                            .singleElement()
+                            .asInstanceOf(InstanceOfAssertFactories.throwable(SafeRuntimeException.class))
+                            .hasMessage("Rethrown by dialogue")
+                            .hasStackTraceContaining("DefaultClientsBlockingTest");
+                });
     }
 
     @Test
@@ -100,7 +130,15 @@ public class DefaultClientsBlockingTest {
         Error error = new Error();
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(error);
 
-        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture)).isSameAs(error);
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
+                .isSameAs(error)
+                .satisfies(exception -> {
+                    assertThat(exception.getSuppressed())
+                            .singleElement()
+                            .asInstanceOf(InstanceOfAssertFactories.throwable(SafeRuntimeException.class))
+                            .hasMessage("Rethrown by dialogue")
+                            .hasStackTraceContaining("DefaultClientsBlockingTest");
+                });
     }
 
     @Test
@@ -160,15 +198,15 @@ public class DefaultClientsBlockingTest {
                 ErrorType.INVALID_ARGUMENT.httpErrorCode());
         ListenableFuture<Object> failedFuture = Futures.immediateFailedFuture(customException);
 
-        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture)).satisfies(exception -> {
-            assertThat(exception).isInstanceOf(CustomRemoteException.class);
-            assertThat(exception).hasMessageContainingAll("Default:InvalidArgument", "{someField=myFieldValue}");
-            assertThat(exception).isInstanceOf(RemoteException.class);
-            assertThat(exception.getCause()).isInstanceOfSatisfying(CustomRemoteException.class, cause -> {
-                assertThat(cause).isNotNull();
-                assertThat(cause).hasMessageContainingAll("Default:InvalidArgument", "{someField=myFieldValue}");
-            });
-        });
+        assertThatThrownBy(() -> DefaultClients.INSTANCE.block(failedFuture))
+                .isSameAs(customException)
+                .satisfies(exception -> {
+                    assertThat(exception.getSuppressed())
+                            .singleElement()
+                            .asInstanceOf(InstanceOfAssertFactories.throwable(SafeRuntimeException.class))
+                            .hasMessage("Rethrown by dialogue")
+                            .hasStackTraceContaining("DefaultClientsBlockingTest");
+                });
     }
 
     public record MyParams(String someField) {}


### PR DESCRIPTION
## Before this PR

When handling failure in `DefaultClients`, some types of `RuntimeException` are reconstructed and re-thrown in order to capture the caller's stacktrace. This approach is quite brittle because it requires us to update this implementation every time new capabilities are added to `RemoteException` or we risk failing to propagate meaningful error information.

## After this PR

We record the caller's stacktrace using suppressed exceptions. This is a more standard and robust way to capture this information that doesn't require this code to make any assumptions about the exceptions and ensure that caller's receive the exact same exception instance that was thrown.

See discussion in https://github.com/palantir/dialogue/pull/2881 for more context.