### PR TITLE
Ensure that RequestBody value is non-null

### DIFF
--- a/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
+++ b/dialogue-target/src/main/java/com/palantir/dialogue/Request.java
@@ -287,7 +287,7 @@ public final class Request {
 
         @SuppressWarnings("unchecked")
         public Request.Builder body(Optional<? extends RequestBody> value) {
-            body = (Optional<RequestBody>) value;
+            body = (Optional<RequestBody>) Preconditions.checkNotNull(value, "body");
             return this;
         }
 

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -16,14 +16,18 @@
 
 package com.palantir.dialogue;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.guava.api.Assertions.assertThat;
-
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.guava.api.Assertions.assertThat;
 
 public final class RequestTest {
 
@@ -87,5 +91,12 @@ public final class RequestTest {
                 .build();
 
         System.out.println(request2.queryParams());
+    }
+
+    @Test
+    void request_body_rejects_null() {
+        Optional<RequestBody> bodyArg = null;
+        assertThatThrownBy(() -> Request.builder().body(bodyArg).build())
+                .isExactlyInstanceOf(SafeNullPointerException.class);
     }
 }

--- a/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
+++ b/dialogue-target/src/test/java/com/palantir/dialogue/RequestTest.java
@@ -16,18 +16,17 @@
 
 package com.palantir.dialogue;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.guava.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
-import org.junit.jupiter.api.Test;
-
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.guava.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public final class RequestTest {
 
@@ -95,8 +94,14 @@ public final class RequestTest {
 
     @Test
     void request_body_rejects_null() {
-        Optional<RequestBody> bodyArg = null;
-        assertThatThrownBy(() -> Request.builder().body(bodyArg).build())
+        assertThatThrownBy(() ->
+                        Request.builder().body((Optional<RequestBody>) null).build())
                 .isExactlyInstanceOf(SafeNullPointerException.class);
+    }
+
+    @Test
+    void request_body_accepts_empty() {
+        Request request1 = Request.builder().body(Optional.empty()).build();
+        assertThat(request1.body()).isEmpty();
     }
 }


### PR DESCRIPTION
## Before this PR
Addressing #3180. Currently there is no null-check for the RequestBody value passed into [this method](https://github.com/palantir/dialogue/blob/70196eea62323d603264dd9de2359b804ff795d9/dialogue-target/src/main/java/com/palantir/dialogue/Request.java). 

## After this PR
Found all usages of this method to ensure that there are no callers that expect to be able to pass a null value and added a test to ensure we get a SafeNullPointerException when the method is passed a null value.

## Possible downsides?
Possibly could have missed a usage of this method that expected a null value since the search was done manually.

