### PR TITLE
Make `QueueTimeoutException` public

### DIFF
--- a/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutException.java
+++ b/dialogue-core/src/main/java/com/palantir/dialogue/core/QueueTimeoutException.java
@@ -27,7 +27,7 @@ import java.util.OptionalLong;
 /**
  * Thrown when a request waits in a {@link QueuedChannel} longer than the configured queue timeout.
  */
-final class QueueTimeoutException extends RuntimeException implements SafeLoggable {
+public final class QueueTimeoutException extends RuntimeException implements SafeLoggable {
     private static final String MESSAGE = "Request queued for longer than queue timeout";
 
     private final List<Arg<?>> args;


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Client code isn't able to catch `QueueTimeoutException` because it's package-private.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make `QueueTimeoutException` public
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

