### PR TITLE
Update `Attachments` to support `remove` and `putIfAbsent`

### DIFF
--- a/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Attachments.java
@@ -44,6 +44,24 @@ final class Attachments {
     }
 
     @Nullable
+    <V> V putIfAbsent(AttachmentKey<V> key, V value) {
+        Preconditions.checkNotNull(key, "key");
+        Preconditions.checkNotNull(value, "value");
+        key.checkIsInstance(value);
+        @SuppressWarnings("unchecked")
+        V result = (V) attachments.putIfAbsent(key, value);
+        return result;
+    }
+
+    @Nullable
+    <V> V remove(AttachmentKey<V> key) {
+        Preconditions.checkNotNull(key, "key");
+        @SuppressWarnings("unchecked")
+        V result = (V) attachments.remove(key);
+        return result;
+    }
+
+    @Nullable
     <V> V getOrDefault(AttachmentKey<V> key, @Nullable V defaultValue) {
         Preconditions.checkNotNull(key, "key");
         @SuppressWarnings("unchecked")

--- a/dialogue-target/src/main/java/com/palantir/dialogue/RequestAttachments.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/RequestAttachments.java
@@ -34,6 +34,16 @@ public final class RequestAttachments {
     }
 
     @Nullable
+    public <V> V putIfAbsent(RequestAttachmentKey<V> key, V value) {
+        return attachments.putIfAbsent(key.attachment(), value);
+    }
+
+    @Nullable
+    public <V> V remove(RequestAttachmentKey<V> key) {
+        return attachments.remove(key.attachment());
+    }
+
+    @Nullable
     public <V> V getOrDefault(RequestAttachmentKey<V> key, @Nullable V defaultValue) {
         return attachments.getOrDefault(key.attachment(), defaultValue);
     }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestAttachmentsTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestAttachmentsTest.java
@@ -30,4 +30,30 @@ public final class RequestAttachmentsTest {
         requestAttachments.put(ATTACHMENT_KEY, true);
         assertThat(requestAttachments.getOrDefault(ATTACHMENT_KEY, false)).isTrue();
     }
+
+    @Test
+    public void testPutIfAbsent() {
+        RequestAttachments requestAttachments = RequestAttachments.create();
+        assertThat(requestAttachments.putIfAbsent(ATTACHMENT_KEY, true)).isNull();
+        assertThat(requestAttachments.putIfAbsent(ATTACHMENT_KEY, false))
+                .as("putIfAbsent should return existing value")
+                .isTrue();
+        assertThat(requestAttachments.getOrDefault(ATTACHMENT_KEY, false))
+                .as("original value should be unchanged")
+                .isTrue();
+    }
+
+    @Test
+    public void testRemove() {
+        RequestAttachments requestAttachments = RequestAttachments.create();
+        requestAttachments.put(ATTACHMENT_KEY, true);
+        assertThat(requestAttachments.remove(ATTACHMENT_KEY)).isTrue();
+        assertThat(requestAttachments.getOrDefault(ATTACHMENT_KEY, null)).isNull();
+    }
+
+    @Test
+    public void testRemoveWhenAbsent() {
+        RequestAttachments requestAttachments = RequestAttachments.create();
+        assertThat(requestAttachments.remove(ATTACHMENT_KEY)).isNull();
+    }
 }


### PR DESCRIPTION
In #2926 I would like to atomically update the value of the queue timeout request attachment if it's not already set. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update `Attachments` to support `remove` and `putIfAbsent`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

