### PR TITLE
Allow building a client with a specific channel name

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -344,6 +344,14 @@ acceptedBreaks:
       new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withQueueTimeout(java.time.Duration)\
         \ @ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory"
       justification: "Adding support for Dialogue queue timeouts"
+  "6.37.0":
+    com.palantir.dialogue:dialogue-clients:
+    - code: "java.method.addedToInterface"
+      new: "method <T> T com.palantir.dialogue.clients.DialogueClients.ClientConfigurationNonReloadingClientFactory::getNonReloading(java.lang.Class<T>,\
+        \ java.lang.String, com.palantir.conjure.java.client.config.ClientConfiguration)"
+      justification: "ClientConfigurationNonReloadingClientFactory is implemented\
+        \ by dialogue and consumed via DialogueClients.create; callers depend on the\
+        \ interface rather than implementing it"
   "6.7.0":
     com.palantir.dialogue:dialogue-target:
     - code: "java.class.removed"

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelNames.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ChannelNames.java
@@ -33,7 +33,11 @@ final class ChannelNames {
     }
 
     static String nonReloading(Class<?> clazz, AugmentClientConfig augment) {
-        return "dialogue-nonreloading-" + clazz.getSimpleName() + summarizeOptions(augment);
+        return nonReloading(clazz.getSimpleName(), augment);
+    }
+
+    static String nonReloading(String serviceName, AugmentClientConfig augment) {
+        return "dialogue-nonreloading-" + serviceName + summarizeOptions(augment);
     }
 
     private static String summarizeOptions(AugmentClientConfig augment) {

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -113,20 +113,14 @@ public final class DialogueClients {
         <T> T getNonReloading(Class<T> clientInterface, ClientConfiguration clientConfiguration);
 
         /**
-         * Equivalent to {@link #getNonReloading(Class, ClientConfiguration)}, but identifies the client in metrics
-         * using the provided {@code serviceName} rather than the name of {@code clientInterface}.
-         *
-         * This is intended for callers which build many clients from a single generated interface, one per upstream,
-         * where the interface describes a protocol rather than a specific service. A dispatcher calling out to a set
-         * of configured webhooks is the motivating example: the derived name is identical for every such client, so
-         * their metrics collapse into a single series even though the upstreams are unrelated.
+         * Equivalent to {@link #getNonReloading(Class, ClientConfiguration)}, but identifies the upstream using the
+         * provided {@code serviceName} rather than the name of {@code clientInterface}.
          *
          * Behaviour is undefined if {@code clientConfiguration} contains no URIs.
          *
-         * @param clientInterface Dialogue client interface annotated with {@link com.palantir.dialogue.DialogueService}
-         * @param serviceName Name of the conceptual upstream, used to identify this client in metrics
-         * @param clientConfiguration Configuration which <b>must</b> contain a user-agent
+         * @deprecated should not be used going forward, prefer reloadable factories.
          */
+        @Deprecated
         <T> T getNonReloading(Class<T> clientInterface, String serviceName, ClientConfiguration clientConfiguration);
     }
 

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/DialogueClients.java
@@ -111,6 +111,23 @@ public final class DialogueClients {
          */
         @Deprecated
         <T> T getNonReloading(Class<T> clientInterface, ClientConfiguration clientConfiguration);
+
+        /**
+         * Equivalent to {@link #getNonReloading(Class, ClientConfiguration)}, but identifies the client in metrics
+         * using the provided {@code serviceName} rather than the name of {@code clientInterface}.
+         *
+         * This is intended for callers which build many clients from a single generated interface, one per upstream,
+         * where the interface describes a protocol rather than a specific service. A dispatcher calling out to a set
+         * of configured webhooks is the motivating example: the derived name is identical for every such client, so
+         * their metrics collapse into a single series even though the upstreams are unrelated.
+         *
+         * Behaviour is undefined if {@code clientConfiguration} contains no URIs.
+         *
+         * @param clientInterface Dialogue client interface annotated with {@link com.palantir.dialogue.DialogueService}
+         * @param serviceName Name of the conceptual upstream, used to identify this client in metrics
+         * @param clientConfiguration Configuration which <b>must</b> contain a user-agent
+         */
+        <T> T getNonReloading(Class<T> clientInterface, String serviceName, ClientConfiguration clientConfiguration);
     }
 
     /** A stateful object - should only need one of these. Live reloads under the hood. */

--- a/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
+++ b/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java
@@ -183,7 +183,15 @@ final class ReloadingClientFactory implements DialogueClients.ReloadingFactory {
 
     @Override
     public <T> T getNonReloading(Class<T> clazz, ClientConfiguration clientConf) {
-        String channelName = ChannelNames.nonReloading(clazz, params);
+        return createNonReloading(clazz, ChannelNames.nonReloading(clazz, params), clientConf);
+    }
+
+    @Override
+    public <T> T getNonReloading(Class<T> clazz, String serviceName, ClientConfiguration clientConf) {
+        return createNonReloading(clazz, ChannelNames.nonReloading(serviceName, params), clientConf);
+    }
+
+    private <T> T createNonReloading(Class<T> clazz, String channelName, ClientConfiguration clientConf) {
         Channel channel = getNonReloadingChannel(channelName, clientConf);
         return Reflection.callStaticFactoryMethod(clazz, channel, params.runtime());
     }


### PR DESCRIPTION
We want to hand roll a dialogue client while we wait for https://github.com/palantir/conjure-java-runtime/issues/3585 to resolve.

We will supply a ClientConfiguration with a proxy option to achieve this, which we can pass to the DialogueClients builder. Unfortunately, there is no way to supply a ServiceName to the getNonReloading method when supplying your own ClientConfiguration. This matters for us because metrics are tagged with the service name, and the default is arguably quite non-intuitive (using the client class name, which can be detached from the destination that the client is trying to reach. Though this is probably a limitation of ClientConfiguration not carrying a channel name).

### Alternatives considered

This is the lowest lift solution. Another option here would be to add a withProxySelector option onto the reloading client factory that dialogue publishes ([here](https://github.com/palantir/dialogue/blob/459bc881aaa58d68fb786c76161e66a704114801/dialogue-clients/src/main/java/com/palantir/dialogue/clients/ReloadingClientFactory.java#L74)). Comparison PR [here](https://github.com/palantir/dialogue/pull/3155).