### PR TITLE
[WIP] Support maxResponseSize in dialogue-annotations clients

### DIFF
--- a/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
+++ b/dialogue-annotations-example/src/test/java/com/palantir/myservice/example/MyServiceIntegrationTest.java
@@ -117,7 +117,7 @@ public final class MyServiceIntegrationTest {
         undertowHandler = exchange -> {
             exchange.assertMethod(HttpMethod.POST);
             exchange.assertPath("/greet");
-            exchange.assertAccept().isEqualTo("application/json");
+            exchange.assertAccept().isEqualTo("application/x-jackson-smile, application/json, application/cbor");
             exchange.assertContentType().isEqualTo("application/json");
 
             exchange.exchange.setStatusCode(200);

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -24,6 +24,8 @@ import com.palantir.dialogue.TypeMarker;
 import com.palantir.dialogue.annotations.DefaultParameterSerializer;
 import com.palantir.dialogue.annotations.ErrorHandlingDeserializerFactory;
 import com.palantir.dialogue.annotations.ErrorHandlingVoidDeserializer;
+import com.palantir.dialogue.annotations.InputStreamDeserializer;
+import com.palantir.dialogue.annotations.Json;
 import com.palantir.dialogue.annotations.ParameterSerializer;
 import com.palantir.dialogue.annotations.processor.data.ArgumentDefinition;
 import com.palantir.dialogue.annotations.processor.data.ArgumentType;
@@ -50,6 +52,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 
@@ -153,7 +156,7 @@ public final class ServiceImplementationGenerator {
                 .build();
     }
 
-    private static FieldSpec serializer(
+    private FieldSpec serializer(
             ArgumentDefinition argumentDefinition, TypeName serializerType, String serializerFieldName) {
         TypeName className = ArgumentTypes.caseOf(argumentDefinition.argType())
                 .primitive((typeName, _parameterSerializerMethodName) -> typeName)
@@ -163,10 +166,24 @@ public final class ServiceImplementationGenerator {
                 .otherwiseEmpty()
                 .orElseThrow(() -> new SafeIllegalStateException(
                         "Unsupported argument type for serializer", SafeArg.of("type", argumentDefinition.argType())));
-        ParameterizedTypeName deserializerType = ParameterizedTypeName.get(ClassName.get(Serializer.class), className);
-        return FieldSpec.builder(deserializerType, serializerFieldName)
+        ParameterizedTypeName wrappedSerializerType =
+                ParameterizedTypeName.get(ClassName.get(Serializer.class), className);
+
+        final CodeBlock initializer;
+        if (acceptsConjureBodySerDe(serializerType)) {
+            initializer = CodeBlock.of(
+                    "new $T($L.bodySerDe()).serializerFor(new $T<$T>() {})",
+                    serializerType,
+                    serviceDefinition.conjureRuntimeArgName(),
+                    TypeMarker.class,
+                    className);
+        } else {
+            initializer = CodeBlock.of(
+                    "new $T().serializerFor(new $T<$T>() {})", serializerType, TypeMarker.class, className);
+        }
+        return FieldSpec.builder(wrappedSerializerType, serializerFieldName)
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .initializer("new $T().serializerFor(new $T<$T>() {})", serializerType, TypeMarker.class, className)
+                .initializer(initializer)
                 .build();
     }
 
@@ -178,22 +195,42 @@ public final class ServiceImplementationGenerator {
         ParameterizedTypeName deserializerType =
                 ParameterizedTypeName.get(ClassName.get(Deserializer.class), innerType);
 
-        CodeBlock realDeserializer = CodeBlock.of(
-                "new $T<>(new $T(), new $T()).deserializerFor(new $T<$T>() {})",
-                ErrorHandlingDeserializerFactory.class,
-                deserializerFactoryType,
-                errorDecoderType,
-                TypeMarker.class,
-                innerType);
-        CodeBlock voidDeserializer = CodeBlock.of(
-                "new $T($L.bodySerDe().emptyBodyDeserializer(), new $T())",
-                ErrorHandlingVoidDeserializer.class,
-                serviceDefinition.conjureRuntimeArgName(),
-                errorDecoderType);
+        final CodeBlock deserializer;
+        if (type.isVoid()) {
+            deserializer = CodeBlock.of(
+                    "new $T($L.bodySerDe().emptyBodyDeserializer(), new $T())",
+                    ErrorHandlingVoidDeserializer.class,
+                    serviceDefinition.conjureRuntimeArgName(),
+                    errorDecoderType);
+        } else if (acceptsConjureBodySerDe(deserializerFactoryType)) {
+            deserializer = CodeBlock.of(
+                    "new $T<>(new $T($L.bodySerDe()), new $T()).deserializerFor(new $T<$T>() {})",
+                    ErrorHandlingDeserializerFactory.class,
+                    deserializerFactoryType,
+                    serviceDefinition.conjureRuntimeArgName(),
+                    errorDecoderType,
+                    TypeMarker.class,
+                    innerType);
+        } else {
+            deserializer = CodeBlock.of(
+                    "new $T<>(new $T(), new $T()).deserializerFor(new $T<$T>() {})",
+                    ErrorHandlingDeserializerFactory.class,
+                    deserializerFactoryType,
+                    errorDecoderType,
+                    TypeMarker.class,
+                    innerType);
+        }
         return Optional.of(FieldSpec.builder(deserializerType, type.deserializerFieldName())
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .initializer(type.isVoid() ? voidDeserializer : realDeserializer)
+                .initializer(deserializer)
                 .build());
+    }
+
+    private static final Set<TypeName> TYPES_ACCEPTING_CONJURE_BODY_SERDE =
+            Set.of(TypeName.get(Json.class), TypeName.get(InputStreamDeserializer.class));
+
+    private static boolean acceptsConjureBodySerDe(TypeName type) {
+        return TYPES_ACCEPTING_CONJURE_BODY_SERDE.contains(type.withoutAnnotations());
     }
 
     private static FieldSpec encoder(ParameterEncoderType type) {

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -47,12 +47,13 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
         return new MyService() {
             private final ParameterSerializer _parameterSerializer = DefaultParameterSerializer.INSTANCE;
 
-            private final Serializer<String> greetSerializer = new Json().serializerFor(new TypeMarker<String>() {});
+            private final Serializer<String> greetSerializer =
+                    new Json(runtime.bodySerDe()).serializerFor(new TypeMarker<String>() {});
 
             private final EndpointChannel greetChannel = endpointChannelFactory.endpoint(Endpoints.greet);
 
             private final Deserializer<String> greetDeserializer = new ErrorHandlingDeserializerFactory<>(
-                            new Json(), new ConjureErrorDecoder())
+                            new Json(runtime.bodySerDe()), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<String>() {});
 
             private final EndpointChannel getGreetingAsyncChannel =
@@ -65,7 +66,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             private final EndpointChannel inputStreamChannel = endpointChannelFactory.endpoint(Endpoints.inputStream);
 
             private final Deserializer<InputStream> inputStreamDeserializer = new ErrorHandlingDeserializerFactory<>(
-                            new InputStreamDeserializer(), new ConjureErrorDecoder())
+                            new InputStreamDeserializer(runtime.bodySerDe()), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<InputStream>() {});
 
             private final EndpointChannel customInputStreamChannel =

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/NestedServiceMyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/NestedServiceMyServiceDialogueServiceFactory.java.generated
@@ -33,7 +33,7 @@ public final class NestedServiceMyServiceDialogueServiceFactory
             private final EndpointChannel getChannel = endpointChannelFactory.endpoint(Endpoints.get);
 
             private final Deserializer<String> getDeserializer = new ErrorHandlingDeserializerFactory<>(
-                            new Json(), new ConjureErrorDecoder())
+                            new Json(runtime.bodySerDe()), new ConjureErrorDecoder())
                     .deserializerFor(new TypeMarker<String>() {});
 
             @Override

--- a/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Json.java
+++ b/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/Json.java
@@ -49,7 +49,7 @@ public final class Json implements DeserializerFactory<Object>, SerializerFactor
         this(DefaultConjureRuntime.builder().encodings(json(mapper)).build().bodySerDe());
     }
 
-    private Json(BodySerDe bodySerDe) {
+    public Json(BodySerDe bodySerDe) {
         this.bodySerDe = bodySerDe;
     }
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -213,12 +213,15 @@ public final class DialogueClients {
         /**
          * Configures the maximum size of response bodies (i.e. headers and other parts of the response are not limited)
          * that will be accepted.
-         *
+         * <p>
          * Any response received by a server exceeding this size and which dialogue attempts to deserialize will throw
          * a {@link ResponseSizeTooLargeException}.
-         *
+         * <p>
          * This does not impact responses returning {@link InputStream},
          * which are not actually deserialized by dialogue.
+         * <p>
+         * This also does not impact Dialogue clients that have been generated with a custom deserializer (through
+         * dialogue-annotations).
          */
         ReloadingFactory withMaxResponseSize(long maxResponseSize);
 


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/dialogue/pull/3046 added support for setting a maximum response size on dialogue clients.

This however is not respected by clients generated by dialogue-annotations-processor, because they don't take a runtime.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support maxResponseSize in dialogue-annotations clients
==COMMIT_MSG==

## Possible downsides?
The current changes make it possible to pass the runtime at least to endpoints generated with the default Json deserializer, but
- It doesn't apply to custom deserializers (which don't currently take a runtime, and there is not simple way to change the `Response` they receive to limit it either)
- It doesn't apply to input streams (fixable), e.g. when they fail
- It changes the default `Json` deserializer used in these endpoints to also accept smile and cbor responses, which may have unintended side-effect

