### PR TITLE
Add TypeMarker factory methods for simple types and common parameterized types

### DIFF
--- a/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MySerializableTypeBodySerializer.java
+++ b/dialogue-annotations-example/src/main/java/com/palantir/myservice/example/MySerializableTypeBodySerializer.java
@@ -28,7 +28,7 @@ public final class MySerializableTypeBodySerializer extends StdSerializer<MySeri
 
     private static final Serializer<MySerializableType> SERIALIZER = new Json(
                     new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT))
-            .serializerFor(new TypeMarker<>() {});
+            .serializerFor(TypeMarker.of(MySerializableType.class));
 
     @Override
     public RequestBody serialize(MySerializableType value) {

--- a/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
+++ b/dialogue-annotations-processor/src/main/java/com/palantir/dialogue/annotations/processor/generate/ServiceImplementationGenerator.java
@@ -49,7 +49,9 @@ import com.palantir.javapoet.TypeSpec;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 
@@ -153,6 +155,16 @@ public final class ServiceImplementationGenerator {
                 .build();
     }
 
+    private static final Map<ClassName, String> TYPE_MARKER_FACTORIES = Map.of(
+            ClassName.get(List.class),
+            "listOf",
+            ClassName.get(Set.class),
+            "setOf",
+            ClassName.get(Optional.class),
+            "optionalOf",
+            ClassName.get(Map.class),
+            "mapOf");
+
     private static FieldSpec serializer(
             ArgumentDefinition argumentDefinition, TypeName serializerType, String serializerFieldName) {
         TypeName className = ArgumentTypes.caseOf(argumentDefinition.argType())
@@ -166,7 +178,7 @@ public final class ServiceImplementationGenerator {
         ParameterizedTypeName deserializerType = ParameterizedTypeName.get(ClassName.get(Serializer.class), className);
         return FieldSpec.builder(deserializerType, serializerFieldName)
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .initializer("new $T().serializerFor(new $T<$T>() {})", serializerType, TypeMarker.class, className)
+                .initializer("new $T().serializerFor($L)", serializerType, typeMarker(className))
                 .build();
     }
 
@@ -179,12 +191,11 @@ public final class ServiceImplementationGenerator {
                 ParameterizedTypeName.get(ClassName.get(Deserializer.class), innerType);
 
         CodeBlock realDeserializer = CodeBlock.of(
-                "new $T<>(new $T(), new $T()).deserializerFor(new $T<$T>() {})",
+                "new $T<>(new $T(), new $T()).deserializerFor($L)",
                 ErrorHandlingDeserializerFactory.class,
                 deserializerFactoryType,
                 errorDecoderType,
-                TypeMarker.class,
-                innerType);
+                typeMarker(innerType));
         CodeBlock voidDeserializer = CodeBlock.of(
                 "new $T($L.bodySerDe().emptyBodyDeserializer(), new $T())",
                 ErrorHandlingVoidDeserializer.class,
@@ -194,6 +205,27 @@ public final class ServiceImplementationGenerator {
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                 .initializer(type.isVoid() ? voidDeserializer : realDeserializer)
                 .build());
+    }
+
+    private static CodeBlock typeMarker(TypeName type) {
+        if (type instanceof ClassName className) {
+            return CodeBlock.of("$T.of($T.class)", TypeMarker.class, className);
+        }
+        // Parameterized type markers cannot have nested types. Anon class type markers must be generated for those
+        if (type instanceof ParameterizedTypeName parameterized
+                && TYPE_MARKER_FACTORIES.containsKey(parameterized.rawType())
+                && parameterized.typeArguments().stream().allMatch(ClassName.class::isInstance)) {
+            CodeBlock.Builder result = CodeBlock.builder()
+                    .add("$T.$L(", TypeMarker.class, TYPE_MARKER_FACTORIES.get(parameterized.rawType()));
+            for (int index = 0; index < parameterized.typeArguments().size(); index++) {
+                if (index > 0) {
+                    result.add(", ");
+                }
+                result.add("$T.class", parameterized.typeArguments().get(index));
+            }
+            return result.add(")").build();
+        }
+        return CodeBlock.of("new $T<$T>() {}", TypeMarker.class, type);
     }
 
     private static FieldSpec encoder(ParameterEncoderType type) {

--- a/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/dialogue/annotations/processor/DialogueRequestAnnotationsProcessorTest.java
@@ -30,6 +30,7 @@ import com.palantir.myservice.service.MismatchedPathParam;
 import com.palantir.myservice.service.MultipleParamAnnotations;
 import com.palantir.myservice.service.MyService;
 import com.palantir.myservice.service.NestedService;
+import com.palantir.myservice.service.ParameterizedReturnTypes;
 import com.palantir.myservice.service.RequestAnnotatedClass;
 import com.palantir.myservice.service.UnmatchedPathParam;
 import com.palantir.myservice.service.UnmatchedPathTemplateParam;
@@ -61,6 +62,11 @@ public final class DialogueRequestAnnotationsProcessorTest {
     @Test
     public void testNestedExampleFileCompiles() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, NestedService.class, NestedService.MyService.class);
+    }
+
+    @Test
+    public void testParameterizedReturnTypes() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, ParameterizedReturnTypes.class);
     }
 
     @Test

--- a/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/ParameterizedReturnTypes.java
+++ b/dialogue-annotations-processor/src/test/java/com/palantir/myservice/service/ParameterizedReturnTypes.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.myservice.service;
+
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.annotations.Request;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public interface ParameterizedReturnTypes {
+
+    @Request(method = HttpMethod.GET, path = "/list")
+    List<String> list();
+
+    @Request(method = HttpMethod.GET, path = "/set")
+    Set<String> set();
+
+    @Request(method = HttpMethod.GET, path = "/optional")
+    Optional<String> optional();
+
+    @Request(method = HttpMethod.GET, path = "/map")
+    Map<String, Integer> map();
+
+    @Request(method = HttpMethod.GET, path = "/unsupported-outer-type")
+    Collection<String> unsupportedOuterType();
+
+    @Request(method = HttpMethod.GET, path = "/nested-parameterization")
+    List<Optional<String>> nestedParameterization();
+}

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/MyServiceDialogueServiceFactory.java.generated
@@ -47,26 +47,26 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
         return new MyService() {
             private final ParameterSerializer _parameterSerializer = DefaultParameterSerializer.INSTANCE;
 
-            private final Serializer<String> greetSerializer = new Json().serializerFor(new TypeMarker<String>() {});
+            private final Serializer<String> greetSerializer = new Json().serializerFor(TypeMarker.of(String.class));
 
             private final EndpointChannel greetChannel = endpointChannelFactory.endpoint(Endpoints.greet);
 
             private final Deserializer<String> greetDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new Json(), new ConjureErrorDecoder())
-                    .deserializerFor(new TypeMarker<String>() {});
+                    .deserializerFor(TypeMarker.of(String.class));
 
             private final EndpointChannel getGreetingAsyncChannel =
                     endpointChannelFactory.endpoint(Endpoints.getGreetingAsync);
 
             private final Deserializer<String> getGreetingAsyncDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new CustomStringDeserializer(), new ConjureErrorDecoder())
-                    .deserializerFor(new TypeMarker<String>() {});
+                    .deserializerFor(TypeMarker.of(String.class));
 
             private final EndpointChannel inputStreamChannel = endpointChannelFactory.endpoint(Endpoints.inputStream);
 
             private final Deserializer<InputStream> inputStreamDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new InputStreamDeserializer(), new ConjureErrorDecoder())
-                    .deserializerFor(new TypeMarker<InputStream>() {});
+                    .deserializerFor(TypeMarker.of(InputStream.class));
 
             private final EndpointChannel customInputStreamChannel =
                     endpointChannelFactory.endpoint(Endpoints.customInputStream);
@@ -74,7 +74,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             private final Deserializer<InputStream> customInputStreamDeserializer =
                     new ErrorHandlingDeserializerFactory<>(
                                     new CustomInputStreamDeserializer(), new ConjureErrorDecoder())
-                            .deserializerFor(new TypeMarker<InputStream>() {});
+                            .deserializerFor(TypeMarker.of(InputStream.class));
 
             private final EndpointChannel customRequestChannel =
                     endpointChannelFactory.endpoint(Endpoints.customRequest);
@@ -87,7 +87,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
 
             private final Deserializer<Response> customResponseDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new ResponseDeserializer(), new ConjureErrorDecoder())
-                    .deserializerFor(new TypeMarker<Response>() {});
+                    .deserializerFor(TypeMarker.of(Response.class));
 
             private final MyCustomTypeParamEncoder paramsQuery8Encoder = new MyCustomTypeParamEncoder();
 
@@ -110,7 +110,7 @@ public final class MyServiceDialogueServiceFactory implements DialogueServiceFac
             private final DefaultMultimapParamEncoder paramsHeaderMapEncoder = new DefaultMultimapParamEncoder();
 
             private final Serializer<MySerializableType> paramsSerializer =
-                    new MySerializableTypeBodySerializer().serializerFor(new TypeMarker<MySerializableType>() {});
+                    new MySerializableTypeBodySerializer().serializerFor(TypeMarker.of(MySerializableType.class));
 
             private final EndpointChannel paramsChannel = endpointChannelFactory.endpoint(Endpoints.params);
 

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/NestedServiceMyServiceDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/NestedServiceMyServiceDialogueServiceFactory.java.generated
@@ -34,7 +34,7 @@ public final class NestedServiceMyServiceDialogueServiceFactory
 
             private final Deserializer<String> getDeserializer = new ErrorHandlingDeserializerFactory<>(
                             new Json(), new ConjureErrorDecoder())
-                    .deserializerFor(new TypeMarker<String>() {});
+                    .deserializerFor(TypeMarker.of(String.class));
 
             @Override
             public String get() {

--- a/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/ParameterizedReturnTypesDialogueServiceFactory.java.generated
+++ b/dialogue-annotations-processor/src/test/resources/com/palantir/myservice/service/ParameterizedReturnTypesDialogueServiceFactory.java.generated
@@ -1,0 +1,302 @@
+package com.palantir.myservice.service;
+
+import com.google.common.collect.ListMultimap;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.PathTemplate;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.dialogue.UrlBuilder;
+import com.palantir.dialogue.annotations.ConjureErrorDecoder;
+import com.palantir.dialogue.annotations.DefaultParameterSerializer;
+import com.palantir.dialogue.annotations.ErrorHandlingDeserializerFactory;
+import com.palantir.dialogue.annotations.Json;
+import com.palantir.dialogue.annotations.ParameterSerializer;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.dialogue.annotations.processor.generate.DialogueServiceFactoryGenerator")
+public final class ParameterizedReturnTypesDialogueServiceFactory
+        implements DialogueServiceFactory<ParameterizedReturnTypes> {
+    @Override
+    public ParameterizedReturnTypes create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+        return new ParameterizedReturnTypes() {
+            private final ParameterSerializer _parameterSerializer = DefaultParameterSerializer.INSTANCE;
+
+            private final EndpointChannel listChannel = endpointChannelFactory.endpoint(Endpoints.list);
+
+            private final Deserializer<List<String>> listDeserializer = new ErrorHandlingDeserializerFactory<>(
+                            new Json(), new ConjureErrorDecoder())
+                    .deserializerFor(TypeMarker.listOf(String.class));
+
+            private final EndpointChannel setChannel = endpointChannelFactory.endpoint(Endpoints.set);
+
+            private final Deserializer<Set<String>> setDeserializer = new ErrorHandlingDeserializerFactory<>(
+                            new Json(), new ConjureErrorDecoder())
+                    .deserializerFor(TypeMarker.setOf(String.class));
+
+            private final EndpointChannel optionalChannel = endpointChannelFactory.endpoint(Endpoints.optional);
+
+            private final Deserializer<Optional<String>> optionalDeserializer = new ErrorHandlingDeserializerFactory<>(
+                            new Json(), new ConjureErrorDecoder())
+                    .deserializerFor(TypeMarker.optionalOf(String.class));
+
+            private final EndpointChannel mapChannel = endpointChannelFactory.endpoint(Endpoints.map);
+
+            private final Deserializer<Map<String, Integer>> mapDeserializer = new ErrorHandlingDeserializerFactory<>(
+                            new Json(), new ConjureErrorDecoder())
+                    .deserializerFor(TypeMarker.mapOf(String.class, Integer.class));
+
+            private final EndpointChannel unsupportedOuterTypeChannel =
+                    endpointChannelFactory.endpoint(Endpoints.unsupportedOuterType);
+
+            private final Deserializer<Collection<String>> unsupportedOuterTypeDeserializer =
+                    new ErrorHandlingDeserializerFactory<>(new Json(), new ConjureErrorDecoder())
+                            .deserializerFor(new TypeMarker<Collection<String>>() {});
+
+            private final EndpointChannel nestedParameterizationChannel =
+                    endpointChannelFactory.endpoint(Endpoints.nestedParameterization);
+
+            private final Deserializer<List<Optional<String>>> nestedParameterizationDeserializer =
+                    new ErrorHandlingDeserializerFactory<>(new Json(), new ConjureErrorDecoder())
+                            .deserializerFor(new TypeMarker<List<Optional<String>>>() {});
+
+            @Override
+            public List<String> list() {
+                Request.Builder _request = Request.builder();
+                return runtime.clients().callBlocking(listChannel, _request.build(), listDeserializer);
+            }
+
+            @Override
+            public Set<String> set() {
+                Request.Builder _request = Request.builder();
+                return runtime.clients().callBlocking(setChannel, _request.build(), setDeserializer);
+            }
+
+            @Override
+            public Optional<String> optional() {
+                Request.Builder _request = Request.builder();
+                return runtime.clients().callBlocking(optionalChannel, _request.build(), optionalDeserializer);
+            }
+
+            @Override
+            public Map<String, Integer> map() {
+                Request.Builder _request = Request.builder();
+                return runtime.clients().callBlocking(mapChannel, _request.build(), mapDeserializer);
+            }
+
+            @Override
+            public Collection<String> unsupportedOuterType() {
+                Request.Builder _request = Request.builder();
+                return runtime.clients()
+                        .callBlocking(unsupportedOuterTypeChannel, _request.build(), unsupportedOuterTypeDeserializer);
+            }
+
+            @Override
+            public List<Optional<String>> nestedParameterization() {
+                Request.Builder _request = Request.builder();
+                return runtime.clients()
+                        .callBlocking(
+                                nestedParameterizationChannel, _request.build(), nestedParameterizationDeserializer);
+            }
+        };
+    }
+
+    private enum Endpoints implements Endpoint {
+        list {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("list").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "ParameterizedReturnTypes";
+            }
+
+            @Override
+            public String endpointName() {
+                return "list";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        },
+
+        set {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("set").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "ParameterizedReturnTypes";
+            }
+
+            @Override
+            public String endpointName() {
+                return "set";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        },
+
+        optional {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("optional").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "ParameterizedReturnTypes";
+            }
+
+            @Override
+            public String endpointName() {
+                return "optional";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        },
+
+        map {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("map").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "ParameterizedReturnTypes";
+            }
+
+            @Override
+            public String endpointName() {
+                return "map";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        },
+
+        unsupportedOuterType {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("unsupported-outer-type").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "ParameterizedReturnTypes";
+            }
+
+            @Override
+            public String endpointName() {
+                return "unsupportedOuterType";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        },
+
+        nestedParameterization {
+            private final PathTemplate pathTemplate =
+                    PathTemplate.builder().fixed("nested-parameterization").build();
+
+            @Override
+            public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+                pathTemplate.fill(params, url);
+            }
+
+            @Override
+            public HttpMethod httpMethod() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String serviceName() {
+                return "ParameterizedReturnTypes";
+            }
+
+            @Override
+            public String endpointName() {
+                return "nestedParameterization";
+            }
+
+            @Override
+            public String version() {
+                return VERSION;
+            }
+        };
+
+        private static final String VERSION = Optional.ofNullable(
+                        ParameterizedReturnTypes.class.getPackage().getImplementationVersion())
+                .orElse("0.0.0");
+    }
+}

--- a/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
+++ b/dialogue-clients/src/test/java/com/palantir/dialogue/clients/ReloadingClientFactoryTest.java
@@ -186,9 +186,9 @@ class ReloadingClientFactoryTest {
         public Deserializer<?> deserializer(ConjureRuntime runtime) {
             BodySerDe bodySerDe = runtime.bodySerDe();
             return switch (this) {
-                case BASIC -> bodySerDe.deserializer(new TypeMarker<String>() {});
+                case BASIC -> bodySerDe.deserializer(TypeMarker.of(String.class));
                 case WITH_EXCEPTION_ARGS ->
-                    bodySerDe.deserializer(exceptionDeserializerArgs(new TypeMarker<String>() {}));
+                    bodySerDe.deserializer(exceptionDeserializerArgs(TypeMarker.of(String.class)));
                 case EMPTY -> bodySerDe.emptyBodyDeserializer();
                 case EMPTY_WITH_EXCEPTION_ARGS ->
                     bodySerDe.emptyBodyDeserializer(exceptionDeserializerArgs(new TypeMarker<>() {}));

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/BinaryEncoding.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/BinaryEncoding.java
@@ -32,8 +32,8 @@ enum BinaryEncoding implements Encoding {
     INSTANCE;
 
     static final String CONTENT_TYPE = "application/octet-stream";
-    static final TypeMarker<InputStream> MARKER = new TypeMarker<InputStream>() {};
-    static final TypeMarker<Optional<InputStream>> OPTIONAL_MARKER = new TypeMarker<Optional<InputStream>>() {};
+    static final TypeMarker<InputStream> MARKER = TypeMarker.of(InputStream.class);
+    static final TypeMarker<Optional<InputStream>> OPTIONAL_MARKER = TypeMarker.optionalOf(InputStream.class);
 
     @Override
     public <T> Serializer<T> serializer(TypeMarker<T> _type) {

--- a/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
+++ b/dialogue-serde/src/main/java/com/palantir/conjure/java/dialogue/serde/ExceptionDeserializingErrorDecoder.java
@@ -71,9 +71,9 @@ final class ExceptionDeserializingErrorDecoder {
     // performant handling of larger paramater payloads.
     private static final Encoding JSON_ENCODING = Encodings.json();
     private static final Deserializer<NamedError> NAMED_ERROR_DESERIALIZER =
-            JSON_ENCODING.deserializer(new TypeMarker<>() {});
+            JSON_ENCODING.deserializer(TypeMarker.of(NamedError.class));
     private static final Deserializer<SerializableError> SERIALIZABLE_ERROR_DESERIALIZER =
-            JSON_ENCODING.deserializer(new TypeMarker<>() {});
+            JSON_ENCODING.deserializer(TypeMarker.of(SerializableError.class));
 
     private final Map<String, DeserializerExceptionPair<?, ?>> errorNameToExceptionDeserializerMap;
     private final boolean expectJsonErrors;

--- a/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
@@ -133,6 +133,10 @@ public abstract class TypeMarker<T> {
             this.actualTypeArguments = actualTypeArguments.clone();
             for (Type actualTypeArgument : this.actualTypeArguments) {
                 Preconditions.checkNotNull(actualTypeArgument, "Type argument is required");
+                Preconditions.checkArgument(
+                        !(actualTypeArgument instanceof Class<?> argumentClass && argumentClass.isPrimitive()),
+                        "Primitive types cannot be used as type arguments",
+                        SafeArg.of("typeArgument", actualTypeArgument));
             }
         }
 

--- a/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/TypeMarker.java
@@ -22,11 +22,23 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Captures generic type information.
  *
- * Usage example: <pre>new TypeMarker&lt;List&lt;Integer&gt;() {}</pre>.
+ * <p>Usage examples:
+ * <pre>{@code
+ * TypeMarker<String> stringMarker = TypeMarker.of(String.class);
+ * TypeMarker<List<String>> listMarker = TypeMarker.listOf(String.class);
+ * TypeMarker<List<List<String>>> nestedMarker = new TypeMarker<>() {};
+ * }</pre>
  */
 @SuppressWarnings("unused") // Generic type exists for compile time safety but is not used internally.
 public abstract class TypeMarker<T> {
@@ -78,12 +90,100 @@ public abstract class TypeMarker<T> {
 
     /** Create a new {@link TypeMarker} instance wrapping the provided {@link Type}. */
     public static TypeMarker<?> of(Type type) {
-        return new WrappingTypeMarker(type);
+        return new WrappingTypeMarker<>(type);
     }
 
-    private static final class WrappingTypeMarker extends TypeMarker<Object> {
+    /** Create a new {@link TypeMarker} instance wrapping the provided class. */
+    public static <T> TypeMarker<T> of(Class<T> type) {
+        return new WrappingTypeMarker<>(type);
+    }
+
+    /** Create a new {@link TypeMarker} representing a list of the provided element class. */
+    public static <T> TypeMarker<List<T>> listOf(Class<T> elementType) {
+        return new WrappingTypeMarker<>(new ParameterizedTypeImpl(List.class, elementType));
+    }
+
+    /** Create a new {@link TypeMarker} representing a set of the provided element class. */
+    public static <T> TypeMarker<Set<T>> setOf(Class<T> elementType) {
+        return new WrappingTypeMarker<>(new ParameterizedTypeImpl(Set.class, elementType));
+    }
+
+    /** Create a new {@link TypeMarker} representing an optional of the provided value class. */
+    public static <T> TypeMarker<Optional<T>> optionalOf(Class<T> valueType) {
+        return new WrappingTypeMarker<>(new ParameterizedTypeImpl(Optional.class, valueType));
+    }
+
+    /** Create a new {@link TypeMarker} representing a map of the provided key and value classes. */
+    public static <K, V> TypeMarker<Map<K, V>> mapOf(Class<K> keyType, Class<V> valueType) {
+        return new WrappingTypeMarker<>(new ParameterizedTypeImpl(Map.class, keyType, valueType));
+    }
+
+    private static final class WrappingTypeMarker<T> extends TypeMarker<T> {
         private WrappingTypeMarker(Type type) {
             super(type);
+        }
+    }
+
+    private static final class ParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> rawType;
+        private final Type[] actualTypeArguments;
+
+        private ParameterizedTypeImpl(Class<?> rawType, Class<?>... actualTypeArguments) {
+            this.rawType = Preconditions.checkNotNull(rawType, "Raw type is required");
+            this.actualTypeArguments = actualTypeArguments.clone();
+            for (Type actualTypeArgument : this.actualTypeArguments) {
+                Preconditions.checkNotNull(actualTypeArgument, "Type argument is required");
+            }
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return actualTypeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public @Nullable Type getOwnerType() {
+            return null;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other instanceof ParameterizedType that) {
+                return Objects.equals(getOwnerType(), that.getOwnerType())
+                        && rawType.equals(that.getRawType())
+                        && Arrays.equals(actualTypeArguments, that.getActualTypeArguments());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(actualTypeArguments) ^ Objects.hashCode(getOwnerType()) ^ Objects.hashCode(rawType);
+        }
+
+        @Override
+        public String getTypeName() {
+            StringBuilder result = new StringBuilder(rawType.getTypeName()).append('<');
+            for (int index = 0; index < actualTypeArguments.length; index++) {
+                if (index > 0) {
+                    result.append(", ");
+                }
+                result.append(actualTypeArguments[index].getTypeName());
+            }
+            return result.append('>').toString();
+        }
+
+        @Override
+        public String toString() {
+            return getTypeName();
         }
     }
 }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/TypeMarkerTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/TypeMarkerTest.java
@@ -17,7 +17,9 @@
 package com.palantir.dialogue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,6 +54,21 @@ final class TypeMarkerTest {
     @Test
     void createsMapTypeMarker() {
         assertEquivalent(TypeMarker.mapOf(String.class, Integer.class), new TypeMarker<Map<String, Integer>>() {});
+    }
+
+    @Test
+    void rejectsPrimitiveTypeArguments() {
+        assertThatThrownBy(() -> TypeMarker.listOf(int.class))
+                .isExactlyInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Primitive types cannot be used as type arguments");
+        assertThatThrownBy(() -> TypeMarker.setOf(boolean.class))
+                .isExactlyInstanceOf(SafeIllegalArgumentException.class);
+        assertThatThrownBy(() -> TypeMarker.optionalOf(long.class))
+                .isExactlyInstanceOf(SafeIllegalArgumentException.class);
+        assertThatThrownBy(() -> TypeMarker.mapOf(int.class, String.class))
+                .isExactlyInstanceOf(SafeIllegalArgumentException.class);
+        assertThatThrownBy(() -> TypeMarker.mapOf(String.class, double.class))
+                .isExactlyInstanceOf(SafeIllegalArgumentException.class);
     }
 
     private static void assertEquivalent(TypeMarker<?> factoryMarker, TypeMarker<?> anonymousMarker) {

--- a/dialogue-target/src/test/java/com/palantir/dialogue/TypeMarkerTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/TypeMarkerTest.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.dialogue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class TypeMarkerTest {
+
+    @Test
+    void createsSimpleTypeMarker() {
+        TypeMarker<String> marker = TypeMarker.of(String.class);
+
+        assertThat(marker).isEqualTo(new TypeMarker<String>() {});
+        assertThat(marker.getType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void createsListTypeMarker() {
+        assertEquivalent(TypeMarker.listOf(String.class), new TypeMarker<List<String>>() {});
+    }
+
+    @Test
+    void createsSetTypeMarker() {
+        assertEquivalent(TypeMarker.setOf(String.class), new TypeMarker<Set<String>>() {});
+    }
+
+    @Test
+    void createsOptionalTypeMarker() {
+        assertEquivalent(TypeMarker.optionalOf(String.class), new TypeMarker<Optional<String>>() {});
+    }
+
+    @Test
+    void createsMapTypeMarker() {
+        assertEquivalent(TypeMarker.mapOf(String.class, Integer.class), new TypeMarker<Map<String, Integer>>() {});
+    }
+
+    private static void assertEquivalent(TypeMarker<?> factoryMarker, TypeMarker<?> anonymousMarker) {
+        assertThat(factoryMarker).isEqualTo(anonymousMarker);
+        assertThat(anonymousMarker).isEqualTo(factoryMarker);
+        assertThat(factoryMarker).hasSameHashCodeAs(anonymousMarker);
+        assertThat(factoryMarker.getType().getTypeName())
+                .isEqualTo(anonymousMarker.getType().getTypeName());
+    }
+}


### PR DESCRIPTION
This is part of a broader effort to eliminate most TypeMarker anonymous classes for Conjure generated code. These anonymous classes pollute the classpath and unnecessarily consume memory at runtime, and aren't strictly necessary a vast majority of the time. 

Introduce static factories into TypeMarker for the parameterized types that Conjure generates: Set, Map, Optional, and List, and change WrappingTypeMarker to be genericized, which allows adding a new type-safe non-parameterized factory method. Use these static factories in the annotation processor instead of generaeting anon classes for the applicable types. Parameterized base types not covered by the static factories and complicated nested types will still generate anon classes. 

Conjure code generation will eventually use these static factories as well for generated Dialogue code and exception markers. 