### PR TITLE
Support setting a per-client response size limit

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -332,6 +332,12 @@ acceptedBreaks:
         \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory::withDeadlineEnforcement(boolean)"
       justification: "New method added to allow clients to set deadline enforcement.\
         \ This interface is only consumed externally, not implemented."
+  "6.31.0":
+    com.palantir.dialogue:dialogue-clients:
+    - code: "java.method.addedToInterface"
+      new: "method com.palantir.dialogue.clients.DialogueClients.ReloadingFactory\
+        \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory::withMaxResponseSize(long)"
+      justification: "ReloadingClientFactory is meant to be consumed, not implemented"
   "6.7.0":
     com.palantir.dialogue:dialogue-target:
     - code: "java.class.removed"

--- a/dialogue-client-verifier/build.gradle
+++ b/dialogue-client-verifier/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     testImplementation 'com.palantir.safe-logging:logger'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
+
+    testAnnotationProcessor 'org.immutables:value'
+    testCompileOnly 'org.immutables:value::annotations'
 }
 
 subprojects {

--- a/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
+++ b/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class IntegrationTest {
     private static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of("BinaryReturnTypeTest", "0.0.0"));
@@ -180,7 +181,7 @@ public class IntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"false", "true"})
+    @ValueSource(booleans = {true, false})
     public void input_stream_response_sizes_are_not_limited(boolean gzippedResponse) throws IOException {
         String content = "a".repeat(MAX_RESPONSE_SIZE * 2);
 
@@ -197,7 +198,7 @@ public class IntegrationTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"false", "true"})
+    @ValueSource(booleans = {true, false})
     public void optional_input_stream_response_sizes_are_not_limited(boolean gzippedResponse) throws IOException {
         String content = "a".repeat(MAX_RESPONSE_SIZE * 2);
 

--- a/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
+++ b/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
@@ -17,6 +17,7 @@
 package com.palantir.verification;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.base.Stopwatch;
@@ -30,8 +31,11 @@ import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.dialogue.clients.DialogueClients.ReloadingFactory;
+import com.palantir.dialogue.clients.ResponseSizeTooLargeException;
 import com.palantir.dialogue.example.AliasOfAliasOfOptional;
 import com.palantir.dialogue.example.AliasOfOptional;
 import com.palantir.dialogue.example.SampleServiceAsync;
@@ -46,20 +50,26 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPOutputStream;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.immutables.value.Value;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class IntegrationTest {
     private static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of("BinaryReturnTypeTest", "0.0.0"));
@@ -68,9 +78,12 @@ public class IntegrationTest {
             Paths.get("../dialogue-core/src/test/resources/keyStore.jks"),
             "keystore");
 
+    private static final int MAX_RESPONSE_SIZE = 128;
+
     private Undertow undertow;
     private HttpHandler undertowHandler;
     private SampleServiceBlocking blocking;
+    private SampleServiceBlocking blockingMaxResponseSize;
     private SampleServiceAsync async;
 
     @BeforeEach
@@ -92,6 +105,9 @@ public class IntegrationTest {
 
         blocking = factory.getNonReloading(SampleServiceBlocking.class, config);
         async = factory.getNonReloading(SampleServiceAsync.class, config);
+
+        blockingMaxResponseSize =
+                factory.withMaxResponseSize(MAX_RESPONSE_SIZE).getNonReloading(SampleServiceBlocking.class, config);
     }
 
     @Test
@@ -129,6 +145,110 @@ public class IntegrationTest {
 
         assertThat(maybeBinary).isPresent();
         assertThat(maybeBinary.get()).hasSameContentAs(asInputStream("Hello, world"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false, false", "false, true", "true,  false", "true,  true"})
+    public void limiting_response_size(boolean belowLimit, boolean gzippedResponse) throws IOException {
+        // We surround the content with quotes, so the response size is 2 more than the content
+        String content = "a".repeat(belowLimit ? MAX_RESPONSE_SIZE - 2 : MAX_RESPONSE_SIZE - 1);
+
+        String jsonContent = "\"" + content + "\"";
+
+        Response wireResponse = Response.builder()
+                .gzipped(gzippedResponse)
+                .contents(jsonContent)
+                .build();
+
+        if (gzippedResponse) {
+            // Even if the gzipped response itself is below the limit, we are measuring the response size after
+            // decompression, since the goal is to protect against memory consumption upon deserialization
+            assertThat(wireResponse.wireContents().length).isLessThan(MAX_RESPONSE_SIZE);
+        }
+        undertowHandler = wireResponse.handler();
+
+        if (belowLimit) {
+            AliasOfOptional response = blockingMaxResponseSize.getMyAlias();
+
+            assertThat(response.get()).isPresent();
+            assertThat(response.get()).hasValue(content);
+        } else {
+            assertThatException()
+                    .isThrownBy(() -> blockingMaxResponseSize.getMyAlias())
+                    .isInstanceOf(ResponseSizeTooLargeException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false", "true"})
+    public void input_stream_response_sizes_are_not_limited(boolean gzippedResponse) throws IOException {
+        String content = "a".repeat(MAX_RESPONSE_SIZE * 2);
+
+        undertowHandler = Response.builder()
+                .contentType("application/octet-stream")
+                .gzipped(gzippedResponse)
+                .contents(content)
+                .buildHandler();
+
+        // Even if we are above the limit, input streams can still properly deserialize
+        try (InputStream response = blockingMaxResponseSize.getBinary()) {
+            assertThat(response).hasContent(content);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false", "true"})
+    public void optional_input_stream_response_sizes_are_not_limited(boolean gzippedResponse) throws IOException {
+        String content = "a".repeat(MAX_RESPONSE_SIZE * 2);
+
+        undertowHandler = Response.builder()
+                .contentType("application/octet-stream")
+                .gzipped(gzippedResponse)
+                .contents(content)
+                .buildHandler();
+
+        // Even if we are above the limit, input streams can still properly deserialize
+        try (InputStream response = blockingMaxResponseSize.getOptionalBinary().get()) {
+            assertThat(response).hasContent(content);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false, false", "false, true", "true,  false", "true,  true"})
+    public void limiting_response_size_for_errors(boolean belowLimit, boolean gzippedResponse) throws IOException {
+        String content = "{\"errorCode\":\"errorCode\",\"errorName\":\"" + "test".repeat(belowLimit ? 1 : 128) + "\"}";
+
+        undertowHandler = Response.builder()
+                .code(400)
+                .gzipped(gzippedResponse)
+                .contents(content)
+                .buildHandler();
+
+        // No matter where we get the exception from, it should be limited if above the limit,
+        // even if a non-error response would not be limited
+        Map<String, ThrowingCallable> cases = Map.of(
+                "json", () -> blockingMaxResponseSize.getMyAlias(),
+                "empty", () -> blockingMaxResponseSize.voidToVoid(),
+                "input stream", () -> blockingMaxResponseSize.getBinary(),
+                "optional input stream", () -> blockingMaxResponseSize.getOptionalBinary());
+        cases.forEach((description, callable) -> {
+            if (belowLimit) {
+                assertThatException()
+                        .describedAs(description)
+                        .isThrownBy(callable)
+                        .isInstanceOf(RemoteException.class)
+                        .extracting(e -> ((RemoteException) e).getError())
+                        .isEqualTo(SerializableError.builder()
+                                .errorCode("errorCode")
+                                .errorName("test")
+                                .build());
+            } else {
+                assertThatException()
+                        .describedAs(description)
+                        .isThrownBy(callable)
+                        .isInstanceOf(ResponseSizeTooLargeException.class);
+            }
+        });
     }
 
     @Test
@@ -229,19 +349,71 @@ public class IntegrationTest {
     }
 
     private void set204Response() {
-        undertowHandler = exchange -> exchange.setStatusCode(204);
+        undertowHandler = Response.builder().code(204).contents("").buildHandler();
     }
 
     private void setBinaryGzipResponse(String stringToCompress) {
-        undertowHandler = exchange -> {
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/octet-stream");
-            Preconditions.checkArgument(exchange.getRequestHeaders().contains(Headers.ACCEPT_ENCODING));
-            Preconditions.checkArgument(exchange.getRequestHeaders()
-                    .getFirst(Headers.ACCEPT_ENCODING)
-                    .contains("gzip"));
-            exchange.getResponseHeaders().put(Headers.CONTENT_ENCODING, "gzip");
-            exchange.getOutputStream().write(gzipCompress(stringToCompress));
-        };
+        undertowHandler = Response.builder()
+                .contentType("application/octet-stream")
+                .gzipped(true)
+                .contents(stringToCompress)
+                .buildHandler();
+    }
+
+    @Value.Immutable
+    interface Response {
+        @Value.Default
+        default int code() {
+            return 200;
+        }
+
+        @Value.Default
+        default String contentType() {
+            return "application/json";
+        }
+
+        @Value.Default
+        default boolean gzipped() {
+            return false;
+        }
+
+        String contents();
+
+        @Value.Derived
+        default byte[] wireContents() {
+            try {
+                return gzipped() ? gzipCompress(contents()) : contents().getBytes(StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Value.Derived
+        default HttpHandler handler() {
+            return exchange -> {
+                exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, contentType());
+                exchange.setStatusCode(code());
+
+                if (gzipped()) {
+                    Preconditions.checkArgument(exchange.getRequestHeaders().contains(Headers.ACCEPT_ENCODING));
+                    Preconditions.checkArgument(exchange.getRequestHeaders()
+                            .getFirst(Headers.ACCEPT_ENCODING)
+                            .contains("gzip"));
+                    exchange.getResponseHeaders().put(Headers.CONTENT_ENCODING, "gzip");
+                }
+                exchange.getOutputStream().write(wireContents());
+            };
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        final class Builder extends ImmutableResponse.Builder {
+            public HttpHandler buildHandler() {
+                return build().handler();
+            }
+        }
     }
 
     @AfterEach

--- a/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
+++ b/dialogue-client-verifier/src/test/java/com/palantir/verification/IntegrationTest.java
@@ -46,6 +46,7 @@ import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.BlockingHandler;
 import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -150,7 +151,7 @@ public class IntegrationTest {
 
     @ParameterizedTest
     @CsvSource({"false, false", "false, true", "true,  false", "true,  true"})
-    public void limiting_response_size(boolean belowLimit, boolean gzippedResponse) throws IOException {
+    public void limiting_response_size(boolean belowLimit, boolean gzippedResponse) {
         // We surround the content with quotes, so the response size is 2 more than the content
         String content = "a".repeat(belowLimit ? MAX_RESPONSE_SIZE - 2 : MAX_RESPONSE_SIZE - 1);
 
@@ -178,6 +179,24 @@ public class IntegrationTest {
                     .isThrownBy(() -> blockingMaxResponseSize.getMyAlias())
                     .isInstanceOf(ResponseSizeTooLargeException.class);
         }
+    }
+
+    @Test
+    public void response_size_limit_does_not_include_headers() {
+        // We surround the content with quotes, so the response size is 2 more than the content
+        String content = "a".repeat(MAX_RESPONSE_SIZE - 2);
+
+        String jsonContent = "\"" + content + "\"";
+
+        undertowHandler = Response.builder()
+                .putHeaders(Headers.USER_AGENT, "fake".repeat(1280))
+                .contents(jsonContent)
+                .buildHandler();
+
+        AliasOfOptional response = blockingMaxResponseSize.getMyAlias();
+
+        assertThat(response.get()).isPresent();
+        assertThat(response.get()).hasValue(content);
     }
 
     @ParameterizedTest
@@ -216,7 +235,7 @@ public class IntegrationTest {
 
     @ParameterizedTest
     @CsvSource({"false, false", "false, true", "true,  false", "true,  true"})
-    public void limiting_response_size_for_errors(boolean belowLimit, boolean gzippedResponse) throws IOException {
+    public void limiting_response_size_for_errors(boolean belowLimit, boolean gzippedResponse) {
         String content = "{\"errorCode\":\"errorCode\",\"errorName\":\"" + "test".repeat(belowLimit ? 1 : 128) + "\"}";
 
         undertowHandler = Response.builder()
@@ -389,9 +408,13 @@ public class IntegrationTest {
             }
         }
 
+        Map<HttpString, String> headers();
+
         @Value.Derived
         default HttpHandler handler() {
             return exchange -> {
+                headers().forEach(exchange.getResponseHeaders()::put);
+
                 exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, contentType());
                 exchange.setStatusCode(code());
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -209,6 +209,12 @@ public final class DialogueClients {
          */
         ReloadingFactory withDeadlineEnforcement(boolean deadlineEnforcementEnabled);
 
+        /**
+         * Configures the maximum size of responses that will be accepted.
+         * Any response received by a server, which exceeds this size, will throw an exception.
+         */
+        ReloadingFactory withMaxResponseSize(long maxResponseSize);
+
         StickyChannelFactory getStickyChannels(String serviceName);
 
         @Beta

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -28,6 +28,7 @@ import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.core.DialogueChannel;
 import com.palantir.dialogue.core.DialogueDnsResolver;
 import com.palantir.refreshable.Refreshable;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -211,7 +212,11 @@ public final class DialogueClients {
 
         /**
          * Configures the maximum size of responses that will be accepted.
-         * Any response received by a server, which exceeds this size, will throw an exception.
+         * Any response received by a server exceeding this size and which dialogue attempts to deserialize will throw
+         * a {@link ResponseSizeTooLargeException}.
+         *
+         * This does not impact responses returning {@link InputStream},
+         * which are not actually deserialized by dialogue.
          */
         ReloadingFactory withMaxResponseSize(long maxResponseSize);
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -211,7 +211,9 @@ public final class DialogueClients {
         ReloadingFactory withDeadlineEnforcement(boolean deadlineEnforcementEnabled);
 
         /**
-         * Configures the maximum size of responses that will be accepted.
+         * Configures the maximum size of response bodies (i.e. headers and other parts of the response are not limited)
+         * that will be accepted.
+         *
          * Any response received by a server exceeding this size and which dialogue attempts to deserialize will throw
          * a {@link ResponseSizeTooLargeException}.
          *

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -115,6 +115,11 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         Refreshable<ServicesConfigBlock> scb();
 
         @Value.Default
+        default long maxResponseSize() {
+            return -1L;
+        }
+
+        @Value.Default
         default ConjureRuntime baseRuntime() {
             return DefaultConjureRuntime.builder().build();
         }
@@ -125,10 +130,15 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         // error serialization format.
         @Value.Derived
         default ConjureRuntime runtime() {
-            return conjureErrorParameterFormat()
-                    .<ConjureRuntime>map(
-                            format -> new ErrorSerializationFormatSettingConjureRuntime(baseRuntime(), format))
-                    .orElseGet(this::baseRuntime);
+            ConjureRuntime runtime = baseRuntime();
+            if (maxResponseSize() > -1) {
+                runtime = new ResponseSizeLimitingConjureRuntime(runtime, maxResponseSize());
+            }
+            if (conjureErrorParameterFormat().isPresent()) {
+                runtime = new ErrorSerializationFormatSettingConjureRuntime(
+                        runtime, conjureErrorParameterFormat().get());
+            }
+            return runtime;
         }
 
         @Value.Default
@@ -416,6 +426,11 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
     @Override
     public ReloadingFactory withDeadlineEnforcement(boolean deadlineEnforcementEnabled) {
         return new ReloadingClientFactory(params.withDeadlineEnforcement(deadlineEnforcementEnabled), cache);
+    }
+
+    @Override
+    public ReloadingFactory withMaxResponseSize(long maxResponseSize) {
+        return new ReloadingClientFactory(params.withMaxResponseSize(maxResponseSize), cache);
     }
 
     @Override

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -126,8 +126,10 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
         Optional<ConjureErrorParameterFormat> conjureErrorParameterFormat();
 
-        // ConjureRuntime is an interface: we can't mutate it so instead we use a delegating wrapper to update the
-        // error serialization format.
+        // ConjureRuntime is an interface: we can't mutate it so instead we use delegating wrappers to update the
+        // various settings we want
+        // We also can't actually set it directly in baseRuntime, because it does not get recomputed when
+        //   withXXX is called on the immutable params class
         @Value.Derived
         default ConjureRuntime runtime() {
             ConjureRuntime runtime = baseRuntime();

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -63,6 +63,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -115,8 +116,8 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         Refreshable<ServicesConfigBlock> scb();
 
         @Value.Default
-        default long maxResponseSize() {
-            return -1L;
+        default OptionalLong maxResponseSize() {
+            return OptionalLong.empty();
         }
 
         @Value.Default
@@ -133,8 +134,9 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
         @Value.Derived
         default ConjureRuntime runtime() {
             ConjureRuntime runtime = baseRuntime();
-            if (maxResponseSize() > -1) {
-                runtime = new ResponseSizeLimitingConjureRuntime(runtime, maxResponseSize());
+            if (maxResponseSize().isPresent()) {
+                runtime = new ResponseSizeLimitingConjureRuntime(
+                        runtime, maxResponseSize().getAsLong());
             }
             if (conjureErrorParameterFormat().isPresent()) {
                 runtime = new ErrorSerializationFormatSettingConjureRuntime(
@@ -432,6 +434,7 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
     @Override
     public ReloadingFactory withMaxResponseSize(long maxResponseSize) {
+        Preconditions.checkArgument(maxResponseSize > 0, "maxResponseSize must be positive");
         return new ReloadingClientFactory(params.withMaxResponseSize(maxResponseSize), cache);
     }
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
@@ -174,7 +174,7 @@ final class ResponseSizeLimitingConjureRuntime implements ConjureRuntime {
 
         @Override
         public Optional<String> accepts() {
-            return Optional.empty();
+            return delegate.accepts();
         }
     }
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue.clients;
 
 import com.google.common.collect.ListMultimap;
 import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
+import com.palantir.conjure.java.dialogue.serde.ErrorDecoder;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.Clients;
@@ -84,49 +85,56 @@ final class ResponseSizeLimitingConjureRuntime implements ConjureRuntime {
 
         @Override
         public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
-            return new ResponseSizeLimitingDeserializer<>(delegate.deserializer(type), maxResponseSize);
+            return ResponseSizeLimitingDeserializer.alwaysLimit(delegate.deserializer(type), maxResponseSize);
         }
 
         @Override
         public <T> Deserializer<T> deserializer(ExceptionDeserializerArgs<T> exceptionDeserializerArgs) {
-            return new ResponseSizeLimitingDeserializer<>(
+            return ResponseSizeLimitingDeserializer.alwaysLimit(
                     delegate.deserializer(exceptionDeserializerArgs), maxResponseSize);
         }
 
         @Override
         public Deserializer<Void> emptyBodyDeserializer() {
-            return new ResponseSizeLimitingDeserializer<>(delegate.emptyBodyDeserializer(), maxResponseSize);
+            // Even if we expect no response, we could get an error, so this needs to be wrapped as well
+            return ResponseSizeLimitingDeserializer.onlyLimitErrors(delegate.emptyBodyDeserializer(), maxResponseSize);
         }
 
         @Override
         public Deserializer<Void> emptyBodyDeserializer(ExceptionDeserializerArgs<Void> exceptionDeserializerArgs) {
-            return new ResponseSizeLimitingDeserializer<>(
+            // Even if we expect no response, we could get an error, so this needs to be wrapped as well
+            return ResponseSizeLimitingDeserializer.onlyLimitErrors(
                     delegate.emptyBodyDeserializer(exceptionDeserializerArgs), maxResponseSize);
         }
 
-        // Note: we don't apply the limit to input stream deserializers, since they are not directly deserialized
+        // Note: we don't apply the limit when returning input streams, since they are not directly deserialized
         // and could be trivially limited by the callers if desired
+        // However, we do apply the limit when the response is actually an error, since that is deserialized
 
         @Override
         public Deserializer<InputStream> inputStreamDeserializer() {
-            return delegate.inputStreamDeserializer();
+            return ResponseSizeLimitingDeserializer.onlyLimitErrors(
+                    delegate.inputStreamDeserializer(), maxResponseSize);
         }
 
         @Override
         public Deserializer<InputStream> inputStreamDeserializer(
                 ExceptionDeserializerArgs<InputStream> exceptionDeserializerArgs) {
-            return delegate.inputStreamDeserializer(exceptionDeserializerArgs);
+            return ResponseSizeLimitingDeserializer.onlyLimitErrors(
+                    delegate.inputStreamDeserializer(exceptionDeserializerArgs), maxResponseSize);
         }
 
         @Override
         public Deserializer<Optional<InputStream>> optionalInputStreamDeserializer() {
-            return delegate.optionalInputStreamDeserializer();
+            return ResponseSizeLimitingDeserializer.onlyLimitErrors(
+                    delegate.optionalInputStreamDeserializer(), maxResponseSize);
         }
 
         @Override
         public Deserializer<Optional<InputStream>> optionalInputStreamDeserializer(
                 ExceptionDeserializerArgs<Optional<InputStream>> exceptionDeserializerArgs) {
-            return delegate.optionalInputStreamDeserializer(exceptionDeserializerArgs);
+            return ResponseSizeLimitingDeserializer.onlyLimitErrors(
+                    delegate.optionalInputStreamDeserializer(exceptionDeserializerArgs), maxResponseSize);
         }
 
         @Override
@@ -138,15 +146,30 @@ final class ResponseSizeLimitingConjureRuntime implements ConjureRuntime {
     private static final class ResponseSizeLimitingDeserializer<T> implements Deserializer<T> {
         private final Deserializer<T> delegate;
         private final long maxResponseSize;
+        private final boolean onlyLimitErrors;
 
-        ResponseSizeLimitingDeserializer(Deserializer<T> delegate, long maxResponseSize) {
+        private ResponseSizeLimitingDeserializer(
+                Deserializer<T> delegate, long maxResponseSize, boolean onlyLimitErrors) {
             this.delegate = delegate;
             this.maxResponseSize = maxResponseSize;
+            this.onlyLimitErrors = onlyLimitErrors;
+        }
+
+        static <T> ResponseSizeLimitingDeserializer<T> alwaysLimit(Deserializer<T> delegate, long limit) {
+            return new ResponseSizeLimitingDeserializer<>(delegate, limit, false);
+        }
+
+        static <T> ResponseSizeLimitingDeserializer<T> onlyLimitErrors(Deserializer<T> delegate, long limit) {
+            return new ResponseSizeLimitingDeserializer<>(delegate, limit, true);
         }
 
         @Override
         public T deserialize(Response response) {
-            return delegate.deserialize(new ResponseSizeLimitingResponse(response, maxResponseSize));
+            if (onlyLimitErrors && !ErrorDecoder.INSTANCE.isError(response)) {
+                return delegate.deserialize(response);
+            } else {
+                return delegate.deserialize(new ResponseSizeLimitingResponse(response, maxResponseSize));
+            }
         }
 
         @Override

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
@@ -34,8 +34,10 @@ import java.io.InputStream;
 import java.util.Optional;
 
 /**
- * Wraps a user-supplied {@link ConjureRuntime} to override {@link BodySerDe#errorParameterFormat()}. Since
- * {@link ConjureRuntime} is an interface, we can't mutate the caller's instance (passed via {@code withRuntime}).
+ * Wraps a user-supplied {@link ConjureRuntime} such that deserializers will throw an exception upon reading
+ * more bytes than the specified limit.
+ * <p>
+ * Since {@link ConjureRuntime} is an interface, we can't mutate the caller's instance (passed via {@code withRuntime}).
  */
 final class ResponseSizeLimitingConjureRuntime implements ConjureRuntime {
     private final ConjureRuntime delegate;

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeLimitingConjureRuntime.java
@@ -1,0 +1,197 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.google.common.collect.ListMultimap;
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
+import com.palantir.dialogue.BinaryRequestBody;
+import com.palantir.dialogue.BodySerDe;
+import com.palantir.dialogue.Clients;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.ExceptionDeserializerArgs;
+import com.palantir.dialogue.PlainSerDe;
+import com.palantir.dialogue.RequestBody;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.ResponseAttachments;
+import com.palantir.dialogue.Serializer;
+import com.palantir.dialogue.TypeMarker;
+import java.io.InputStream;
+import java.util.Optional;
+
+/**
+ * Wraps a user-supplied {@link ConjureRuntime} to override {@link BodySerDe#errorParameterFormat()}. Since
+ * {@link ConjureRuntime} is an interface, we can't mutate the caller's instance (passed via {@code withRuntime}).
+ */
+final class ResponseSizeLimitingConjureRuntime implements ConjureRuntime {
+    private final ConjureRuntime delegate;
+    private final BodySerDe bodySerDe;
+
+    ResponseSizeLimitingConjureRuntime(ConjureRuntime delegate, long maxResponseSize) {
+        this.delegate = delegate;
+        this.bodySerDe = new ResponseSizeLimitingBodySerDe(delegate.bodySerDe(), maxResponseSize);
+    }
+
+    @Override
+    public BodySerDe bodySerDe() {
+        return bodySerDe;
+    }
+
+    @Override
+    public PlainSerDe plainSerDe() {
+        return delegate.plainSerDe();
+    }
+
+    @Override
+    public Clients clients() {
+        return delegate.clients();
+    }
+
+    private static final class ResponseSizeLimitingBodySerDe implements BodySerDe {
+        private final BodySerDe delegate;
+        private final long maxResponseSize;
+
+        ResponseSizeLimitingBodySerDe(BodySerDe delegate, long maxResponseSize) {
+            this.delegate = delegate;
+            this.maxResponseSize = maxResponseSize;
+        }
+
+        @Override
+        public Optional<ConjureErrorParameterFormat> errorParameterFormat() {
+            return delegate.errorParameterFormat();
+        }
+
+        @Override
+        public <T> Serializer<T> serializer(TypeMarker<T> type) {
+            return delegate.serializer(type);
+        }
+
+        @Override
+        public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
+            return new ResponseSizeLimitingDeserializer<>(delegate.deserializer(type), maxResponseSize);
+        }
+
+        @Override
+        public <T> Deserializer<T> deserializer(ExceptionDeserializerArgs<T> exceptionDeserializerArgs) {
+            return new ResponseSizeLimitingDeserializer<>(
+                    delegate.deserializer(exceptionDeserializerArgs), maxResponseSize);
+        }
+
+        @Override
+        public Deserializer<Void> emptyBodyDeserializer() {
+            return new ResponseSizeLimitingDeserializer<>(delegate.emptyBodyDeserializer(), maxResponseSize);
+        }
+
+        @Override
+        public Deserializer<Void> emptyBodyDeserializer(ExceptionDeserializerArgs<Void> exceptionDeserializerArgs) {
+            return new ResponseSizeLimitingDeserializer<>(
+                    delegate.emptyBodyDeserializer(exceptionDeserializerArgs), maxResponseSize);
+        }
+
+        // Note: we don't apply the limit to input stream deserializers, since they are not directly deserialized
+        // and could be trivially limited by the callers if desired
+
+        @Override
+        public Deserializer<InputStream> inputStreamDeserializer() {
+            return delegate.inputStreamDeserializer();
+        }
+
+        @Override
+        public Deserializer<InputStream> inputStreamDeserializer(
+                ExceptionDeserializerArgs<InputStream> exceptionDeserializerArgs) {
+            return delegate.inputStreamDeserializer(exceptionDeserializerArgs);
+        }
+
+        @Override
+        public Deserializer<Optional<InputStream>> optionalInputStreamDeserializer() {
+            return delegate.optionalInputStreamDeserializer();
+        }
+
+        @Override
+        public Deserializer<Optional<InputStream>> optionalInputStreamDeserializer(
+                ExceptionDeserializerArgs<Optional<InputStream>> exceptionDeserializerArgs) {
+            return delegate.optionalInputStreamDeserializer(exceptionDeserializerArgs);
+        }
+
+        @Override
+        public RequestBody serialize(BinaryRequestBody value) {
+            return delegate.serialize(value);
+        }
+    }
+
+    private static final class ResponseSizeLimitingDeserializer<T> implements Deserializer<T> {
+        private final Deserializer<T> delegate;
+        private final long maxResponseSize;
+
+        ResponseSizeLimitingDeserializer(Deserializer<T> delegate, long maxResponseSize) {
+            this.delegate = delegate;
+            this.maxResponseSize = maxResponseSize;
+        }
+
+        @Override
+        public T deserialize(Response response) {
+            return delegate.deserialize(new ResponseSizeLimitingResponse(response, maxResponseSize));
+        }
+
+        @Override
+        public Optional<String> accepts() {
+            return Optional.empty();
+        }
+    }
+
+    private static final class ResponseSizeLimitingResponse implements Response {
+        private final Response delegate;
+        private final SizeLimitedInputStream limitedBody;
+
+        ResponseSizeLimitingResponse(Response delegate, long maxResponseSize) {
+            this.delegate = delegate;
+            this.limitedBody = new SizeLimitedInputStream(delegate.body(), maxResponseSize);
+        }
+
+        @Override
+        public InputStream body() {
+            return limitedBody;
+        }
+
+        @Override
+        public int code() {
+            return delegate.code();
+        }
+
+        @Override
+        public ListMultimap<String, String> headers() {
+            return delegate.headers();
+        }
+
+        @Override
+        public Optional<String> getFirstHeader(String header) {
+            return delegate.getFirstHeader(header);
+        }
+
+        @Override
+        public ResponseAttachments attachments() {
+            return delegate.attachments();
+        }
+
+        @Override
+        public void close() {
+            // This will close the underlying body input stream as well as needed
+            // We don't need to close the SizeLimitedInputStream wrapper itself
+            delegate.close();
+        }
+    }
+}

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeTooLargeException.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ResponseSizeTooLargeException.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.List;
+
+public final class ResponseSizeTooLargeException extends RuntimeException implements SafeLoggable {
+
+    @Safe
+    private final long maxBytes;
+
+    public ResponseSizeTooLargeException(@Safe long maxBytes) {
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public @Safe String getLogMessage() {
+        return "Exceeded maximum allowed bytes read";
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return List.of(SafeArg.of("limit", maxBytes));
+    }
+}

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
@@ -16,7 +16,6 @@
 
 package com.palantir.dialogue.clients;
 
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -49,7 +48,7 @@ final class SizeLimitedInputStream extends FilterInputStream {
     public int read() throws IOException {
         int read = super.read();
         if (read != -1 && bytesRead++ > maxBytes) {
-            throw new SafeIllegalStateException("Exceeded maximum allowed bytes read", SafeArg.of("limit", maxBytes));
+            throw new ResponseSizeTooLargeException(maxBytes);
         }
         return read;
     }
@@ -60,8 +59,7 @@ final class SizeLimitedInputStream extends FilterInputStream {
         if (count > 0) {
             bytesRead += count;
             if (bytesRead > maxBytes) {
-                throw new SafeIllegalStateException(
-                        "Exceeded maximum allowed bytes read", SafeArg.of("limit", maxBytes));
+                throw new ResponseSizeTooLargeException(maxBytes);
             }
         }
         return count;

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 final class SizeLimitedInputStream extends FilterInputStream {
 
     private final long maxBytes;
+
     private long bytesRead = 0;
 
     SizeLimitedInputStream(InputStream in, long maxBytes) {

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * TODO
+ */
+final class SizeLimitedInputStream extends FilterInputStream {
+
+    private final long maxBytes;
+    private long bytesRead = 0;
+
+    SizeLimitedInputStream(InputStream in, long maxBytes) {
+        super(in);
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int read = super.read();
+        if (read != -1 && bytesRead++ > maxBytes) {
+            throw new SafeIllegalStateException("Exceeded maximum allowed bytes read", SafeArg.of("limit", maxBytes));
+        }
+        return read;
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+        int count = super.read(buf, off, len);
+        if (count > 0) {
+            bytesRead += count;
+            if (bytesRead > maxBytes) {
+                throw new SafeIllegalStateException(
+                        "Exceeded maximum allowed bytes read", SafeArg.of("limit", maxBytes));
+            }
+        }
+        return count;
+    }
+}

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
@@ -23,7 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * TODO
+ * Wrapper class that limits the number of bytes read from an underlying {@link InputStream}.
+ * Upon reading more bytes than the specified limit, a {@link SafeIllegalStateException} is thrown.
+ * <p>
+ * This does not account for skipped bytes, the goal being to protect against memory consumption from reading too many
+ * bytes.
  */
 final class SizeLimitedInputStream extends FilterInputStream {
 
@@ -34,6 +38,12 @@ final class SizeLimitedInputStream extends FilterInputStream {
         super(in);
         this.maxBytes = maxBytes;
     }
+
+    // We only need to override the below two methods, because all other read methods delegate to them
+    // All read methods are tested in SizeLimitedInputStreamTest to confirm this
+    // Note that this does not cover new read methods that could be added in the future which may not delegate to the
+    // below methods, but we can't protect against this as far as I know, and it's highly unlikely that this will
+    // happen
 
     @Override
     public int read() throws IOException {

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/SizeLimitedInputStream.java
@@ -16,14 +16,13 @@
 
 package com.palantir.dialogue.clients;
 
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 /**
  * Wrapper class that limits the number of bytes read from an underlying {@link InputStream}.
- * Upon reading more bytes than the specified limit, a {@link SafeIllegalStateException} is thrown.
+ * Upon reading more bytes than the specified limit, a {@link ResponseSizeTooLargeException} is thrown.
  * <p>
  * This does not account for skipped bytes, the goal being to protect against memory consumption from reading too many
  * bytes.

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
@@ -28,6 +28,8 @@ import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -41,7 +43,6 @@ import com.palantir.dialogue.clients.DialogueClients.ReloadingFactory;
 import com.palantir.dialogue.clients.ReloadingClientFactory.LiveReloadingChannel;
 import com.palantir.dialogue.example.SampleServiceAsync;
 import com.palantir.dialogue.example.SampleServiceBlocking;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.refreshable.Refreshable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -151,7 +152,28 @@ class ReloadingClientFactoryTest {
 
         assertThatException()
                 .isThrownBy(() -> deserializeString(runtime, "\"" + "test".repeat(1280) + "\""))
-                .isInstanceOf(SafeIllegalStateException.class);
+                .isInstanceOf(ResponseSizeTooLargeException.class);
+    }
+
+    @Test
+    void withMaxResponseSize_deserializers_respects_max_size_for_errors() {
+        ReloadingFactory factory = getFactory().withMaxResponseSize(128L);
+
+        ConjureRuntime runtime = getRuntime(factory);
+
+        assertThatException()
+                .isThrownBy(() -> deserializeError(runtime, "{\"errorCode\":\"errorCode\",\"errorName\":\"test\"}"))
+                .isInstanceOf(RemoteException.class)
+                .extracting(e -> ((RemoteException) e).getError())
+                .isEqualTo(SerializableError.builder()
+                        .errorCode("errorCode")
+                        .errorName("test")
+                        .build());
+
+        assertThatException()
+                .isThrownBy(() -> deserializeError(
+                        runtime, "{\"errorCode\":\"errorCode\",\"errorName\":\"" + "test".repeat(1280) + "\"}"))
+                .isInstanceOf(ResponseSizeTooLargeException.class);
     }
 
     private static ReloadingClientFactory getFactory() {
@@ -168,13 +190,17 @@ class ReloadingClientFactoryTest {
     }
 
     private static String deserializeString(ConjureRuntime runtime, String body) {
-        return deserialize(runtime, body, new TypeMarker<>() {});
+        return deserialize(runtime, 200, body, new TypeMarker<>() {});
     }
 
-    private static <T> T deserialize(ConjureRuntime runtime, String body, TypeMarker<T> type) {
-        return runtime.bodySerDe()
-                .deserializer(type)
-                .deserialize(TestResponse.withBody(body).withHeader(HttpHeaders.CONTENT_TYPE, "application/json"));
+    private static void deserializeError(ConjureRuntime runtime, String body) {
+        deserialize(runtime, 400, body, new TypeMarker<>() {});
+    }
+
+    private static <T> T deserialize(ConjureRuntime runtime, int code, String body, TypeMarker<T> type) {
+        TestResponse response = TestResponse.withBody(body).withHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        response.code(code);
+        return runtime.bodySerDe().deserializer(type).deserialize(response);
     }
 
     @DialogueService(RuntimeCapturingService.Factory.class)

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
@@ -17,12 +17,14 @@
 package com.palantir.dialogue.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
@@ -33,10 +35,13 @@ import com.palantir.dialogue.DialogueService;
 import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.TestResponse;
+import com.palantir.dialogue.TypeMarker;
 import com.palantir.dialogue.clients.DialogueClients.ReloadingFactory;
 import com.palantir.dialogue.clients.ReloadingClientFactory.LiveReloadingChannel;
 import com.palantir.dialogue.example.SampleServiceAsync;
 import com.palantir.dialogue.example.SampleServiceBlocking;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.refreshable.Refreshable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,6 +149,34 @@ class ReloadingClientFactoryTest {
 
         assertThat(service.runtime().bodySerDe().errorParameterFormat())
                 .contains(ConjureErrorParameterFormat.JSON_FORMAT);
+    }
+
+    @Test
+    void withMaxResponseSize_deserializers_respects_max_size() {
+        ChannelCache mockCache = mock(ChannelCache.class);
+        ImmutableReloadingParams params = ImmutableReloadingParams.builder()
+                .scb(Refreshable.only(ServicesConfigBlock.builder().build()))
+                .build();
+        ReloadingClientFactory factory = new ReloadingClientFactory(params, mockCache);
+
+        ReloadingFactory modifiedFactory = factory.withMaxResponseSize(128L);
+
+        RuntimeCapturingService service = modifiedFactory.get(RuntimeCapturingService.class, "foo");
+
+        assertThat(service.runtime()
+                        .bodySerDe()
+                        .deserializer(TypeMarker.of(String.class))
+                        .deserialize(TestResponse.withBody("\"test\"")
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")))
+                .isEqualTo("test");
+
+        assertThatException()
+                .isThrownBy(() -> service.runtime()
+                        .bodySerDe()
+                        .deserializer(TypeMarker.of(String.class))
+                        .deserialize(TestResponse.withBody("\"" + "test".repeat(1280) + "\"")
+                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")))
+                .isInstanceOf(SafeIllegalStateException.class);
     }
 
     @DialogueService(RuntimeCapturingService.Factory.class)

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
@@ -18,6 +18,7 @@ package com.palantir.dialogue.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Fail.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -31,12 +32,16 @@ import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
+import com.palantir.dialogue.BodySerDe;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.Deserializer;
 import com.palantir.dialogue.DialogueService;
 import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.ExceptionDeserializerArgs;
+import com.palantir.dialogue.Response;
 import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.dialogue.clients.DialogueClients.ReloadingFactory;
@@ -44,9 +49,17 @@ import com.palantir.dialogue.clients.ReloadingClientFactory.LiveReloadingChannel
 import com.palantir.dialogue.example.SampleServiceAsync;
 import com.palantir.dialogue.example.SampleServiceBlocking;
 import com.palantir.refreshable.Refreshable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -142,27 +155,95 @@ class ReloadingClientFactoryTest {
                 .contains(ConjureErrorParameterFormat.JSON_FORMAT);
     }
 
-    @Test
-    void withMaxResponseSize_deserializers_respects_max_size() {
+    private static <T> ExceptionDeserializerArgs<T> exceptionDeserializerArgs(TypeMarker<T> type) {
+        return ExceptionDeserializerArgs.<T>builder().returnType(type).build();
+    }
+
+    enum Deserializers {
+        BASIC,
+        WITH_EXCEPTION_ARGS,
+        EMPTY,
+        EMPTY_WITH_EXCEPTION_ARGS,
+        INPUT_STREAM,
+        INPUT_STREAM_WITH_EXCEPTION_ARGS,
+        OPTIONAL_INPUT_STREAM,
+        OPTIONAL_INPUT_STREAM_WITH_EXCEPTION_ARGS;
+
+        private static <T> Deserializer<T> unwrap(Deserializer<Optional<T>> deserializer) {
+            return new Deserializer<>() {
+                @Override
+                public T deserialize(Response response) {
+                    return deserializer.deserialize(response).get();
+                }
+
+                @Override
+                public Optional<String> accepts() {
+                    return deserializer.accepts();
+                }
+            };
+        }
+
+        public Deserializer<?> deserializer(ConjureRuntime runtime) {
+            BodySerDe bodySerDe = runtime.bodySerDe();
+            return switch (this) {
+                case BASIC -> bodySerDe.deserializer(new TypeMarker<String>() {});
+                case WITH_EXCEPTION_ARGS ->
+                    bodySerDe.deserializer(exceptionDeserializerArgs(new TypeMarker<String>() {}));
+                case EMPTY -> bodySerDe.emptyBodyDeserializer();
+                case EMPTY_WITH_EXCEPTION_ARGS ->
+                    bodySerDe.emptyBodyDeserializer(exceptionDeserializerArgs(new TypeMarker<>() {}));
+                case INPUT_STREAM -> bodySerDe.inputStreamDeserializer();
+                case INPUT_STREAM_WITH_EXCEPTION_ARGS ->
+                    bodySerDe.inputStreamDeserializer(exceptionDeserializerArgs(new TypeMarker<>() {}));
+                case OPTIONAL_INPUT_STREAM -> unwrap(bodySerDe.optionalInputStreamDeserializer());
+                case OPTIONAL_INPUT_STREAM_WITH_EXCEPTION_ARGS ->
+                    unwrap(bodySerDe.optionalInputStreamDeserializer(exceptionDeserializerArgs(new TypeMarker<>() {})));
+            };
+        }
+    }
+
+    private static Stream<Deserializers> alwaysLimitingDeserializers() {
+        return Stream.of(Deserializers.BASIC, Deserializers.WITH_EXCEPTION_ARGS);
+    }
+
+    private static Stream<Deserializers> errorLimitingDeserializers() {
+        return Arrays.stream(Deserializers.values());
+    }
+
+    private static Stream<Deserializers> inputStreamDeserializers() {
+        return Stream.of(
+                Deserializers.INPUT_STREAM,
+                Deserializers.INPUT_STREAM_WITH_EXCEPTION_ARGS,
+                Deserializers.OPTIONAL_INPUT_STREAM,
+                Deserializers.OPTIONAL_INPUT_STREAM_WITH_EXCEPTION_ARGS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("alwaysLimitingDeserializers")
+    void withMaxResponseSize_deserializers_respects_max_size(Deserializers arg) {
         ReloadingFactory factory = getFactory().withMaxResponseSize(128L);
 
         ConjureRuntime runtime = getRuntime(factory);
 
-        assertThat(deserializeString(runtime, "\"test\"")).isEqualTo("test");
+        Deserializer<String> deserializer = (Deserializer<String>) arg.deserializer(runtime);
+        assertThat(deserialize(deserializer, "\"test\"")).isEqualTo("test");
 
         assertThatException()
-                .isThrownBy(() -> deserializeString(runtime, "\"" + "test".repeat(1280) + "\""))
+                .isThrownBy(() -> deserialize(deserializer, "\"" + "test".repeat(1280) + "\""))
                 .isInstanceOf(ResponseSizeTooLargeException.class);
     }
 
-    @Test
-    void withMaxResponseSize_deserializers_respects_max_size_for_errors() {
+    @ParameterizedTest
+    @MethodSource("errorLimitingDeserializers")
+    void withMaxResponseSize_deserializers_respects_max_size_for_errors(Deserializers arg) {
         ReloadingFactory factory = getFactory().withMaxResponseSize(128L);
 
         ConjureRuntime runtime = getRuntime(factory);
 
+        Deserializer<?> deserializer = arg.deserializer(runtime);
         assertThatException()
-                .isThrownBy(() -> deserializeError(runtime, "{\"errorCode\":\"errorCode\",\"errorName\":\"test\"}"))
+                .isThrownBy(
+                        () -> deserializeError(deserializer, "{\"errorCode\":\"errorCode\",\"errorName\":\"test\"}"))
                 .isInstanceOf(RemoteException.class)
                 .extracting(e -> ((RemoteException) e).getError())
                 .isEqualTo(SerializableError.builder()
@@ -172,8 +253,29 @@ class ReloadingClientFactoryTest {
 
         assertThatException()
                 .isThrownBy(() -> deserializeError(
-                        runtime, "{\"errorCode\":\"errorCode\",\"errorName\":\"" + "test".repeat(1280) + "\"}"))
+                        deserializer, "{\"errorCode\":\"errorCode\",\"errorName\":\"" + "test".repeat(1280) + "\"}"))
                 .isInstanceOf(ResponseSizeTooLargeException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputStreamDeserializers")
+    void withMaxResponseSize_deserializers_ignores_max_size_for_input_streams(Deserializers arg) throws IOException {
+        ReloadingFactory factory = getFactory().withMaxResponseSize(128L);
+
+        ConjureRuntime runtime = getRuntime(factory);
+
+        Deserializer<InputStream> deserializer = (Deserializer<InputStream>) arg.deserializer(runtime);
+        String shortString = "test";
+        try (InputStream deserialized = deserialize(deserializer, "application/octet-stream", 200, shortString)) {
+            assertThat(new String(deserialized.readAllBytes(), StandardCharsets.UTF_8))
+                    .isEqualTo(shortString);
+        }
+
+        String longString = "test".repeat(1280);
+        try (InputStream deserialized = deserialize(deserializer, "application/octet-stream", 200, longString)) {
+            assertThat(new String(deserialized.readAllBytes(), StandardCharsets.UTF_8))
+                    .isEqualTo(longString);
+        }
     }
 
     private static ReloadingClientFactory getFactory() {
@@ -189,18 +291,19 @@ class ReloadingClientFactoryTest {
         return service.runtime();
     }
 
-    private static String deserializeString(ConjureRuntime runtime, String body) {
-        return deserialize(runtime, 200, body, new TypeMarker<>() {});
+    private static void deserializeError(Deserializer<?> deserializer, String body) {
+        deserialize(deserializer, "application/json", 400, body);
+        fail("Should have thrown an exception upon deserializing");
     }
 
-    private static void deserializeError(ConjureRuntime runtime, String body) {
-        deserialize(runtime, 400, body, new TypeMarker<>() {});
+    private static <T> T deserialize(Deserializer<T> deserializer, String body) {
+        return deserialize(deserializer, "application/json", 200, body);
     }
 
-    private static <T> T deserialize(ConjureRuntime runtime, int code, String body, TypeMarker<T> type) {
-        TestResponse response = TestResponse.withBody(body).withHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+    private static <T> T deserialize(Deserializer<T> deserializer, String contentType, int code, String body) {
+        TestResponse response = TestResponse.withBody(body).withHeader(HttpHeaders.CONTENT_TYPE, contentType);
         response.code(code);
-        return runtime.bodySerDe().deserializer(type).deserialize(response);
+        return deserializer.deserialize(response);
     }
 
     @DialogueService(RuntimeCapturingService.Factory.class)

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
@@ -51,7 +51,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ReloadingClientFactoryTest {
-    private final DefaultConjureRuntime runtime =
+    private final DefaultConjureRuntime defaultRuntime =
             DefaultConjureRuntime.builder().build();
 
     interface Foo extends Channel, EndpointChannelFactory {}
@@ -73,7 +73,7 @@ class ReloadingClientFactoryTest {
 
     @Test
     void plain_codegen_uses_the_EndpointChannelFactory_channel() {
-        SampleServiceBlocking.of((Channel) channel, runtime);
+        SampleServiceBlocking.of((Channel) channel, defaultRuntime);
 
         // ensure we use the bind method
         verify(channel, atLeastOnce()).endpoint(any());
@@ -81,7 +81,7 @@ class ReloadingClientFactoryTest {
 
     @Test
     void plain_codegen_uses_the_EndpointChannelFactory_factory() {
-        SampleServiceBlocking.of((EndpointChannelFactory) channel, runtime);
+        SampleServiceBlocking.of((EndpointChannelFactory) channel, defaultRuntime);
 
         // ensure we use the bind method
         verify(channel, atLeastOnce()).endpoint(any());
@@ -89,8 +89,9 @@ class ReloadingClientFactoryTest {
 
     @Test
     void live_reloading_wrapper_still_uses_the_EndpointChannelFactory_channel() {
-        LiveReloadingChannel live = new LiveReloadingChannel(Refreshable.create(channel), runtime.clients());
-        assertThat(SampleServiceAsync.of((Channel) live, runtime).getMyAlias()).isNotDone();
+        LiveReloadingChannel live = new LiveReloadingChannel(Refreshable.create(channel), defaultRuntime.clients());
+        assertThat(SampleServiceAsync.of((Channel) live, defaultRuntime).getMyAlias())
+                .isNotDone();
 
         // ensure we use the bind method
         verify(channel, atLeastOnce()).endpoint(any());
@@ -98,8 +99,9 @@ class ReloadingClientFactoryTest {
 
     @Test
     void live_reloading_wrapper_still_uses_the_EndpointChannelFactory_factory() {
-        LiveReloadingChannel live = new LiveReloadingChannel(Refreshable.only(channel), runtime.clients());
-        assertThat(SampleServiceAsync.of((EndpointChannelFactory) live, runtime).getMyAlias())
+        LiveReloadingChannel live = new LiveReloadingChannel(Refreshable.only(channel), defaultRuntime.clients());
+        assertThat(SampleServiceAsync.of((EndpointChannelFactory) live, defaultRuntime)
+                        .getMyAlias())
                 .isNotDone();
 
         // ensure we use the bind method
@@ -108,41 +110,29 @@ class ReloadingClientFactoryTest {
 
     @Test
     void withConjureErrorParameterSerializationFormat_wraps_runtime_with_specified_format() {
-        ChannelCache mockCache = mock(ChannelCache.class);
-        ImmutableReloadingParams params = ImmutableReloadingParams.builder()
-                .scb(Refreshable.only(ServicesConfigBlock.builder().build()))
-                .build();
-        ReloadingClientFactory factory = new ReloadingClientFactory(params, mockCache);
+        ReloadingClientFactory factory = getFactory();
 
         // Get the original runtime
-        ConjureRuntime originalRuntime = params.runtime();
+        ConjureRuntime originalRuntime = getRuntime(factory);
         assertThat(originalRuntime.bodySerDe().errorParameterFormat()).isEmpty();
 
         // Set the error parameter format to JSON
         ReloadingFactory modifiedFactory =
                 factory.withConjureErrorParameterFormat(ConjureErrorParameterFormat.JSON_FORMAT);
 
-        // Call get
-        RuntimeCapturingService service = modifiedFactory.get(RuntimeCapturingService.class, "foo");
+        ConjureRuntime modifiedRuntime = getRuntime(modifiedFactory);
 
-        assertThat(service.runtime().bodySerDe().errorParameterFormat())
+        assertThat(modifiedRuntime.bodySerDe().errorParameterFormat())
                 .contains(ConjureErrorParameterFormat.JSON_FORMAT);
 
         // Verify that the original runtime is unchanged
-        RuntimeCapturingService originalService = factory.get(RuntimeCapturingService.class, "foo");
-        assertThat(originalService.runtime().bodySerDe().errorParameterFormat()).isEmpty();
+        assertThat(getRuntime(factory).bodySerDe().errorParameterFormat()).isEmpty();
     }
 
     @Test
     void withRuntime_after_withConjureErrorParameterFormat_preserves_format() {
-        ChannelCache mockCache = mock(ChannelCache.class);
-        ImmutableReloadingParams params = ImmutableReloadingParams.builder()
-                .scb(Refreshable.only(ServicesConfigBlock.builder().build()))
-                .build();
-        ReloadingClientFactory factory = new ReloadingClientFactory(params, mockCache);
-
-        ReloadingFactory modifiedFactory = factory.withConjureErrorParameterFormat(
-                        ConjureErrorParameterFormat.JSON_FORMAT)
+        ReloadingFactory modifiedFactory = getFactory()
+                .withConjureErrorParameterFormat(ConjureErrorParameterFormat.JSON_FORMAT)
                 .withRuntime(DefaultConjureRuntime.builder().build());
 
         RuntimeCapturingService service = modifiedFactory.get(RuntimeCapturingService.class, "foo");
@@ -153,30 +143,38 @@ class ReloadingClientFactoryTest {
 
     @Test
     void withMaxResponseSize_deserializers_respects_max_size() {
+        ReloadingFactory factory = getFactory().withMaxResponseSize(128L);
+
+        ConjureRuntime runtime = getRuntime(factory);
+
+        assertThat(deserializeString(runtime, "\"test\"")).isEqualTo("test");
+
+        assertThatException()
+                .isThrownBy(() -> deserializeString(runtime, "\"" + "test".repeat(1280) + "\""))
+                .isInstanceOf(SafeIllegalStateException.class);
+    }
+
+    private static ReloadingClientFactory getFactory() {
         ChannelCache mockCache = mock(ChannelCache.class);
         ImmutableReloadingParams params = ImmutableReloadingParams.builder()
                 .scb(Refreshable.only(ServicesConfigBlock.builder().build()))
                 .build();
-        ReloadingClientFactory factory = new ReloadingClientFactory(params, mockCache);
+        return new ReloadingClientFactory(params, mockCache);
+    }
 
-        ReloadingFactory modifiedFactory = factory.withMaxResponseSize(128L);
+    private static ConjureRuntime getRuntime(ReloadingFactory factory) {
+        RuntimeCapturingService service = factory.get(RuntimeCapturingService.class, "foo");
+        return service.runtime();
+    }
 
-        RuntimeCapturingService service = modifiedFactory.get(RuntimeCapturingService.class, "foo");
+    private static String deserializeString(ConjureRuntime runtime, String body) {
+        return deserialize(runtime, body, new TypeMarker<>() {});
+    }
 
-        assertThat(service.runtime()
-                        .bodySerDe()
-                        .deserializer(TypeMarker.of(String.class))
-                        .deserialize(TestResponse.withBody("\"test\"")
-                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")))
-                .isEqualTo("test");
-
-        assertThatException()
-                .isThrownBy(() -> service.runtime()
-                        .bodySerDe()
-                        .deserializer(TypeMarker.of(String.class))
-                        .deserialize(TestResponse.withBody("\"" + "test".repeat(1280) + "\"")
-                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")))
-                .isInstanceOf(SafeIllegalStateException.class);
+    private static <T> T deserialize(ConjureRuntime runtime, String body, TypeMarker<T> type) {
+        return runtime.bodySerDe()
+                .deserializer(type)
+                .deserialize(TestResponse.withBody(body).withHeader(HttpHeaders.CONTENT_TYPE, "application/json"));
     }
 
     @DialogueService(RuntimeCapturingService.Factory.class)

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/SizeLimitedInputStreamTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/SizeLimitedInputStreamTest.java
@@ -30,6 +30,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+/**
+ * Tests all the different InputStream read methods against various cases (e.g. reading fewer/more/exactly as many bytes
+ * as the configured limit, as well as when the stream has less/more/equals as many bytes as the configured limit).
+ */
 public class SizeLimitedInputStreamTest {
 
     private static final int BYTES_LIMIT = 1024;

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/SizeLimitedInputStreamTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/SizeLimitedInputStreamTest.java
@@ -19,7 +19,6 @@ package com.palantir.dialogue.clients;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -128,7 +127,7 @@ public class SizeLimitedInputStreamTest {
             if (available.size > BYTES_LIMIT && toRead > BYTES_LIMIT) {
                 assertThatException()
                         .isThrownBy(() -> readDesired(readBytes, stream, toRead))
-                        .isInstanceOf(SafeIllegalStateException.class);
+                        .isInstanceOf(ResponseSizeTooLargeException.class);
             } else {
                 assertThat(readDesired(readBytes, stream, toRead))
                         .isEqualTo(Math.min(Math.min(toRead, BYTES_LIMIT), available.size));

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/SizeLimitedInputStreamTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/SizeLimitedInputStreamTest.java
@@ -1,0 +1,162 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SizeLimitedInputStreamTest {
+
+    private static final int BYTES_LIMIT = 1024;
+
+    enum BytesAvailable {
+        BELOW_LIMIT(512),
+        EXACT_LIMIT(1024),
+        ABOVE_LIMIT(2048);
+
+        private final int size;
+
+        BytesAvailable(int size) {
+            this.size = size;
+        }
+    }
+
+    enum BytesRead {
+        ZERO,
+        BELOW_ALL,
+        AT_MIN_AVAILABLE_AND_LIMIT,
+        BETWEEN_AVAILABLE_AND_LIMIT,
+        AT_MAX_AVAILABLE_AND_LIMIT,
+        ABOVE_ALL;
+
+        private int get(BytesAvailable bytes) {
+            int min = Math.min(bytes.size, BYTES_LIMIT);
+            int max = Math.max(bytes.size, BYTES_LIMIT);
+            return switch (this) {
+                case ZERO -> 0;
+                case BELOW_ALL -> min / 2;
+                case AT_MIN_AVAILABLE_AND_LIMIT -> min;
+                case BETWEEN_AVAILABLE_AND_LIMIT -> min + (max - min) / 2;
+                case AT_MAX_AVAILABLE_AND_LIMIT -> max;
+                case ABOVE_ALL -> max * 2;
+            };
+        }
+    }
+
+    static Stream<Arguments> testCases() {
+        return Stream.of(BytesAvailable.values())
+                .flatMap(available -> Stream.of(BytesRead.values()).map(read -> Arguments.of(available, read)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void read(BytesAvailable available, BytesRead read) {
+        test(s -> s.read() != -1 ? 1 : 0, available, read);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void readBuffer(BytesAvailable available, BytesRead read) {
+        test(s -> s.read(new byte[64]), available, read);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void readBufferOffset(BytesAvailable available, BytesRead read) {
+        test(s -> s.read(new byte[128], 32, 64), available, read);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void readNBytes(BytesAvailable available, BytesRead read) {
+        test(s -> s.readNBytes(64).length, available, read);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void readNBytesBuffer(BytesAvailable available, BytesRead read) {
+        test(s -> s.readNBytes(new byte[128], 32, 64), available, read);
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void readAllBytes(BytesAvailable available) {
+        BytesRead read =
+                switch (available) {
+                    case BELOW_LIMIT, EXACT_LIMIT -> BytesRead.AT_MIN_AVAILABLE_AND_LIMIT;
+                    case ABOVE_LIMIT -> BytesRead.AT_MAX_AVAILABLE_AND_LIMIT;
+                };
+        test(s -> s.readAllBytes().length, available, read);
+    }
+
+    interface Reader {
+        int read(InputStream stream) throws IOException;
+    }
+
+    private static void test(Reader readBytes, BytesAvailable available, BytesRead read) {
+        try (SizeLimitedInputStream stream = buildStream(available.size)) {
+            int toRead = read.get(available);
+            if (available.size > BYTES_LIMIT && toRead > BYTES_LIMIT) {
+                assertThatException()
+                        .isThrownBy(() -> readDesired(readBytes, stream, toRead))
+                        .isInstanceOf(SafeIllegalStateException.class);
+            } else {
+                assertThat(readDesired(readBytes, stream, toRead))
+                        .isEqualTo(Math.min(Math.min(toRead, BYTES_LIMIT), available.size));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static int readDesired(Reader readBytes, InputStream stream, int toRead) {
+        int total = 0;
+        while (total < toRead) {
+            int count;
+            try {
+                count = readBytes.read(stream);
+            } catch (IOException e) {
+                throw new SafeUncheckedIoException(e);
+            }
+            if (count <= 0) {
+                break;
+            }
+            total += count;
+        }
+
+        return total;
+    }
+
+    private static SizeLimitedInputStream buildStream(int readableBytes) {
+        byte[] bytes = new byte[readableBytes];
+        for (int i = 0; i < readableBytes; i++) {
+            bytes[i] = (byte) (i % 256);
+        }
+        return new SizeLimitedInputStream(new ByteArrayInputStream(bytes), BYTES_LIMIT);
+    }
+}

--- a/dialogue-example/src/main/conjure/example.yml
+++ b/dialogue-example/src/main/conjure/example.yml
@@ -64,6 +64,10 @@ services:
           body: SampleObject
         returns: SampleObject
 
+      getBinary:
+        http: GET /getBinary
+        returns: binary
+
       getOptionalBinary:
         http: GET /getOptionalBinary
         returns: optional<binary>


### PR DESCRIPTION
## Before this PR
Clients want to be able to protect themselves against misbehaving servers, which may return responses far too large compared to what they'd expect, causing them to OOM when trying to deserialize them

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support setting a per-client response size limit
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

