### PR TITLE
Provide more metadata in CIAD debug logs

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java
@@ -54,8 +54,16 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
 
     private final Behavior behavior;
 
+    // Used strictly for providing the channel name in debug logs.
+    // Volatile because it may be set from a different thread than the one emitting the log line.
+    private volatile String channelNameForLogging = "unknown";
+
     CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior behavior) {
         this.behavior = behavior;
+    }
+
+    void setChannelNameForLogging(String value) {
+        this.channelNameForLogging = value;
     }
 
     /**
@@ -219,7 +227,12 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
             inFlight.decrementAndGet();
             double newLimit = accumulateAndGetLimit(inFlightSnapshot, LimitUpdater.DROPPED);
             if (log.isDebugEnabled()) {
-                log.debug("Decreasing limit {}", SafeArg.of("newLimit", newLimit));
+                log.debug(
+                        "Decreasing limit on {} to {}",
+                        SafeArg.of("channel", channelNameForLogging),
+                        SafeArg.of("newLimit", newLimit),
+                        SafeArg.of("behavior", behavior),
+                        SafeArg.of("inFlightSnapshot", inFlightSnapshot));
             }
         }
 
@@ -228,7 +241,12 @@ final class CautiousIncreaseAggressiveDecreaseConcurrencyLimiter {
             inFlight.decrementAndGet();
             double newLimit = accumulateAndGetLimit(inFlightSnapshot, LimitUpdater.SUCCESS);
             if (log.isDebugEnabled()) {
-                log.debug("Increasing limit {}", SafeArg.of("newLimit", newLimit));
+                log.debug(
+                        "Increasing limit on {} to {}",
+                        SafeArg.of("channel", channelNameForLogging),
+                        SafeArg.of("newLimit", newLimit),
+                        SafeArg.of("behavior", behavior),
+                        SafeArg.of("inFlightSnapshot", inFlightSnapshot));
             }
         }
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/ConcurrencyLimitedChannel.java
@@ -64,6 +64,7 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
                 hostSpecificState.getState(HOST_SPECIFIC_STATE_KEY);
         ConcurrencyLimitedChannelInstrumentation instrumentation =
                 new HostConcurrencyLimitedChannelInstrumentation(cf.channelName(), uriIndex, limiter, metrics);
+        limiter.setChannelNameForLogging(instrumentation.channelNameForLogging());
         return new ConcurrencyLimitedChannel(channel, limiter, instrumentation);
     }
 
@@ -73,10 +74,12 @@ final class ConcurrencyLimitedChannel implements LimitedChannel {
      */
     static LimitedChannel createForEndpoint(
             Channel channel, String channelName, int uriIndex, Endpoint endpoint, ChannelState endpointChannelState) {
-        return new ConcurrencyLimitedChannel(
-                channel,
-                endpointChannelState.getState(ENDPOINT_SPECIFIC_STATE_KEY),
-                new EndpointConcurrencyLimitedChannelInstrumentation(channelName, uriIndex, endpoint));
+        CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter =
+                endpointChannelState.getState(ENDPOINT_SPECIFIC_STATE_KEY);
+        ConcurrencyLimitedChannelInstrumentation instrumentation =
+                new EndpointConcurrencyLimitedChannelInstrumentation(channelName, uriIndex, endpoint);
+        limiter.setChannelNameForLogging(instrumentation.channelNameForLogging());
+        return new ConcurrencyLimitedChannel(channel, limiter, instrumentation);
     }
 
     ConcurrencyLimitedChannel(

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/StickyConcurrencyLimitedChannel.java
@@ -78,8 +78,10 @@ final class StickyConcurrencyLimitedChannel implements LimitedChannel {
     }
 
     static LimitedChannel create(LimitedChannel channel, String channelName) {
-        return new StickyConcurrencyLimitedChannel(
-                channel, new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.STICKY), channelName);
+        CautiousIncreaseAggressiveDecreaseConcurrencyLimiter limiter =
+                new CautiousIncreaseAggressiveDecreaseConcurrencyLimiter(Behavior.STICKY);
+        limiter.setChannelNameForLogging(channelName);
+        return new StickyConcurrencyLimitedChannel(channel, limiter, channelName);
     }
 
     private void logPermitAcquired() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The debug logs in `CautiousIncreaseAggressiveDecreaseConcurrencyLimiter` [do not contain any metadata](https://github.com/palantir/dialogue/blob/618c94b99be0d1e0e1cdf79c8a77dee2da447aee/dialogue-core/src/main/java/com/palantir/dialogue/core/CautiousIncreaseAggressiveDecreaseConcurrencyLimiter.java#L222) pertaining to the channel/limiter updated.

We should add some metadata to make it easier to debug our CIAD logic.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Provide more metadata in CIAD debug logs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

