### PR TITLE
Add request URL to client failure diagnostics

### DIFF
--- a/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
+++ b/dialogue-apache-hc5-client/src/main/java/com/palantir/dialogue/hc5/ApacheHttpClientBlockingChannel.java
@@ -207,6 +207,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
 
     private Arg<?>[] failureDiagnosticArgs(Endpoint endpoint, Request request, long startTimeNanos) {
         long durationMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
+        URL requestUrl = baseUrl.render(endpoint, request);
         return new Arg<?>[] {
             SafeArg.of("durationMillis", durationMillis),
             SafeArg.of("connectTimeout", client.clientConfiguration().connectTimeout()),
@@ -214,6 +215,7 @@ final class ApacheHttpClientBlockingChannel implements BlockingChannel {
             SafeArg.of("clientName", client.name()),
             SafeArg.of("serviceName", endpoint.serviceName()),
             SafeArg.of("endpointName", endpoint.endpointName()),
+            UnsafeArg.of("requestUrl", requestUrl.toString()),
             SafeArg.of("requestTraceId", request.headerParams().get(TraceHttpHeaders.TRACE_ID)),
             // Request span ID can be used to associate a failed request with a request log line on the server.
             SafeArg.of("requestSpanId", request.headerParams().get(TraceHttpHeaders.SPAN_ID)),

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
@@ -95,7 +95,8 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
                                                         "requestSpanId",
                                                         "hostIndex");
                                         assertThat(safeLoggable.getArgs().stream()
-                                                        .filter(arg -> arg.getName().equals("requestUrl"))
+                                                        .filter(arg ->
+                                                                arg.getName().equals("requestUrl"))
                                                         .findFirst()
                                                         .orElseThrow()
                                                         .getValue())

--- a/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
+++ b/dialogue-apache-hc5-client/src/test/java/com/palantir/dialogue/hc5/ApacheHttpClientChannelsTest.java
@@ -90,9 +90,16 @@ public final class ApacheHttpClientChannelsTest extends AbstractChannelTest {
                                                         "clientName",
                                                         "serviceName",
                                                         "endpointName",
+                                                        "requestUrl",
                                                         "requestTraceId",
                                                         "requestSpanId",
                                                         "hostIndex");
+                                        assertThat(safeLoggable.getArgs().stream()
+                                                        .filter(arg -> arg.getName().equals("requestUrl"))
+                                                        .findFirst()
+                                                        .orElseThrow()
+                                                        .getValue())
+                                                .isEqualTo("http://foo");
                                     }));
         }
 


### PR DESCRIPTION
## Before this PR

When transport failures happen in the Apache HTTP client channel, Dialogue attaches a suppressed `Diagnostic` exception with structured logging arguments. These include client and endpoint metadata, but not the actual URL being requested. That makes it harder to debug connectivity issues when you have multiple upstream hosts and the raw exception message does not say which one failed.

Fixes #3166

## After this PR

==COMMIT_MSG==
Add request URL to client failure diagnostics
==COMMIT_MSG==

Failed requests now include `requestUrl` in the suppressed failure diagnostic, making it easier to identify which host failed during connection errors like `NoRouteToHostException` or `UnknownHostException`.

## Possible downsides?

Request URLs can contain path or query parameters that are sensitive in some environments. The field uses `UnsafeArg` for this reason, which is consistent with how Dialogue logs URLs elsewhere.