### PR TITLE
Fix Dialogue client memory leak when using `generateErrorParameterFormatRespectingDialogueInterfaces`

### DIFF
--- a/dialogue-example/build.gradle
+++ b/dialogue-example/build.gradle
@@ -7,3 +7,9 @@ subprojects {
     tasks.checkImplicitDependenciesMain.enabled = false
     tasks.checkUnusedDependenciesMain.enabled = false
 }
+
+conjure {
+    java {
+        generateErrorParameterFormatRespectingDialogueInterfaces = true
+    }
+}

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ConjureBodySerDe.java
@@ -21,6 +21,7 @@ import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.net.HttpHeaders;
 import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
@@ -28,6 +29,7 @@ import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.Deserializer;
 import com.palantir.dialogue.ExceptionDeserializerArgs;
+import com.palantir.dialogue.ExceptionDeserializerArgs.ErrorExceptionPair;
 import com.palantir.dialogue.RequestBody;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.Serializer;
@@ -63,7 +65,7 @@ final class ConjureBodySerDe implements BodySerDe {
     private final Deserializer<Void> emptyBodyDeserializer;
     private final LoadingCache<Type, Serializer<?>> serializers;
     private final LoadingCache<Type, Deserializer<?>> deserializers;
-    private final LoadingCache<ExceptionDeserializerCacheKey<?>, Deserializer<?>> exceptionDeserializers;
+    private final LoadingCache<ExceptionDeserializerCacheKey, Deserializer<?>> exceptionDeserializers;
 
     /**
      * Selects the first (based on input order) of the provided encodings that
@@ -107,9 +109,9 @@ final class ConjureBodySerDe implements BodySerDe {
                 .build(key -> deserializerFor(
                         key.type(),
                         emptyContainerDeserializer,
-                        key.args().returnType(),
+                        TypeMarker.of(key.returnType()),
                         new ExceptionDeserializingErrorDecoder(
-                                key.args().errorNameToExceptionTypeMarkers(), expectJsonErrors())));
+                                key.errorNameToExceptionTypeMarkers(), expectJsonErrors())));
     }
 
     @SuppressWarnings("unchecked")
@@ -445,14 +447,22 @@ final class ConjureBodySerDe implements BodySerDe {
         INPUT_STREAM_OR_OPTIONAL_INPUT_STREAM,
     }
 
-    private record ExceptionDeserializerCacheKey<T>(ExceptionDeserializerArgs<T> args, DeserializerType type) {
+    private record ExceptionDeserializerCacheKey(
+            // We use Type rather than TypeMarker here, because `new TypeMarker<T>() {}` retains references
+            // to the dialogue clients which construct them, which causes memory to leak when stored in the cache
+            Type returnType,
+            ImmutableMap<String, ErrorExceptionPair<?, ?>> errorNameToExceptionTypeMarkers,
+            DeserializerType type) {
         ExceptionDeserializerCacheKey {
-            Preconditions.checkNotNull(args, "args must be non-null");
+            Preconditions.checkNotNull(returnType, "returnType must be non-null");
+            Preconditions.checkNotNull(
+                    errorNameToExceptionTypeMarkers, "errorNameToExceptionTypeMarkers must be non-null");
             Preconditions.checkNotNull(type, "type must be non-null");
         }
 
-        static <T> ExceptionDeserializerCacheKey<T> of(ExceptionDeserializerArgs<T> args, DeserializerType type) {
-            return new ExceptionDeserializerCacheKey<>(args, type);
+        static <T> ExceptionDeserializerCacheKey of(ExceptionDeserializerArgs<T> args, DeserializerType type) {
+            return new ExceptionDeserializerCacheKey(
+                    args.returnType().getType(), args.errorNameToExceptionTypeMarkers(), type);
         }
     }
 }


### PR DESCRIPTION
## Before this PR
When you set `generateErrorParameterFormatRespectingDialogueInterfaces` to true, the `DialogueClientsDnsIntegrationTest#nonReloadableClientConfig` and corresponding `nonReloadableServiceConfig` start failing at the last step, which verifies that when you orphan the dialogue client, the corresponding metric gets cleaned up.

This actually does not work when using generateErrorParameterFormatRespectingDialogueInterfaces because it generates code like
```java
private final Deserializer<Void> voidToVoidDeserializer = _runtime.bodySerDe()
        .emptyBodyDeserializer(createExceptionDeserializerArgs(new TypeMarker<Void>() {}));
```

The `new TypeMarker<Void>() {}` is the issue here, because
- It keeps a reference to the parent object (i.e. the dialogue client)
- It is retained by the `ConjureBodySerde`'s `exceptionDeserializers` cache (since it's part of the key, and it doesn't use weak keys)

<img width="2502" height="1074" alt="image" src="https://github.com/user-attachments/assets/5ca6e074-de41-4fc8-9338-7caee511ef07" />

This means that dialogue clients constructed with `generateErrorParameterFormatRespectingDialogueInterfaces` cannot get GC'ed, which in general isn't a problem since they're meant to be long-lived, but could actually result in a memory leak when using sticky clients, which tend to create new clients every time

Edit: This is actually unlikely to be a big problem, since two instances of the same client would end up hitting the same cache keys, due to `TypeMarker` checking equality on the underlying `Type`, and since we don't use weak keys, so only the first created instance would be incorrectly retained. Still not ideal though, and worth a simple fix.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix Dialogue client memory leak when using `generateErrorParameterFormatRespectingDialogueInterfaces`
==COMMIT_MSG==

The fix here is to not use the `ExceptionDeserializerArgs` objects directly as the cache key, but instead extract its information to build the actual cache key.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

