### PR TITLE
Conjure error parameter is not overridden by custom runtime

### DIFF
--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ErrorSerializationFormatSettingConjureRuntime.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ErrorSerializationFormatSettingConjureRuntime.java
@@ -30,6 +30,10 @@ import com.palantir.dialogue.TypeMarker;
 import java.io.InputStream;
 import java.util.Optional;
 
+/**
+ * Wraps a user-supplied {@link ConjureRuntime} to override {@link BodySerDe#errorParameterFormat()}. Since
+ * {@link ConjureRuntime} is an interface, we can't mutate the caller's instance (passed via {@code withRuntime}).
+ */
 final class ErrorSerializationFormatSettingConjureRuntime implements ConjureRuntime {
     private final ConjureRuntime delegate;
     private final BodySerDe bodySerDe;

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -115,8 +115,18 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         Refreshable<ServicesConfigBlock> scb();
 
         @Value.Default
-        default ConjureRuntime runtime() {
+        default ConjureRuntime baseRuntime() {
             return DefaultConjureRuntime.builder().build();
+        }
+
+        Optional<ConjureErrorParameterFormat> conjureErrorParameterFormat();
+
+        @Value.Derived
+        default ConjureRuntime runtime() {
+            return conjureErrorParameterFormat()
+                    .<ConjureRuntime>map(
+                            format -> new ErrorSerializationFormatSettingConjureRuntime(baseRuntime(), format))
+                    .orElseGet(this::baseRuntime);
         }
 
         @Value.Default
@@ -332,7 +342,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
     @Override
     public DialogueClients.ReloadingFactory withRuntime(ConjureRuntime runtime) {
-        return new ReloadingClientFactory(params.withRuntime(runtime), cache);
+        return new ReloadingClientFactory(params.withBaseRuntime(runtime), cache);
     }
 
     @Override
@@ -383,8 +393,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
     @Override
     public ReloadingFactory withConjureErrorParameterFormat(ConjureErrorParameterFormat format) {
-        return new ReloadingClientFactory(
-                params.withRuntime(new ErrorSerializationFormatSettingConjureRuntime(params.runtime(), format)), cache);
+        return new ReloadingClientFactory(params.withConjureErrorParameterFormat(format), cache);
     }
 
     @Override

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -121,6 +121,8 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
         Optional<ConjureErrorParameterFormat> conjureErrorParameterFormat();
 
+        // ConjureRuntime is an interface: we can't mutate it so instead we use a delegating wrapper to update the
+        // error serialization format.
         @Value.Derived
         default ConjureRuntime runtime() {
             return conjureErrorParameterFormat()

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
@@ -128,6 +128,24 @@ class ReloadingClientFactoryTest {
         assertThat(originalService.runtime().bodySerDe().errorParameterFormat()).isEmpty();
     }
 
+    @Test
+    void withRuntime_after_withConjureErrorParameterFormat_preserves_format() {
+        ChannelCache mockCache = mock(ChannelCache.class);
+        ImmutableReloadingParams params = ImmutableReloadingParams.builder()
+                .scb(Refreshable.only(ServicesConfigBlock.builder().build()))
+                .build();
+        ReloadingClientFactory factory = new ReloadingClientFactory(params, mockCache);
+
+        ReloadingFactory modifiedFactory = factory.withConjureErrorParameterFormat(
+                        ConjureErrorParameterFormat.JSON_FORMAT)
+                .withRuntime(DefaultConjureRuntime.builder().build());
+
+        RuntimeCapturingService service = modifiedFactory.get(RuntimeCapturingService.class, "foo");
+
+        assertThat(service.runtime().bodySerDe().errorParameterFormat())
+                .contains(ConjureErrorParameterFormat.JSON_FORMAT);
+    }
+
     @DialogueService(RuntimeCapturingService.Factory.class)
     private record RuntimeCapturingService(ConjureRuntime runtime) {
         static RuntimeCapturingService of(ConjureRuntime runtime) {


### PR DESCRIPTION
## Before this PR
Setting the Conjure error parameter format with `withConjureErrorParameterFormat` creates an interface that extends `ConjureRuntime` where `runtime#bodySerDe#errorParameterFormat` returns the set format. When `withRuntime` is called after the error parameter format is set, the interface created that set the format is replaced. The ordering of `withRuntime` and `withConjureErrorParameterFormat` matters.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
The order should not matter.

==COMMIT_MSG==
Conjure error parameter is not overridden by custom runtime
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Any client relying on `withRuntime` to clear the previously set error parameter format will now break. This is incorrect and unintended behavior. There are no such callers internally.