### PR TITLE
Queue timeouts respect enforced deadline values

### DIFF
--- a/dialogue-clients/metrics.md
+++ b/dialogue-clients/metrics.md
@@ -114,7 +114,12 @@ populated with the reason for which the last retry has failed.
 - `dialogue.client.requests.queued` tagged `channel-name` (counter): Number of queued requests waiting to execute.
 - `dialogue.client.requests.endpoint.queued` tagged `channel-name`, `service-name`, `endpoint` (counter): Number of queued requests waiting to execute for a specific endpoint due to server QoS.
 - `dialogue.client.requests.sticky.queued` tagged `channel-name` (counter): Number of sticky queued requests waiting to try to be executed.
-- `dialogue.client.request.queue.timeout` tagged `channel-name` (counter): Count of requests that are failed due to queue timeout.
+- `dialogue.client.request.queue.timeout` (counter): Count of requests that are failed due to queue timeout. The source indicates which budget produced
+the timeout: `deadline` when it was derived from the request's remaining deadline, or `configured`
+when it came from the client's configured `queueTimeout`.
+
+  - `channel-name`
+  - `source` values (`deadline`,`configured`)
 - `dialogue.client.request.queued.time` tagged `channel-name` (timer): Time spent waiting in the queue before execution.
 - `dialogue.client.request.endpoint.queued.time` tagged `channel-name`, `service-name`, `endpoint` (timer): Time spent waiting in the queue before execution on a specific endpoint due to server QoS.
 - `dialogue.client.request.sticky.queued.time` tagged `channel-name` (timer): Time spent waiting in the sticky queue before execution attempt.

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -337,6 +337,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                         .map(userAgent -> UserAgentEndpointChannel.create(endpointChannel, endpoint, userAgent))
                         .orElse(endpointChannel);
                 channel = RetryingChannel.create(cf, channel, endpoint);
+                channel = QueueTimeoutDeadlineChannel.create(cf, channel);
                 channel = DeprecationWarningChannel.create(cf, channel, endpoint);
                 channel = ContentDecodingChannel.create(cf, channel, endpoint);
                 channel = new RetryAdvertisementChannel(channel);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/DialogueChannel.java
@@ -329,6 +329,7 @@ public final class DialogueChannel implements Channel, EndpointChannelFactory {
                         .map(userAgent -> UserAgentEndpointChannel.create(endpointChannel, endpoint, userAgent))
                         .orElse(endpointChannel);
                 channel = RetryingChannel.create(cf, channel, endpoint);
+                channel = QueueTimeoutDeadlineChannel.create(cf, channel);
                 channel = DeprecationWarningChannel.create(cf, channel, endpoint);
                 channel = ContentDecodingChannel.create(cf, channel, endpoint);
                 channel = new RetryAdvertisementChannel(channel);

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutAttachments.java
@@ -21,47 +21,39 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.RequestAttachmentKey;
 import javax.annotation.Nullable;
 
-/**
- * Attachment for sharing a queue timeout expiration across both the channel-level and endpoint-level
- * {@link QueuedChannel} instances. The first queue to enqueue a request stamps an absolute expiration time (nanos from
- * {@link com.github.benmanes.caffeine.cache.Ticker#read()}). The second queue reads the existing expiration and uses
- * the remaining budget.
- */
+/** Shares configured queue-timeout and deadline expirations across {@link QueuedChannel} instances. */
 final class QueueTimeoutAttachments {
-    private static final RequestAttachmentKey<Long> QUEUE_EXPIRATION_NANOS = RequestAttachmentKey.create(Long.class);
-    private static final RequestAttachmentKey<DeadlineExpiration> DEADLINE_EXPIRATION =
-            RequestAttachmentKey.create(DeadlineExpiration.class);
+    private static final RequestAttachmentKey<Long> CONFIGURED_EXPIRATION_NANOS =
+            RequestAttachmentKey.create(Long.class);
+    private static final RequestAttachmentKey<Long> DEADLINE_EXPIRATION_NANOS = RequestAttachmentKey.create(Long.class);
 
     private QueueTimeoutAttachments() {}
 
-    /** Clears the expiration so the next queue stamps a fresh budget (used on retry). */
-    static void clearExpiration(Request request) {
-        request.attachments().remove(QUEUE_EXPIRATION_NANOS);
+    /** Clears the configured expiration so the next queue stamps a fresh budget (used on retry). */
+    static void clearConfiguredExpiration(Request request) {
+        request.attachments().remove(CONFIGURED_EXPIRATION_NANOS);
     }
 
-    /** Sets the expiration only if one hasn't been set yet. */
-    static void setExpirationIfAbsent(Request request, long expirationNanos) {
-        request.attachments().putIfAbsent(QUEUE_EXPIRATION_NANOS, expirationNanos);
+    /** Returns the configured expiration, initializing it to the candidate value if absent. */
+    static long getOrInitializeConfiguredExpiration(Request request, long candidateExpirationNanos) {
+        Long existing = request.attachments().putIfAbsent(CONFIGURED_EXPIRATION_NANOS, candidateExpirationNanos);
+        return existing != null ? existing : candidateExpirationNanos;
     }
 
     @VisibleForTesting
-    static @Nullable Long getExpiration(Request request) {
-        return request.attachments().getOrDefault(QUEUE_EXPIRATION_NANOS, null);
+    static @Nullable Long getConfiguredExpiration(Request request) {
+        return request.attachments().getOrDefault(CONFIGURED_EXPIRATION_NANOS, null);
     }
 
-    static void setDeadlineExpirationIfAbsent(Request request, @Nullable Long expirationNanos) {
-        request.attachments().putIfAbsent(DEADLINE_EXPIRATION, new DeadlineExpiration(expirationNanos));
+    static void setDeadlineExpiration(Request request, long expirationNanos) {
+        request.attachments().put(DEADLINE_EXPIRATION_NANOS, expirationNanos);
     }
 
-    static boolean isDeadlineResolved(Request request) {
-        return request.attachments().getOrDefault(DEADLINE_EXPIRATION, null) != null;
+    static void clearDeadlineExpiration(Request request) {
+        request.attachments().remove(DEADLINE_EXPIRATION_NANOS);
     }
 
     static @Nullable Long getDeadlineExpiration(Request request) {
-        DeadlineExpiration expiration = request.attachments().getOrDefault(DEADLINE_EXPIRATION, null);
-        return expiration == null ? null : expiration.expirationNanos();
+        return request.attachments().getOrDefault(DEADLINE_EXPIRATION_NANOS, null);
     }
-
-    // The wrapper distinguishes an unresolved deadline from a resolved request with no deadline.
-    private record DeadlineExpiration(@Nullable Long expirationNanos) {}
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutAttachments.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
  */
 final class QueueTimeoutAttachments {
     private static final RequestAttachmentKey<Long> QUEUE_EXPIRATION_NANOS = RequestAttachmentKey.create(Long.class);
+    private static final RequestAttachmentKey<DeadlineExpiration> DEADLINE_EXPIRATION =
+            RequestAttachmentKey.create(DeadlineExpiration.class);
 
     private QueueTimeoutAttachments() {}
 
@@ -46,4 +48,20 @@ final class QueueTimeoutAttachments {
     static @Nullable Long getExpiration(Request request) {
         return request.attachments().getOrDefault(QUEUE_EXPIRATION_NANOS, null);
     }
+
+    static void setDeadlineExpirationIfAbsent(Request request, @Nullable Long expirationNanos) {
+        request.attachments().putIfAbsent(DEADLINE_EXPIRATION, new DeadlineExpiration(expirationNanos));
+    }
+
+    static boolean isDeadlineResolved(Request request) {
+        return request.attachments().getOrDefault(DEADLINE_EXPIRATION, null) != null;
+    }
+
+    static @Nullable Long getDeadlineExpiration(Request request) {
+        DeadlineExpiration expiration = request.attachments().getOrDefault(DEADLINE_EXPIRATION, null);
+        return expiration == null ? null : expiration.expirationNanos();
+    }
+
+    // The wrapper distinguishes an unresolved deadline from a resolved request with no deadline.
+    private record DeadlineExpiration(@Nullable Long expirationNanos) {}
 }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutAttachments.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutAttachments.java
@@ -35,7 +35,7 @@ final class QueueTimeoutAttachments {
     }
 
     /** Returns the configured expiration, initializing it to the candidate value if absent. */
-    static long getOrInitializeConfiguredExpiration(Request request, long candidateExpirationNanos) {
+    static long setConfiguredExpirationIfAbsent(Request request, long candidateExpirationNanos) {
         Long existing = request.attachments().putIfAbsent(CONFIGURED_EXPIRATION_NANOS, candidateExpirationNanos);
         return existing != null ? existing : candidateExpirationNanos;
     }

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutDeadlineChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutDeadlineChannel.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.deadlines.Deadlines;
+import com.palantir.deadlines.Deadlines.Enforcement;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.futures.DialogueFutures;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Resolves the enforced deadline once for an entire request. Queues use the resolved deadline as an upper bound on
+ * the configured queue timeout, and reuse it across retries.
+ */
+final class QueueTimeoutDeadlineChannel implements EndpointChannel {
+    private final EndpointChannel delegate;
+    private final Ticker clock;
+    private final Enforcement clientEnforcement;
+
+    static QueueTimeoutDeadlineChannel create(Config config, EndpointChannel delegate) {
+        return new QueueTimeoutDeadlineChannel(delegate, config.ticker(), config.deadlineEnforcement());
+    }
+
+    QueueTimeoutDeadlineChannel(EndpointChannel delegate, Ticker clock, Optional<Boolean> deadlineEnforcement) {
+        this.delegate = delegate;
+        this.clock = clock;
+        this.clientEnforcement = deadlineEnforcement
+                .map(value -> value ? Enforcement.ENFORCE : Enforcement.DISABLE)
+                .orElse(Enforcement.DEFER);
+    }
+
+    @Override
+    public ListenableFuture<Response> execute(Request request) {
+        QueueTimeoutAttachments.clearDeadlineExpiration(request);
+        enforcedRemainingDeadline()
+                .ifPresent(remaining ->
+                        QueueTimeoutAttachments.setDeadlineExpiration(request, clock.read() + remaining.toNanos()));
+
+        ListenableFuture<Response> result;
+        try {
+            result = delegate.execute(request);
+        } catch (RuntimeException | Error throwable) {
+            QueueTimeoutAttachments.clearDeadlineExpiration(request);
+            throw throwable;
+        }
+        return DialogueFutures.addDirectListener(
+                result, () -> QueueTimeoutAttachments.clearDeadlineExpiration(request));
+    }
+
+    private Optional<Duration> enforcedRemainingDeadline() {
+        Optional<Enforcement> traceEnforcement = Deadlines.getEnforcement();
+        if (traceEnforcement.isEmpty()
+                || traceEnforcement.get().resolveWith(clientEnforcement) != Enforcement.ENFORCE) {
+            return Optional.empty();
+        }
+        return Deadlines.getRemainingDeadline();
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutException.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutException.java
@@ -32,8 +32,12 @@ final class QueueTimeoutException extends RuntimeException implements SafeLoggab
 
     private final List<Arg<?>> args;
 
-    QueueTimeoutException(@Safe String channelName, @Safe OptionalLong queueTimeoutNanos) {
-        this(List.of(SafeArg.of("channelName", channelName), SafeArg.of("queueTimeoutNanos", queueTimeoutNanos)));
+    QueueTimeoutException(
+            @Safe String channelName, @Safe QueueTimeoutSource source, @Safe OptionalLong configuredQueueTimeoutNanos) {
+        this(List.of(
+                SafeArg.of("channelName", channelName),
+                SafeArg.of("queueTimeoutSource", source.tagValue()),
+                SafeArg.of("configuredQueueTimeoutNanos", configuredQueueTimeoutNanos)));
     }
 
     private QueueTimeoutException(List<Arg<?>> args) {

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutSource.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutSource.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+enum QueueTimeoutSource {
+    DEADLINE("deadline"),
+    CONFIGURED("configured");
+
+    private final String tagValue;
+
+    QueueTimeoutSource(String tagValue) {
+        this.tagValue = tagValue;
+    }
+
+    String tagValue() {
+        return tagValue;
+    }
+}

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -26,8 +26,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.palantir.deadlines.Deadlines;
-import com.palantir.deadlines.Deadlines.Enforcement;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
@@ -97,14 +95,6 @@ final class QueuedChannel implements Channel {
         return queueTimeout.map(Duration::toNanos).map(OptionalLong::of).orElseGet(OptionalLong::empty);
     }
 
-    private static Optional<Duration> enforcedRemainingDeadline() {
-        Optional<Enforcement> enforcement = Deadlines.getEnforcement();
-        if (enforcement.isEmpty() || enforcement.get() != Enforcement.ENFORCE) {
-            return Optional.empty();
-        }
-        return Deadlines.getRemainingDeadline();
-    }
-
     private final Deque<DeferredCall> queuedCalls;
     private final NeverThrowLimitedChannel delegate;
 
@@ -135,8 +125,6 @@ final class QueuedChannel implements Channel {
     @Safe
     private final OptionalLong queueTimeoutNanos;
 
-    private final Supplier<Optional<Duration>> remainingDeadline;
-
     private final Ticker clock;
 
     @Nullable
@@ -158,8 +146,7 @@ final class QueuedChannel implements Channel {
                 maxQueueSize,
                 toNanos(queueTimeout),
                 clock,
-                sharedTimeoutScheduler.get(),
-                QueuedChannel::enforcedRemainingDeadline);
+                sharedTimeoutScheduler.get());
     }
 
     /** Visible for testing so a deterministic scheduler can be injected. */
@@ -173,29 +160,6 @@ final class QueuedChannel implements Channel {
             OptionalLong queueTimeoutNanos,
             Ticker clock,
             @Nullable ScheduledExecutorService scheduler) {
-        this(
-                delegate,
-                channelName,
-                queueType,
-                metrics,
-                maxQueueSize,
-                queueTimeoutNanos,
-                clock,
-                scheduler,
-                QueuedChannel::enforcedRemainingDeadline);
-    }
-
-    @VisibleForTesting
-    QueuedChannel(
-            LimitedChannel delegate,
-            @Safe String channelName,
-            @Safe String queueType,
-            QueuedChannelInstrumentation metrics,
-            int maxQueueSize,
-            OptionalLong queueTimeoutNanos,
-            Ticker clock,
-            @Nullable ScheduledExecutorService scheduler,
-            Supplier<Optional<Duration>> remainingDeadline) {
         this.delegate = new NeverThrowLimitedChannel(delegate);
         this.channelName = channelName;
         this.queueType = queueType;
@@ -203,7 +167,6 @@ final class QueuedChannel implements Channel {
         this.queuedCalls = new ProtectedConcurrentLinkedDeque<>();
         this.maxQueueSize = maxQueueSize;
         this.queueTimeoutNanos = queueTimeoutNanos;
-        this.remainingDeadline = remainingDeadline;
         this.clock = clock;
         this.scheduler = scheduler;
         // Lazily create the counter. Unlike meters, timers, and histograms, counters cannot be ignored when they have
@@ -321,7 +284,8 @@ final class QueuedChannel implements Channel {
         // response future completes the attachment is cleared and the retry's next enqueue stamps a brand-new
         // expiration rather than inheriting this attempt's remaining budget.
         if (queueTimeoutNanos.isPresent()) {
-            DialogueFutures.addDirectListener(responseFuture, () -> QueueTimeoutAttachments.clearExpiration(request));
+            DialogueFutures.addDirectListener(
+                    responseFuture, () -> QueueTimeoutAttachments.clearConfiguredExpiration(request));
         }
 
         DeferredCall components = DeferredCall.builder()
@@ -359,35 +323,7 @@ final class QueuedChannel implements Channel {
             DetachedSpan span,
             IdempotentTimerContext timer,
             QueueSizeAccounting accounting) {
-        initializeTimeoutExpirations(request);
-        return scheduleTimeoutFromExpiration(request, responseFuture, span, timer, accounting);
-    }
-
-    private void initializeTimeoutExpirations(Request request) {
-        if (queueTimeoutNanos.isPresent()) {
-            QueueTimeoutAttachments.setExpirationIfAbsent(request, clock.read() + queueTimeoutNanos.getAsLong());
-        }
-        if (!QueueTimeoutAttachments.isDeadlineResolved(request)) {
-            // Read trace-local state on the initial caller thread, then reuse it across queue layers and retries.
-            Long deadlineExpirationNanos = remainingDeadline
-                    .get()
-                    .map(remaining -> clock.read() + remaining.toNanos())
-                    .orElse(null);
-            QueueTimeoutAttachments.setDeadlineExpirationIfAbsent(request, deadlineExpirationNanos);
-        }
-    }
-
-    /**
-     * Schedules a timeout task based on the expiration already stamped on the request attachment.
-     */
-    @Nullable
-    private ScheduledFuture<?> scheduleTimeoutFromExpiration(
-            Request request,
-            SettableFuture<Response> responseFuture,
-            DetachedSpan span,
-            IdempotentTimerContext timer,
-            QueueSizeAccounting accounting) {
-        Optional<EffectiveExpiration> maybeExpiration = effectiveExpiration(request);
+        Optional<EffectiveExpiration> maybeExpiration = initializeAndGetEffectiveExpiration(request);
         if (maybeExpiration.isEmpty()) {
             return null;
         }
@@ -410,8 +346,11 @@ final class QueuedChannel implements Channel {
                 TimeUnit.NANOSECONDS);
     }
 
-    private Optional<EffectiveExpiration> effectiveExpiration(Request request) {
-        Long configuredExpiration = QueueTimeoutAttachments.getExpiration(request);
+    private Optional<EffectiveExpiration> initializeAndGetEffectiveExpiration(Request request) {
+        Long configuredExpiration = queueTimeoutNanos.isPresent()
+                ? QueueTimeoutAttachments.getOrInitializeConfiguredExpiration(
+                        request, clock.read() + queueTimeoutNanos.getAsLong())
+                : null;
         Long deadlineExpiration = QueueTimeoutAttachments.getDeadlineExpiration(request);
         if (deadlineExpiration == null) {
             return Optional.ofNullable(configuredExpiration)
@@ -443,13 +382,11 @@ final class QueuedChannel implements Channel {
             IdempotentTimerContext timer,
             QueueSizeAccounting accounting) {
         if (responseFuture.setException(new QueueTimeoutException(channelName, source, queueTimeoutNanos))) {
-            timeoutCounter(source).get().inc();
+            (source == QueueTimeoutSource.DEADLINE ? deadlineTimeoutCounter : configuredTimeoutCounter)
+                    .get()
+                    .inc();
         }
         completeAndDecrement(Optional.empty(), span, timer, accounting);
-    }
-
-    private Supplier<Counter> timeoutCounter(QueueTimeoutSource source) {
-        return source == QueueTimeoutSource.DEADLINE ? deadlineTimeoutCounter : configuredTimeoutCounter;
     }
 
     private void onCompletion() {
@@ -627,7 +564,7 @@ final class QueuedChannel implements Channel {
      */
     private DeferredCall addTimeoutOnRequeue(DeferredCall original) {
         @Nullable
-        ScheduledFuture<?> newTimeout = scheduleTimeoutFromExpiration(
+        ScheduledFuture<?> newTimeout = scheduleQueueTimeout(
                 original.request(), original.response(), original.span(), original.timer(), original.accounting());
         return DeferredCall.builder()
                 .from(original)

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -26,6 +26,8 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.deadlines.Deadlines;
+import com.palantir.deadlines.Deadlines.Enforcement;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
@@ -91,13 +93,16 @@ final class QueuedChannel implements Channel {
                             .build(),
                     TIMEOUT_SCHEDULER_NAME)));
 
-    @Nullable
-    static ScheduledExecutorService timeoutScheduler(OptionalLong queueTimeoutNanos) {
-        return queueTimeoutNanos.isPresent() ? sharedTimeoutScheduler.get() : null;
-    }
-
     private static OptionalLong toNanos(Optional<Duration> queueTimeout) {
         return queueTimeout.map(Duration::toNanos).map(OptionalLong::of).orElseGet(OptionalLong::empty);
+    }
+
+    private static Optional<Duration> enforcedRemainingDeadline() {
+        Optional<Enforcement> enforcement = Deadlines.getEnforcement();
+        if (enforcement.isEmpty() || enforcement.get() != Enforcement.ENFORCE) {
+            return Optional.empty();
+        }
+        return Deadlines.getRemainingDeadline();
     }
 
     private final Deque<DeferredCall> queuedCalls;
@@ -115,7 +120,8 @@ final class QueuedChannel implements Channel {
     private final AtomicInteger queueSizeEstimate = new AtomicInteger(0);
     private final int maxQueueSize;
     private final Supplier<Counter> queueSizeCounter;
-    private final Supplier<Counter> queueTimeoutCounter;
+    private final Supplier<Counter> deadlineTimeoutCounter;
+    private final Supplier<Counter> configuredTimeoutCounter;
     private final Timer queuedTime;
     private final Supplier<ListenableFuture<Response>> limitedResultSupplier;
     // Metrics aren't reported until the queue is first used, allowing per-endpoint queues to
@@ -128,6 +134,8 @@ final class QueuedChannel implements Channel {
     // The timeout budget is shared across both queue layers via a Request attachment (see QueueTimeoutAttachments).
     @Safe
     private final OptionalLong queueTimeoutNanos;
+
+    private final Supplier<Optional<Duration>> remainingDeadline;
 
     private final Ticker clock;
 
@@ -150,7 +158,8 @@ final class QueuedChannel implements Channel {
                 maxQueueSize,
                 toNanos(queueTimeout),
                 clock,
-                timeoutScheduler(toNanos(queueTimeout)));
+                sharedTimeoutScheduler.get(),
+                QueuedChannel::enforcedRemainingDeadline);
     }
 
     /** Visible for testing so a deterministic scheduler can be injected. */
@@ -164,6 +173,29 @@ final class QueuedChannel implements Channel {
             OptionalLong queueTimeoutNanos,
             Ticker clock,
             @Nullable ScheduledExecutorService scheduler) {
+        this(
+                delegate,
+                channelName,
+                queueType,
+                metrics,
+                maxQueueSize,
+                queueTimeoutNanos,
+                clock,
+                scheduler,
+                QueuedChannel::enforcedRemainingDeadline);
+    }
+
+    @VisibleForTesting
+    QueuedChannel(
+            LimitedChannel delegate,
+            @Safe String channelName,
+            @Safe String queueType,
+            QueuedChannelInstrumentation metrics,
+            int maxQueueSize,
+            OptionalLong queueTimeoutNanos,
+            Ticker clock,
+            @Nullable ScheduledExecutorService scheduler,
+            Supplier<Optional<Duration>> remainingDeadline) {
         this.delegate = new NeverThrowLimitedChannel(delegate);
         this.channelName = channelName;
         this.queueType = queueType;
@@ -171,12 +203,15 @@ final class QueuedChannel implements Channel {
         this.queuedCalls = new ProtectedConcurrentLinkedDeque<>();
         this.maxQueueSize = maxQueueSize;
         this.queueTimeoutNanos = queueTimeoutNanos;
+        this.remainingDeadline = remainingDeadline;
         this.clock = clock;
         this.scheduler = scheduler;
         // Lazily create the counter. Unlike meters, timers, and histograms, counters cannot be ignored when they have
         // zero interactions because they support both increment and decrement operations.
         this.queueSizeCounter = Suppliers.memoize(metrics::requestsQueued);
-        this.queueTimeoutCounter = Suppliers.memoize(metrics::requestQueueTimeout);
+        this.deadlineTimeoutCounter = Suppliers.memoize(() -> metrics.requestQueueTimeout(QueueTimeoutSource.DEADLINE));
+        this.configuredTimeoutCounter =
+                Suppliers.memoize(() -> metrics.requestQueueTimeout(QueueTimeoutSource.CONFIGURED));
         this.queuedTime = metrics.requestQueuedTime();
         this.limitedResultSupplier = () -> {
             List<SafeArg<?>> safeArgs = new ArrayList<>(metrics.queueFullSafeArgs());
@@ -324,12 +359,22 @@ final class QueuedChannel implements Channel {
             DetachedSpan span,
             IdempotentTimerContext timer,
             QueueSizeAccounting accounting) {
-        if (queueTimeoutNanos.isEmpty()) {
-            return null;
-        }
-        Preconditions.checkNotNull(scheduler, "Scheduler must be present when queue timeouts are enabled");
-        QueueTimeoutAttachments.setExpirationIfAbsent(request, clock.read() + queueTimeoutNanos.getAsLong());
+        initializeTimeoutExpirations(request);
         return scheduleTimeoutFromExpiration(request, responseFuture, span, timer, accounting);
+    }
+
+    private void initializeTimeoutExpirations(Request request) {
+        if (queueTimeoutNanos.isPresent()) {
+            QueueTimeoutAttachments.setExpirationIfAbsent(request, clock.read() + queueTimeoutNanos.getAsLong());
+        }
+        if (!QueueTimeoutAttachments.isDeadlineResolved(request)) {
+            // Read trace-local state on the initial caller thread, then reuse it across queue layers and retries.
+            Long deadlineExpirationNanos = remainingDeadline
+                    .get()
+                    .map(remaining -> clock.read() + remaining.toNanos())
+                    .orElse(null);
+            QueueTimeoutAttachments.setDeadlineExpirationIfAbsent(request, deadlineExpirationNanos);
+        }
     }
 
     /**
@@ -342,26 +387,43 @@ final class QueuedChannel implements Channel {
             DetachedSpan span,
             IdempotentTimerContext timer,
             QueueSizeAccounting accounting) {
-        if (queueTimeoutNanos.isEmpty() || scheduler == null) {
+        Optional<EffectiveExpiration> maybeExpiration = effectiveExpiration(request);
+        if (maybeExpiration.isEmpty()) {
             return null;
         }
-        Long expirationNanos = QueueTimeoutAttachments.getExpiration(request);
-        if (expirationNanos == null) {
-            return null;
-        }
-        long delayNanos = expirationNanos - clock.read();
+        EffectiveExpiration expiration = maybeExpiration.get();
+        long delayNanos = expiration.expirationNanos() - clock.read();
         if (delayNanos <= 0) {
             // The timeout is already reached, so we fail immediately. The queue-size decrement is safe to request
             // unconditionally: on initial enqueue the entry has not been counted yet (maybeExecute returns early,
             // before incrementing), so it is a no-op; on re-queue the entry is counted and gets decremented here.
-            failWithQueueTimeout(responseFuture, span, timer, accounting);
+            failWithQueueTimeout(expiration.source(), responseFuture, span, timer, accounting);
             return null;
         }
+        ScheduledExecutorService timeoutScheduler =
+                Preconditions.checkNotNull(scheduler, "Scheduler must be present when a queue timeout is scheduled");
         // When the timeout fires, failWithQueueTimeout proactively decrements the queue size, so the queue size
         // reflects only live requests rather than lingering until the next scheduleNextTask() drain pops the entry.
-        return scheduler.schedule(
-                () -> failWithQueueTimeout(responseFuture, span, timer, accounting), delayNanos, TimeUnit.NANOSECONDS);
+        return timeoutScheduler.schedule(
+                () -> failWithQueueTimeout(expiration.source(), responseFuture, span, timer, accounting),
+                delayNanos,
+                TimeUnit.NANOSECONDS);
     }
+
+    private Optional<EffectiveExpiration> effectiveExpiration(Request request) {
+        Long configuredExpiration = QueueTimeoutAttachments.getExpiration(request);
+        Long deadlineExpiration = QueueTimeoutAttachments.getDeadlineExpiration(request);
+        if (deadlineExpiration == null) {
+            return Optional.ofNullable(configuredExpiration)
+                    .map(value -> new EffectiveExpiration(value, QueueTimeoutSource.CONFIGURED));
+        }
+        if (configuredExpiration == null || deadlineExpiration <= configuredExpiration) {
+            return Optional.of(new EffectiveExpiration(deadlineExpiration, QueueTimeoutSource.DEADLINE));
+        }
+        return Optional.of(new EffectiveExpiration(configuredExpiration, QueueTimeoutSource.CONFIGURED));
+    }
+
+    private record EffectiveExpiration(long expirationNanos, QueueTimeoutSource source) {}
 
     /**
      * Fails the given future with a queue timeout exception and performs the same terminal cleanup as a normal
@@ -375,14 +437,19 @@ final class QueuedChannel implements Channel {
      */
     @VisibleForTesting
     void failWithQueueTimeout(
+            QueueTimeoutSource source,
             SettableFuture<Response> responseFuture,
             DetachedSpan span,
             IdempotentTimerContext timer,
             QueueSizeAccounting accounting) {
-        if (responseFuture.setException(new QueueTimeoutException(channelName, queueTimeoutNanos))) {
-            queueTimeoutCounter.get().inc();
+        if (responseFuture.setException(new QueueTimeoutException(channelName, source, queueTimeoutNanos))) {
+            timeoutCounter(source).get().inc();
         }
         completeAndDecrement(Optional.empty(), span, timer, accounting);
+    }
+
+    private Supplier<Counter> timeoutCounter(QueueTimeoutSource source) {
+        return source == QueueTimeoutSource.DEADLINE ? deadlineTimeoutCounter : configuredTimeoutCounter;
     }
 
     private void onCompletion() {
@@ -694,7 +761,14 @@ final class QueuedChannel implements Channel {
 
         List<SafeArg<?>> queueFullSafeArgs();
 
-        Counter requestQueueTimeout();
+        Counter requestQueueTimeout(QueueTimeoutSource source);
+    }
+
+    private static DialogueClientMetrics.RequestQueueTimeout_Source metricSource(QueueTimeoutSource source) {
+        return switch (source) {
+            case DEADLINE -> DialogueClientMetrics.RequestQueueTimeout_Source.DEADLINE;
+            case CONFIGURED -> DialogueClientMetrics.RequestQueueTimeout_Source.CONFIGURED;
+        };
     }
 
     static QueuedChannelInstrumentation channelInstrumentation(DialogueClientMetrics metrics, String channelName) {
@@ -715,8 +789,11 @@ final class QueuedChannel implements Channel {
             }
 
             @Override
-            public Counter requestQueueTimeout() {
-                return metrics.requestQueueTimeout(channelName);
+            public Counter requestQueueTimeout(QueueTimeoutSource source) {
+                return metrics.requestQueueTimeout()
+                        .channelName(channelName)
+                        .source(metricSource(source))
+                        .build();
             }
         };
     }
@@ -741,8 +818,11 @@ final class QueuedChannel implements Channel {
             }
 
             @Override
-            public Counter requestQueueTimeout() {
-                return metrics.requestQueueTimeout(channelName);
+            public Counter requestQueueTimeout(QueueTimeoutSource source) {
+                return metrics.requestQueueTimeout()
+                        .channelName(channelName)
+                        .source(metricSource(source))
+                        .build();
             }
         });
     }
@@ -774,8 +854,11 @@ final class QueuedChannel implements Channel {
             }
 
             @Override
-            public Counter requestQueueTimeout() {
-                return metrics.requestQueueTimeout(channelName);
+            public Counter requestQueueTimeout(QueueTimeoutSource source) {
+                return metrics.requestQueueTimeout()
+                        .channelName(channelName)
+                        .source(metricSource(source))
+                        .build();
             }
         };
     }
@@ -785,13 +868,17 @@ final class QueuedChannel implements Channel {
         private final Supplier<Counter> requestsQueuedSupplier;
         private final Supplier<Timer> requestQueuedTimeSupplier;
         private final Supplier<List<SafeArg<?>>> queueFullSafeArgs;
-        private final Supplier<Counter> requestQueueTimeoutSupplier;
+        private final Supplier<Counter> deadlineTimeoutSupplier;
+        private final Supplier<Counter> configuredTimeoutSupplier;
 
         MemoizedQueuedChannelInstrumentation(QueuedChannelInstrumentation delegate) {
             this.requestsQueuedSupplier = Suppliers.memoize(delegate::requestsQueued);
             this.requestQueuedTimeSupplier = Suppliers.memoize(delegate::requestQueuedTime);
             this.queueFullSafeArgs = Suppliers.memoize(delegate::queueFullSafeArgs);
-            this.requestQueueTimeoutSupplier = Suppliers.memoize(delegate::requestQueueTimeout);
+            this.deadlineTimeoutSupplier =
+                    Suppliers.memoize(() -> delegate.requestQueueTimeout(QueueTimeoutSource.DEADLINE));
+            this.configuredTimeoutSupplier =
+                    Suppliers.memoize(() -> delegate.requestQueueTimeout(QueueTimeoutSource.CONFIGURED));
         }
 
         @Override
@@ -810,8 +897,8 @@ final class QueuedChannel implements Channel {
         }
 
         @Override
-        public Counter requestQueueTimeout() {
-            return requestQueueTimeoutSupplier.get();
+        public Counter requestQueueTimeout(QueueTimeoutSource source) {
+            return (source == QueueTimeoutSource.DEADLINE ? deadlineTimeoutSupplier : configuredTimeoutSupplier).get();
         }
     }
 

--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueuedChannel.java
@@ -346,9 +346,10 @@ final class QueuedChannel implements Channel {
                 TimeUnit.NANOSECONDS);
     }
 
+    /** Returns the earlier of the configured queue-timeout expiration and the request deadline, if either is present. */
     private Optional<EffectiveExpiration> initializeAndGetEffectiveExpiration(Request request) {
         Long configuredExpiration = queueTimeoutNanos.isPresent()
-                ? QueueTimeoutAttachments.getOrInitializeConfiguredExpiration(
+                ? QueueTimeoutAttachments.setConfiguredExpirationIfAbsent(
                         request, clock.read() + queueTimeoutNanos.getAsLong())
                 : null;
         Long deadlineExpiration = QueueTimeoutAttachments.getDeadlineExpiration(request);
@@ -835,7 +836,10 @@ final class QueuedChannel implements Channel {
 
         @Override
         public Counter requestQueueTimeout(QueueTimeoutSource source) {
-            return (source == QueueTimeoutSource.DEADLINE ? deadlineTimeoutSupplier : configuredTimeoutSupplier).get();
+            return switch (source) {
+                case DEADLINE -> deadlineTimeoutSupplier.get();
+                case CONFIGURED -> configuredTimeoutSupplier.get();
+            };
         }
     }
 

--- a/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
+++ b/dialogue-core/src/main/metrics/dialogue-core-metrics.yml
@@ -68,8 +68,14 @@ namespaces:
         docs: Number of sticky queued requests waiting to try to be executed.
       request.queue.timeout:
         type: counter
-        tags: [channel-name]
-        docs: Count of requests that are failed due to queue timeout.
+        tags:
+          - name: channel-name
+          - name: source
+            values: [deadline, configured]
+        docs: |
+          Count of requests that are failed due to queue timeout. The source indicates which budget produced
+          the timeout: `deadline` when it was derived from the request's remaining deadline, or `configured`
+          when it came from the client's configured `queueTimeout`.
       request.queued.time:
         type: timer
         tags: [channel-name]

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueueTimeoutDeadlineChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueueTimeoutDeadlineChannelTest.java
@@ -1,0 +1,135 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.deadlines.Deadlines;
+import com.palantir.deadlines.Deadlines.Enforcement;
+import com.palantir.deadlines.Deadlines.RequestDecodingAdapter;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import com.palantir.dialogue.TestResponse;
+import com.palantir.tracing.CloseableTracer;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.Queue;
+import org.junit.jupiter.api.Test;
+
+class QueueTimeoutDeadlineChannelTest {
+
+    private final ManualTicker ticker = new ManualTicker();
+    private final Queue<SettableFuture<Response>> responses = new ArrayDeque<>();
+    private final EndpointChannel delegate = _request -> {
+        SettableFuture<Response> response = SettableFuture.create();
+        responses.add(response);
+        return response;
+    };
+
+    @Test
+    void reused_request_resolves_a_fresh_deadline_for_each_logical_call() {
+        QueueTimeoutDeadlineChannel channel = new QueueTimeoutDeadlineChannel(delegate, ticker, Optional.empty());
+        Request request = Request.builder().build();
+
+        ListenableFuture<Response> first;
+        try (CloseableTracer ignored = CloseableTracer.startSpan("first")) {
+            setDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE);
+            first = channel.execute(request);
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request))
+                    .isBetween(
+                            Duration.ofSeconds(4).toNanos(),
+                            Duration.ofSeconds(5).toNanos());
+        }
+
+        responses.remove().set(new TestResponse().code(200));
+        assertThat(first).isDone();
+        assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request)).isNull();
+
+        ticker.advance(Duration.ofSeconds(1));
+        try (CloseableTracer ignored = CloseableTracer.startSpan("second")) {
+            setDeadline(Duration.ofSeconds(10), Enforcement.ENFORCE);
+            ListenableFuture<Response> second = channel.execute(request);
+            assertThat(second).isNotDone();
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request))
+                    .isBetween(
+                            Duration.ofSeconds(10).toNanos(),
+                            Duration.ofSeconds(11).toNanos());
+        }
+    }
+
+    @Test
+    void explicit_disable_overrides_an_enforced_trace_deadline() {
+        QueueTimeoutDeadlineChannel channel = new QueueTimeoutDeadlineChannel(delegate, ticker, Optional.of(false));
+
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            setDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE);
+            Request request = Request.builder().build();
+            ListenableFuture<Response> result = channel.execute(request);
+
+            assertThat(result).isNotDone();
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request)).isNull();
+        }
+    }
+
+    @Test
+    void explicit_enable_enforces_a_deferred_trace_deadline() {
+        QueueTimeoutDeadlineChannel channel = new QueueTimeoutDeadlineChannel(delegate, ticker, Optional.of(true));
+
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            setDeadline(Duration.ofSeconds(5), Enforcement.DEFER);
+            Request request = Request.builder().build();
+            ListenableFuture<Response> result = channel.execute(request);
+
+            assertThat(result).isNotDone();
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request))
+                    .isBetween(
+                            Duration.ofSeconds(4).toNanos(),
+                            Duration.ofSeconds(5).toNanos());
+        }
+    }
+
+    private static void setDeadline(Duration duration, Enforcement enforcement) {
+        Deadlines.parseFromRequest(Optional.of(duration), Request.builder().build(), Decoder.INSTANCE, enforcement);
+    }
+
+    private enum Decoder implements RequestDecodingAdapter<Request> {
+        INSTANCE;
+
+        @Override
+        public Optional<String> getFirstHeader(Request request, String headerName) {
+            return request.headerParams().get(headerName).stream().findFirst();
+        }
+    }
+
+    private static final class ManualTicker implements Ticker {
+        private long nanos;
+
+        @Override
+        public long read() {
+            return nanos;
+        }
+
+        void advance(Duration duration) {
+            nanos += duration.toNanos();
+        }
+    }
+}

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueueTimeoutEteTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueueTimeoutEteTest.java
@@ -371,7 +371,7 @@ class QueueTimeoutEteTest {
             Request retried = Request.builder().build();
             ListenableFuture<Response> future = channel.execute(ENDPOINT, retried);
             assertThat(future).isNotDone();
-            assertThat(QueueTimeoutAttachments.getExpiration(retried))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(retried))
                     .as("first attempt stamps expiration at ticker.read() + timeout")
                     .isEqualTo(LONG_TIMEOUT.toNanos());
 
@@ -386,7 +386,7 @@ class QueueTimeoutEteTest {
             held.poll().set(new TestResponse().code(200));
 
             assertThat(future).as("the request is retried").isNotDone();
-            assertThat(QueueTimeoutAttachments.getExpiration(retried))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(retried))
                     .as("retry re-queues with a fresh budget", elapsedBeforeRetry, LONG_TIMEOUT)
                     .isEqualTo(elapsedBeforeRetry.plus(LONG_TIMEOUT).toNanos());
         }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -22,6 +22,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.deadlines.Deadlines;
+import com.palantir.deadlines.Deadlines.Enforcement;
+import com.palantir.deadlines.Deadlines.RequestDecodingAdapter;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
@@ -30,6 +33,7 @@ import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.core.QueuedChannel.QueuedChannelInstrumentation;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.tracing.CloseableTracer;
 import com.palantir.tracing.DetachedSpan;
 import com.palantir.tracing.TestTracing;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -43,8 +47,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -1026,6 +1033,7 @@ public class QueuedChannelTest {
         // size is reconciled by the subsequent drain in these tests.
         private void simulateTimeout(ListenableFuture<Response> future) {
             queuedChannel.failWithQueueTimeout(
+                    QueueTimeoutSource.CONFIGURED,
                     (SettableFuture<Response>) future,
                     DetachedSpan.start("test"),
                     new QueuedChannel.IdempotentTimerContext(DialogueClientMetrics.of(new DefaultTaggedMetricRegistry())
@@ -1070,6 +1078,298 @@ public class QueuedChannelTest {
                 SettableFuture<Response> future = SettableFuture.create();
                 dispatched.add(future);
                 return Optional.of(future);
+            }
+        }
+    }
+
+    @Nested
+    class DeadlineDerivedQueueTimeoutTests {
+        private static final String CHANNEL_NAME = "deadline-timeout-test";
+        private static final int QUEUE_SIZE = 100;
+
+        private DefaultTaggedMetricRegistry registry;
+        private QueueTimeoutTests.ManualTicker ticker;
+        private QueueTimeoutTests.ToggleableDelegate delegate;
+        private DeterministicScheduler scheduler;
+        private QueuedChannelInstrumentation instrumentation;
+
+        @BeforeEach
+        void beforeEach() {
+            registry = new DefaultTaggedMetricRegistry();
+            ticker = new QueueTimeoutTests.ManualTicker();
+            delegate = new QueueTimeoutTests.ToggleableDelegate();
+            scheduler = new DeterministicScheduler();
+            instrumentation = QueuedChannel.channelInstrumentation(DialogueClientMetrics.of(registry), CHANNEL_NAME);
+        }
+
+        @Test
+        void deadline_only_times_out_at_the_remaining_deadline() {
+            long deadlineNanos = Duration.ofSeconds(5).toNanos();
+            QueuedChannel channel = channel(OptionalLong.empty(), () -> Optional.of(Duration.ofSeconds(5)));
+            setInFlight(channel);
+
+            Request request = Request.builder().build();
+            ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
+            assertThat(future).isNotDone();
+            assertThat(QueueTimeoutAttachments.getExpiration(request))
+                    .as("no configured queueTimeout, so no configured expiration is stamped")
+                    .isNull();
+            assertThat(deadlineExpiration(request))
+                    .as("deadline resolution stamps ticker.read() + remaining deadline")
+                    .isEqualTo(deadlineNanos);
+
+            scheduler.tick(deadlineNanos, TimeUnit.NANOSECONDS);
+
+            assertThat(future)
+                    .failsWithin(Duration.ZERO)
+                    .withThrowableThat()
+                    .withCauseInstanceOf(QueueTimeoutException.class);
+            assertThat(timeoutCount(QueueTimeoutSource.DEADLINE)).isEqualTo(1);
+            assertThat(timeoutCount(QueueTimeoutSource.CONFIGURED)).isZero();
+        }
+
+        @Test
+        void min_uses_the_deadline_when_it_is_tighter_than_the_configured_timeout() {
+            long deadlineNanos = Duration.ofSeconds(3).toNanos();
+            QueuedChannel channel = channel(
+                    OptionalLong.of(Duration.ofSeconds(10).toNanos()), () -> Optional.of(Duration.ofSeconds(3)));
+            setInFlight(channel);
+
+            ListenableFuture<Response> future =
+                    channel.execute(TestEndpoint.POST, Request.builder().build());
+            scheduler.tick(deadlineNanos, TimeUnit.NANOSECONDS);
+
+            assertThat(future)
+                    .failsWithin(Duration.ZERO)
+                    .withThrowableThat()
+                    .withCauseInstanceOf(QueueTimeoutException.class);
+            assertThat(timeoutCount(QueueTimeoutSource.DEADLINE))
+                    .as("deadline is the tighter bound, so it is the binding source")
+                    .isEqualTo(1);
+            assertThat(timeoutCount(QueueTimeoutSource.CONFIGURED)).isZero();
+        }
+
+        @Test
+        void min_uses_the_configured_timeout_when_it_is_tighter_than_the_deadline() {
+            long configuredNanos = Duration.ofSeconds(3).toNanos();
+            QueuedChannel channel =
+                    channel(OptionalLong.of(configuredNanos), () -> Optional.of(Duration.ofSeconds(10)));
+            setInFlight(channel);
+
+            ListenableFuture<Response> future =
+                    channel.execute(TestEndpoint.POST, Request.builder().build());
+            scheduler.tick(configuredNanos, TimeUnit.NANOSECONDS);
+
+            assertThat(future)
+                    .failsWithin(Duration.ZERO)
+                    .withThrowableThat()
+                    .withCauseInstanceOf(QueueTimeoutException.class);
+            assertThat(timeoutCount(QueueTimeoutSource.CONFIGURED))
+                    .as("configured timeout is the tighter bound, so it is the binding source")
+                    .isEqualTo(1);
+            assertThat(timeoutCount(QueueTimeoutSource.DEADLINE)).isZero();
+        }
+
+        @Test
+        void no_deadline_and_no_configured_timeout_never_times_out() {
+            QueuedChannel channel = channel(OptionalLong.empty(), Optional::empty);
+            setInFlight(channel);
+
+            Request request = Request.builder().build();
+            ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
+            assertThat(future).isNotDone();
+            assertThat(QueueTimeoutAttachments.isDeadlineResolved(request))
+                    .as("the deadline is resolved once, even when absent, to avoid re-reading on other threads")
+                    .isTrue();
+            assertThat(deadlineExpiration(request))
+                    .as("no deadline present, so the resolution carries no expiration")
+                    .isNull();
+
+            scheduler.tick(Duration.ofHours(1).toNanos(), TimeUnit.NANOSECONDS);
+            assertThat(future)
+                    .as("no budget of any kind, so the request queues indefinitely")
+                    .isNotDone();
+        }
+
+        @Test
+        void already_expired_deadline_fails_immediately() {
+            QueuedChannel channel = channel(OptionalLong.empty(), () -> Optional.of(Duration.ZERO));
+            setInFlight(channel);
+
+            ListenableFuture<Response> future =
+                    channel.execute(TestEndpoint.POST, Request.builder().build());
+            assertThat(future)
+                    .as("a deadline with no budget remaining fails on enqueue")
+                    .isDone();
+            assertThat(future)
+                    .failsWithin(Duration.ZERO)
+                    .withThrowableThat()
+                    .withCauseInstanceOf(QueueTimeoutException.class);
+            assertThat(timeoutCount(QueueTimeoutSource.DEADLINE)).isEqualTo(1);
+            assertThat(instrumentation.requestsQueued().getCount()).isZero();
+        }
+
+        @Test
+        void deadline_resolution_persists_across_retry_while_configured_expiration_is_cleared() {
+            QueuedChannel channel = channel(
+                    OptionalLong.of(Duration.ofSeconds(10).toNanos()), () -> Optional.of(Duration.ofSeconds(5)));
+            setInFlight(channel);
+
+            Request request = Request.builder().build();
+            ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
+            assertThat(QueueTimeoutAttachments.getExpiration(request))
+                    .as("configured expiration is stamped on enqueue")
+                    .isNotNull();
+            assertThat(QueueTimeoutAttachments.isDeadlineResolved(request)).isTrue();
+
+            // Dispatch and complete the attempt, triggering the completion listener that clears the config budget.
+            delegate.setAccepting(true);
+            channel.schedule();
+            delegate.lastDispatched(); // setInFlight's dispatch
+            SettableFuture<Response> wire = delegate.lastDispatched();
+            assertThat(wire).isNotNull();
+            wire.set(new TestResponse().code(200));
+            assertThat(future).succeedsWithin(Duration.ZERO);
+
+            assertThat(QueueTimeoutAttachments.getExpiration(request))
+                    .as("configured budget resets per attempt, so it is cleared on completion")
+                    .isNull();
+            assertThat(QueueTimeoutAttachments.isDeadlineResolved(request))
+                    .as("the deadline is an absolute instant for the whole call, so it persists across retries")
+                    .isTrue();
+        }
+
+        @Test
+        void production_default_times_out_on_an_enforced_trace_deadline() {
+            try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+                Deadlines.parseFromRequest(
+                        Optional.of(Duration.ofSeconds(5)),
+                        Request.builder().build(),
+                        Decoder.INSTANCE,
+                        Enforcement.ENFORCE);
+
+                QueuedChannel channel = new QueuedChannel(
+                        delegate,
+                        CHANNEL_NAME,
+                        "channel",
+                        instrumentation,
+                        QUEUE_SIZE,
+                        OptionalLong.empty(),
+                        ticker,
+                        scheduler);
+                setInFlight(channel);
+
+                Request request = Request.builder().build();
+                ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
+                assertThat(future).isNotDone();
+                assertThat(deadlineExpiration(request))
+                        .as("the queue reads the enforced remaining deadline from the trace and stamps an expiration")
+                        .isNotNull();
+
+                scheduler.tick(Duration.ofSeconds(5).toNanos(), TimeUnit.NANOSECONDS);
+                assertThat(future)
+                        .failsWithin(Duration.ZERO)
+                        .withThrowableThat()
+                        .withCauseInstanceOf(QueueTimeoutException.class);
+                assertThat(timeoutCount(QueueTimeoutSource.DEADLINE)).isEqualTo(1);
+            }
+        }
+
+        @Test
+        void public_constructor_ignores_a_non_enforced_trace_deadline() {
+            try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+                Deadlines.parseFromRequest(
+                        Optional.of(Duration.ofSeconds(5)),
+                        Request.builder().build(),
+                        Decoder.INSTANCE,
+                        Enforcement.DEFER);
+
+                QueuedChannel channel = new QueuedChannel(
+                        delegate, CHANNEL_NAME, "channel", instrumentation, QUEUE_SIZE, Optional.empty(), ticker);
+                setInFlight(channel);
+
+                Request request = Request.builder().build();
+                ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
+                assertThat(future).isNotDone();
+                assertThat(deadlineExpiration(request))
+                        .as("a non-enforced deadline stamps no expiration, so it cannot produce a queue timeout")
+                        .isNull();
+                assertThat(timeoutCount(QueueTimeoutSource.DEADLINE)).isZero();
+            }
+        }
+
+        @Test
+        void deadline_is_read_only_once_and_reused_across_queue_layers() {
+            AtomicInteger reads = new AtomicInteger();
+            Supplier<Optional<Duration>> countingDeadline = () -> {
+                reads.incrementAndGet();
+                return Optional.of(Duration.ofSeconds(5));
+            };
+            QueuedChannel layer1 = channel(OptionalLong.empty(), countingDeadline);
+            QueuedChannel layer2 = channel(OptionalLong.empty(), countingDeadline);
+            setInFlight(layer1);
+            setInFlight(layer2);
+
+            Request shared = Request.builder().build();
+            layer1.execute(TestEndpoint.POST, shared);
+            assertThat(reads.get()).as("first enqueue reads the deadline").isEqualTo(1);
+            Long resolvedExpiration = deadlineExpiration(shared);
+            assertThat(resolvedExpiration).isNotNull();
+
+            ticker.advance(Duration.ofSeconds(1));
+            layer2.execute(TestEndpoint.POST, shared);
+            assertThat(reads.get())
+                    .as("second layer reuses the resolution instead of re-reading a possibly-foreign deadline")
+                    .isEqualTo(1);
+            assertThat(deadlineExpiration(shared))
+                    .as("the shared deadline expiration is unchanged")
+                    .isEqualTo(resolvedExpiration);
+        }
+
+        private QueuedChannel channel(
+                OptionalLong configuredTimeoutNanos, Supplier<Optional<Duration>> remainingDeadline) {
+            return new QueuedChannel(
+                    delegate,
+                    CHANNEL_NAME,
+                    "channel",
+                    instrumentation,
+                    QUEUE_SIZE,
+                    configuredTimeoutNanos,
+                    ticker,
+                    scheduler,
+                    remainingDeadline);
+        }
+
+        // Drives inFlight > 0 on the given channel so subsequent requests hit the queueing path.
+        private void setInFlight(QueuedChannel channel) {
+            delegate.setAccepting(true);
+            channel.execute(TestEndpoint.POST, Request.builder().build());
+            delegate.setAccepting(false);
+        }
+
+        @Nullable
+        private Long deadlineExpiration(Request request) {
+            return QueueTimeoutAttachments.getDeadlineExpiration(request);
+        }
+
+        private long timeoutCount(QueueTimeoutSource source) {
+            return DialogueClientMetrics.of(registry)
+                    .requestQueueTimeout()
+                    .channelName(CHANNEL_NAME)
+                    .source(
+                            source == QueueTimeoutSource.DEADLINE
+                                    ? DialogueClientMetrics.RequestQueueTimeout_Source.DEADLINE
+                                    : DialogueClientMetrics.RequestQueueTimeout_Source.CONFIGURED)
+                    .build()
+                    .getCount();
+        }
+
+        private enum Decoder implements RequestDecodingAdapter<Request> {
+            INSTANCE;
+
+            @Override
+            public Optional<String> getFirstHeader(Request request, String headerName) {
+                return request.headerParams().get(headerName).stream().findFirst();
             }
         }
     }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -22,9 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.palantir.deadlines.Deadlines;
-import com.palantir.deadlines.Deadlines.Enforcement;
-import com.palantir.deadlines.Deadlines.RequestDecodingAdapter;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
@@ -33,7 +30,6 @@ import com.palantir.dialogue.TestResponse;
 import com.palantir.dialogue.core.QueuedChannel.QueuedChannelInstrumentation;
 import com.palantir.dialogue.futures.DialogueFutures;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import com.palantir.tracing.CloseableTracer;
 import com.palantir.tracing.DetachedSpan;
 import com.palantir.tracing.TestTracing;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -47,11 +43,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.jmock.lib.concurrent.DeterministicScheduler;
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -708,7 +701,7 @@ public class QueuedChannelTest {
 
             // First execution: the delegate is rejecting, so the request queues and stamps an absolute expiration.
             ListenableFuture<Response> first = queuedChannel.execute(TestEndpoint.POST, reused);
-            assertThat(QueueTimeoutAttachments.getExpiration(reused))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(reused))
                     .as("first execution stamps the expiration at clock.read() + timeout")
                     .isEqualTo(QUEUE_TIMEOUT_NANOS);
 
@@ -720,7 +713,7 @@ public class QueuedChannelTest {
             wire.set(new TestResponse().code(200));
             assertThat(first).succeedsWithin(Duration.ZERO);
 
-            assertThat(QueueTimeoutAttachments.getExpiration(reused))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(reused))
                     .as("expiration is cleared on terminal completion so the request can be safely reused")
                     .isNull();
 
@@ -732,7 +725,7 @@ public class QueuedChannelTest {
             assertThat(second)
                     .as("reused request must not immediately time out from a stale deadline")
                     .isNotDone();
-            assertThat(QueueTimeoutAttachments.getExpiration(reused))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(reused))
                     .as("a fresh budget is stamped for the second execution")
                     .isEqualTo(QUEUE_TIMEOUT_NANOS * 3);
         }
@@ -874,11 +867,12 @@ public class QueuedChannelTest {
 
             // No expiration before enqueue
             Request sharedRequest = Request.builder().build();
-            assertThat(QueueTimeoutAttachments.getExpiration(sharedRequest)).isNull();
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(sharedRequest))
+                    .isNull();
 
             // Enqueue in queue1 at ticker=0 — stamps expiration at 0 + TIMEOUT
             queue1.execute(TestEndpoint.POST, sharedRequest);
-            Long expirationAfterQueue1 = QueueTimeoutAttachments.getExpiration(sharedRequest);
+            Long expirationAfterQueue1 = QueueTimeoutAttachments.getConfiguredExpiration(sharedRequest);
             assertThat(expirationAfterQueue1)
                     .as("queue1 should stamp expiration at ticker.read() + timeout")
                     .isEqualTo(QUEUE_TIMEOUT_NANOS);
@@ -888,7 +882,7 @@ public class QueuedChannelTest {
 
             // Enqueue same request in queue2. The existing expiration should be read.
             queue2.execute(TestEndpoint.POST, sharedRequest);
-            Long expirationAfterQueue2 = QueueTimeoutAttachments.getExpiration(sharedRequest);
+            Long expirationAfterQueue2 = QueueTimeoutAttachments.getConfiguredExpiration(sharedRequest);
             assertThat(expirationAfterQueue2)
                     .as("queue2 must use the existing expiration from queue1, not stamp a fresh one")
                     .isEqualTo(expirationAfterQueue1);
@@ -899,7 +893,7 @@ public class QueuedChannelTest {
             setInFlightRequest();
             Request req = Request.builder().build();
             ListenableFuture<Response> callerFuture = queuedChannel.execute(TestEndpoint.POST, req);
-            Long originalExpiration = QueueTimeoutAttachments.getExpiration(req);
+            Long originalExpiration = QueueTimeoutAttachments.getConfiguredExpiration(req);
             assertThat(originalExpiration)
                     .as("initial enqueue stamps expiration at ticker.read() + timeout")
                     .isEqualTo(QUEUE_TIMEOUT_NANOS);
@@ -913,7 +907,7 @@ public class QueuedChannelTest {
                     .as("request was re-queued, not dispatched or failed")
                     .isNotDone();
             assertThat(instrumentation.requestsQueued().getCount()).isEqualTo(1);
-            assertThat(QueueTimeoutAttachments.getExpiration(req))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(req))
                     .as("re-queue must preserve the original expiration, not reset the queue-timeout budget")
                     .isEqualTo(originalExpiration);
         }
@@ -924,7 +918,7 @@ public class QueuedChannelTest {
 
             // Stamp an expiration on the request, then advance the clock past it.
             Request expired = Request.builder().build();
-            QueueTimeoutAttachments.setExpirationIfAbsent(expired, ticker.read() + QUEUE_TIMEOUT_NANOS);
+            QueueTimeoutAttachments.getOrInitializeConfiguredExpiration(expired, ticker.read() + QUEUE_TIMEOUT_NANOS);
             ticker.advance(Duration.ofNanos(QUEUE_TIMEOUT_NANOS + 1));
 
             // The delegate is rejecting (inFlight > 0), so the request reaches the queueing path, sees the expired
@@ -967,7 +961,7 @@ public class QueuedChannelTest {
             assertThat(callerFuture).isNotDone();
 
             // No expiration should be stamped
-            assertThat(QueueTimeoutAttachments.getExpiration(req)).isNull();
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(req)).isNull();
 
             // Advance time
             ticker.advance(Duration.ofHours(1));
@@ -1105,16 +1099,16 @@ public class QueuedChannelTest {
         @Test
         void deadline_only_times_out_at_the_remaining_deadline() {
             long deadlineNanos = Duration.ofSeconds(5).toNanos();
-            QueuedChannel channel = channel(OptionalLong.empty(), () -> Optional.of(Duration.ofSeconds(5)));
+            QueuedChannel channel = channel(OptionalLong.empty());
             setInFlight(channel);
 
-            Request request = Request.builder().build();
+            Request request = requestWithDeadline(Duration.ofSeconds(5));
             ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
             assertThat(future).isNotDone();
-            assertThat(QueueTimeoutAttachments.getExpiration(request))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(request))
                     .as("no configured queueTimeout, so no configured expiration is stamped")
                     .isNull();
-            assertThat(deadlineExpiration(request))
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request))
                     .as("deadline resolution stamps ticker.read() + remaining deadline")
                     .isEqualTo(deadlineNanos);
 
@@ -1131,12 +1125,12 @@ public class QueuedChannelTest {
         @Test
         void min_uses_the_deadline_when_it_is_tighter_than_the_configured_timeout() {
             long deadlineNanos = Duration.ofSeconds(3).toNanos();
-            QueuedChannel channel = channel(
-                    OptionalLong.of(Duration.ofSeconds(10).toNanos()), () -> Optional.of(Duration.ofSeconds(3)));
+            QueuedChannel channel =
+                    channel(OptionalLong.of(Duration.ofSeconds(10).toNanos()));
             setInFlight(channel);
 
             ListenableFuture<Response> future =
-                    channel.execute(TestEndpoint.POST, Request.builder().build());
+                    channel.execute(TestEndpoint.POST, requestWithDeadline(Duration.ofSeconds(3)));
             scheduler.tick(deadlineNanos, TimeUnit.NANOSECONDS);
 
             assertThat(future)
@@ -1152,12 +1146,11 @@ public class QueuedChannelTest {
         @Test
         void min_uses_the_configured_timeout_when_it_is_tighter_than_the_deadline() {
             long configuredNanos = Duration.ofSeconds(3).toNanos();
-            QueuedChannel channel =
-                    channel(OptionalLong.of(configuredNanos), () -> Optional.of(Duration.ofSeconds(10)));
+            QueuedChannel channel = channel(OptionalLong.of(configuredNanos));
             setInFlight(channel);
 
             ListenableFuture<Response> future =
-                    channel.execute(TestEndpoint.POST, Request.builder().build());
+                    channel.execute(TestEndpoint.POST, requestWithDeadline(Duration.ofSeconds(10)));
             scheduler.tick(configuredNanos, TimeUnit.NANOSECONDS);
 
             assertThat(future)
@@ -1172,16 +1165,13 @@ public class QueuedChannelTest {
 
         @Test
         void no_deadline_and_no_configured_timeout_never_times_out() {
-            QueuedChannel channel = channel(OptionalLong.empty(), Optional::empty);
+            QueuedChannel channel = channel(OptionalLong.empty());
             setInFlight(channel);
 
             Request request = Request.builder().build();
             ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
             assertThat(future).isNotDone();
-            assertThat(QueueTimeoutAttachments.isDeadlineResolved(request))
-                    .as("the deadline is resolved once, even when absent, to avoid re-reading on other threads")
-                    .isTrue();
-            assertThat(deadlineExpiration(request))
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request))
                     .as("no deadline present, so the resolution carries no expiration")
                     .isNull();
 
@@ -1193,11 +1183,10 @@ public class QueuedChannelTest {
 
         @Test
         void already_expired_deadline_fails_immediately() {
-            QueuedChannel channel = channel(OptionalLong.empty(), () -> Optional.of(Duration.ZERO));
+            QueuedChannel channel = channel(OptionalLong.empty());
             setInFlight(channel);
 
-            ListenableFuture<Response> future =
-                    channel.execute(TestEndpoint.POST, Request.builder().build());
+            ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, requestWithDeadline(Duration.ZERO));
             assertThat(future)
                     .as("a deadline with no budget remaining fails on enqueue")
                     .isDone();
@@ -1210,17 +1199,17 @@ public class QueuedChannelTest {
         }
 
         @Test
-        void deadline_resolution_persists_across_retry_while_configured_expiration_is_cleared() {
-            QueuedChannel channel = channel(
-                    OptionalLong.of(Duration.ofSeconds(10).toNanos()), () -> Optional.of(Duration.ofSeconds(5)));
+        void completion_clears_only_configured_expiration() {
+            QueuedChannel channel =
+                    channel(OptionalLong.of(Duration.ofSeconds(10).toNanos()));
             setInFlight(channel);
 
-            Request request = Request.builder().build();
+            Request request = requestWithDeadline(Duration.ofSeconds(5));
             ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
-            assertThat(QueueTimeoutAttachments.getExpiration(request))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(request))
                     .as("configured expiration is stamped on enqueue")
                     .isNotNull();
-            assertThat(QueueTimeoutAttachments.isDeadlineResolved(request)).isTrue();
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request)).isNotNull();
 
             // Dispatch and complete the attempt, triggering the completion listener that clears the config budget.
             delegate.setAccepting(true);
@@ -1231,103 +1220,33 @@ public class QueuedChannelTest {
             wire.set(new TestResponse().code(200));
             assertThat(future).succeedsWithin(Duration.ZERO);
 
-            assertThat(QueueTimeoutAttachments.getExpiration(request))
+            assertThat(QueueTimeoutAttachments.getConfiguredExpiration(request))
                     .as("configured budget resets per attempt, so it is cleared on completion")
                     .isNull();
-            assertThat(QueueTimeoutAttachments.isDeadlineResolved(request))
-                    .as("the deadline is an absolute instant for the whole call, so it persists across retries")
-                    .isTrue();
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(request))
+                    .as("the deadline is an absolute instant for the whole call")
+                    .isNotNull();
         }
 
         @Test
-        void production_default_times_out_on_an_enforced_trace_deadline() {
-            try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
-                Deadlines.parseFromRequest(
-                        Optional.of(Duration.ofSeconds(5)),
-                        Request.builder().build(),
-                        Decoder.INSTANCE,
-                        Enforcement.ENFORCE);
-
-                QueuedChannel channel = new QueuedChannel(
-                        delegate,
-                        CHANNEL_NAME,
-                        "channel",
-                        instrumentation,
-                        QUEUE_SIZE,
-                        OptionalLong.empty(),
-                        ticker,
-                        scheduler);
-                setInFlight(channel);
-
-                Request request = Request.builder().build();
-                ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
-                assertThat(future).isNotDone();
-                assertThat(deadlineExpiration(request))
-                        .as("the queue reads the enforced remaining deadline from the trace and stamps an expiration")
-                        .isNotNull();
-
-                scheduler.tick(Duration.ofSeconds(5).toNanos(), TimeUnit.NANOSECONDS);
-                assertThat(future)
-                        .failsWithin(Duration.ZERO)
-                        .withThrowableThat()
-                        .withCauseInstanceOf(QueueTimeoutException.class);
-                assertThat(timeoutCount(QueueTimeoutSource.DEADLINE)).isEqualTo(1);
-            }
-        }
-
-        @Test
-        void public_constructor_ignores_a_non_enforced_trace_deadline() {
-            try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
-                Deadlines.parseFromRequest(
-                        Optional.of(Duration.ofSeconds(5)),
-                        Request.builder().build(),
-                        Decoder.INSTANCE,
-                        Enforcement.DEFER);
-
-                QueuedChannel channel = new QueuedChannel(
-                        delegate, CHANNEL_NAME, "channel", instrumentation, QUEUE_SIZE, Optional.empty(), ticker);
-                setInFlight(channel);
-
-                Request request = Request.builder().build();
-                ListenableFuture<Response> future = channel.execute(TestEndpoint.POST, request);
-                assertThat(future).isNotDone();
-                assertThat(deadlineExpiration(request))
-                        .as("a non-enforced deadline stamps no expiration, so it cannot produce a queue timeout")
-                        .isNull();
-                assertThat(timeoutCount(QueueTimeoutSource.DEADLINE)).isZero();
-            }
-        }
-
-        @Test
-        void deadline_is_read_only_once_and_reused_across_queue_layers() {
-            AtomicInteger reads = new AtomicInteger();
-            Supplier<Optional<Duration>> countingDeadline = () -> {
-                reads.incrementAndGet();
-                return Optional.of(Duration.ofSeconds(5));
-            };
-            QueuedChannel layer1 = channel(OptionalLong.empty(), countingDeadline);
-            QueuedChannel layer2 = channel(OptionalLong.empty(), countingDeadline);
+        void deadline_attachment_is_reused_across_queue_layers() {
+            QueuedChannel layer1 = channel(OptionalLong.empty());
+            QueuedChannel layer2 = channel(OptionalLong.empty());
             setInFlight(layer1);
             setInFlight(layer2);
 
-            Request shared = Request.builder().build();
+            Request shared = requestWithDeadline(Duration.ofSeconds(5));
+            Long resolvedExpiration = QueueTimeoutAttachments.getDeadlineExpiration(shared);
             layer1.execute(TestEndpoint.POST, shared);
-            assertThat(reads.get()).as("first enqueue reads the deadline").isEqualTo(1);
-            Long resolvedExpiration = deadlineExpiration(shared);
-            assertThat(resolvedExpiration).isNotNull();
 
             ticker.advance(Duration.ofSeconds(1));
             layer2.execute(TestEndpoint.POST, shared);
-            assertThat(reads.get())
-                    .as("second layer reuses the resolution instead of re-reading a possibly-foreign deadline")
-                    .isEqualTo(1);
-            assertThat(deadlineExpiration(shared))
+            assertThat(QueueTimeoutAttachments.getDeadlineExpiration(shared))
                     .as("the shared deadline expiration is unchanged")
                     .isEqualTo(resolvedExpiration);
         }
 
-        private QueuedChannel channel(
-                OptionalLong configuredTimeoutNanos, Supplier<Optional<Duration>> remainingDeadline) {
+        private QueuedChannel channel(OptionalLong configuredTimeoutNanos) {
             return new QueuedChannel(
                     delegate,
                     CHANNEL_NAME,
@@ -1336,8 +1255,13 @@ public class QueuedChannelTest {
                     QUEUE_SIZE,
                     configuredTimeoutNanos,
                     ticker,
-                    scheduler,
-                    remainingDeadline);
+                    scheduler);
+        }
+
+        private Request requestWithDeadline(Duration remaining) {
+            Request request = Request.builder().build();
+            QueueTimeoutAttachments.setDeadlineExpiration(request, ticker.read() + remaining.toNanos());
+            return request;
         }
 
         // Drives inFlight > 0 on the given channel so subsequent requests hit the queueing path.
@@ -1345,11 +1269,6 @@ public class QueuedChannelTest {
             delegate.setAccepting(true);
             channel.execute(TestEndpoint.POST, Request.builder().build());
             delegate.setAccepting(false);
-        }
-
-        @Nullable
-        private Long deadlineExpiration(Request request) {
-            return QueueTimeoutAttachments.getDeadlineExpiration(request);
         }
 
         private long timeoutCount(QueueTimeoutSource source) {
@@ -1362,15 +1281,6 @@ public class QueuedChannelTest {
                                     : DialogueClientMetrics.RequestQueueTimeout_Source.CONFIGURED)
                     .build()
                     .getCount();
-        }
-
-        private enum Decoder implements RequestDecodingAdapter<Request> {
-            INSTANCE;
-
-            @Override
-            public Optional<String> getFirstHeader(Request request, String headerName) {
-                return request.headerParams().get(headerName).stream().findFirst();
-            }
         }
     }
 }

--- a/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
+++ b/dialogue-core/src/test/java/com/palantir/dialogue/core/QueuedChannelTest.java
@@ -918,7 +918,7 @@ public class QueuedChannelTest {
 
             // Stamp an expiration on the request, then advance the clock past it.
             Request expired = Request.builder().build();
-            QueueTimeoutAttachments.getOrInitializeConfiguredExpiration(expired, ticker.read() + QUEUE_TIMEOUT_NANOS);
+            QueueTimeoutAttachments.setConfiguredExpirationIfAbsent(expired, ticker.read() + QUEUE_TIMEOUT_NANOS);
             ticker.advance(Duration.ofNanos(QUEUE_TIMEOUT_NANOS + 1));
 
             // The delegate is rejecting (inFlight > 0), so the request reaches the queueing path, sees the expired


### PR DESCRIPTION
 ## Before this PR
Queue timeout enforcement only considered the client’s configured `queueTimeout`.

For example, a request with five seconds remaining on its enforced deadline and a one-minute `queueTimeout` could remain queued for the full minute, despite no longer being able to complete successfully. Without a configured `queueTimeout`, it could remain queued indefinitely.

## After this PR
==COMMIT_MSG==
Fail queued requests when their enforced deadline expires.
==COMMIT_MSG==

Dialogue resolves the enforced deadline once per logical request and shares its absolute expiration across queue layers and retries. Each queue uses the earlier of:
  - The remaining request deadline.
  - The configured `queueTimeout`

The configured queue-timeout budget continues to reset for each retry, while the request deadline remains fixed across the entire logical request.

The `dialogue.client.request.queue.timeout` metric now includes a `source` tag with either `deadline` or `configured`.

## Possible downsides?
Requests may now fail while queued with a `QueueTimeoutException` when their enforced deadline expires, rather than remaining queued until capacity becomes available. This can be alarming to some clients, but with deadlines enforced, this is the right behavior. Currently, a deadline expiration while in a Dialogue queue does not throw an exception pre-emptively.

